### PR TITLE
fix(Enterprise Management): added token (next_docid) to support pagination in terraform code

### DIFF
--- a/enterprisemanagementv1/enterprise_management_v1.go
+++ b/enterprisemanagementv1/enterprise_management_v1.go
@@ -285,7 +285,7 @@ func (enterpriseManagement *EnterpriseManagementV1) ListAccountGroupsWithContext
 	if listAccountGroupsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listAccountGroupsOptions.Limit))
 	}
-	if listAccountGroupsOptions.Next_docid != nil {
+	if listAccountGroupsOptions.Next_docid != nil && *listAccountGroupsOptions.Next_docid != "" {
 		builder.AddQuery("next_docid", fmt.Sprint(*listAccountGroupsOptions.Next_docid))
 	}
 	request, err := builder.Build()
@@ -620,7 +620,7 @@ func (enterpriseManagement *EnterpriseManagementV1) ListAccountsWithContext(ctx 
 	if listAccountsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listAccountsOptions.Limit))
 	}
-	if listAccountsOptions.Next_docid != nil {
+	if listAccountsOptions.Next_docid != nil && *listAccountsOptions.Next_docid != "" {
 		builder.AddQuery("next_docid", fmt.Sprint(*listAccountsOptions.Next_docid))
 	}
 

--- a/enterprisemanagementv1/enterprise_management_v1.go
+++ b/enterprisemanagementv1/enterprise_management_v1.go
@@ -1754,7 +1754,7 @@ type ListAccountGroupsOptions struct {
 	Limit *int64 `json:"limit,omitempty"`
 
 	// Allows users to set next_docid for pagination
-	Next_docid *string `json:"limit,omitempty"`
+	Next_docid *string `json:"next_docid,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string

--- a/enterprisemanagementv1/enterprise_management_v1.go
+++ b/enterprisemanagementv1/enterprise_management_v1.go
@@ -285,7 +285,9 @@ func (enterpriseManagement *EnterpriseManagementV1) ListAccountGroupsWithContext
 	if listAccountGroupsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listAccountGroupsOptions.Limit))
 	}
-
+	if listAccountGroupsOptions.Next_docid != nil {
+		builder.AddQuery("next_docid", fmt.Sprint(*listAccountGroupsOptions.Next_docid))
+	}
 	request, err := builder.Build()
 	if err != nil {
 		return
@@ -617,6 +619,9 @@ func (enterpriseManagement *EnterpriseManagementV1) ListAccountsWithContext(ctx 
 	}
 	if listAccountsOptions.Limit != nil {
 		builder.AddQuery("limit", fmt.Sprint(*listAccountsOptions.Limit))
+	}
+	if listAccountsOptions.Next_docid != nil {
+		builder.AddQuery("next_docid", fmt.Sprint(*listAccountsOptions.Next_docid))
 	}
 
 	request, err := builder.Build()
@@ -1748,6 +1753,9 @@ type ListAccountGroupsOptions struct {
 	// Return results up to this limit. Valid values are between `0` and `100`.
 	Limit *int64 `json:"limit,omitempty"`
 
+	// Allows users to set next_docid for pagination
+	Next_docid *string `json:"limit,omitempty"`
+
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
@@ -1784,6 +1792,12 @@ func (options *ListAccountGroupsOptions) SetLimit(limit int64) *ListAccountGroup
 // SetHeaders : Allow user to set Headers
 func (options *ListAccountGroupsOptions) SetHeaders(param map[string]string) *ListAccountGroupsOptions {
 	options.Headers = param
+	return options
+}
+
+// SetNext_docid : Allow user to set Next_docid
+func (options *ListAccountGroupsOptions) SetNext_docid(next_docid string) *ListAccountGroupsOptions {
+	options.EnterpriseID = core.StringPtr(next_docid)
 	return options
 }
 
@@ -1835,6 +1849,9 @@ type ListAccountsOptions struct {
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
+
+	// Allow users to set next_docid
+	Next_docid *string `json:"next_docid,omitempty"`
 }
 
 // NewListAccountsOptions : Instantiate ListAccountsOptions
@@ -1869,6 +1886,12 @@ func (options *ListAccountsOptions) SetLimit(limit int64) *ListAccountsOptions {
 // SetHeaders : Allow user to set Headers
 func (options *ListAccountsOptions) SetHeaders(param map[string]string) *ListAccountsOptions {
 	options.Headers = param
+	return options
+}
+
+// SetNext_docid : Allow user to set Next_docid
+func (options *ListAccountsOptions) SetNext_docid(next_docid string) *ListAccountsOptions {
+	options.Next_docid=core.StringPtr(next_docid)
 	return options
 }
 

--- a/enterprisemanagementv1/enterprise_management_v1_test.go
+++ b/enterprisemanagementv1/enterprise_management_v1_test.go
@@ -354,7 +354,7 @@ var _ = Describe(`EnterpriseManagementV1`, func() {
 					Expect(req.URL.Query()["parent"]).To(Equal([]string{"testString"}))
 
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(38))}))
-
+					Expect(req.URL.Query()["next_docid"]).To(Equal([]string{"teststring"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
 					fmt.Fprintf(res, `} this is not valid json {`)
@@ -374,6 +374,7 @@ var _ = Describe(`EnterpriseManagementV1`, func() {
 				listAccountGroupsOptionsModel.ParentAccountGroupID = core.StringPtr("testString")
 				listAccountGroupsOptionsModel.Parent = core.StringPtr("testString")
 				listAccountGroupsOptionsModel.Limit = core.Int64Ptr(int64(38))
+				listAccountGroupsOptionsModel.Next_docid =core.StringPtr("teststring")
 				listAccountGroupsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := enterpriseManagementService.ListAccountGroups(listAccountGroupsOptionsModel)
@@ -415,6 +416,8 @@ var _ = Describe(`EnterpriseManagementV1`, func() {
 
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(38))}))
 
+					Expect(req.URL.Query()["next_docid"]).To(Equal([]string{"testString"}))
+
 					// Sleep a short time to support a timeout test
 					time.Sleep(serverSleepTime)
 
@@ -446,6 +449,7 @@ var _ = Describe(`EnterpriseManagementV1`, func() {
 				listAccountGroupsOptionsModel.Parent = core.StringPtr("testString")
 				listAccountGroupsOptionsModel.Limit = core.Int64Ptr(int64(38))
 				listAccountGroupsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				listAccountGroupsOptionsModel.Next_docid =core.StringPtr("testString")
 
 				// Invoke operation with valid options model (positive test)
 				result, response, operationErr = enterpriseManagementService.ListAccountGroups(listAccountGroupsOptionsModel)


### PR DESCRIPTION
## PR summary
 This PR adds "next_docid" as pagination token in ListAccountGroups and ListAccounts for Enterprise Management


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behaviour  
Current behaviour: Currently, to support pagination in ListAccountGroups and ListAccounts, next_url is called. Terraform recommends using a pagination token instead of using next_url parameter.

New behaviour: Added next_docid as pagination token which will be set by TF code to loop over the entire list of resources.
As listed in the API doc:
 **/v1/enterprises?enterprise_id={enterprise_id}&next_docid={next_docid}**
**/v1/account-groups?account_group_id={account_group_id}&next_docid={next_docid}**

API Doc link: https://cloud.ibm.com/apidocs/enterprise-apis/enterprise#pagination

## Does this PR introduce a breaking change? 

- [ ] Yes   
- [x] No

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->