### PR TITLE
fix(Activity Tracker): re-gen service after recent API changes

### DIFF
--- a/atrackerv1/atracker_v1.go
+++ b/atrackerv1/atracker_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.33.0-caf29bd0-20210603-225214
+ * IBM OpenAPI SDK Code Generator Version: 3.35.1-e449803c-20210628-211617
  */
 
 // Package atrackerv1 : Operations and models for the AtrackerV1 service
@@ -34,9 +34,9 @@ import (
 	"github.com/go-openapi/strfmt"
 )
 
-// AtrackerV1 : IBM Cloud Activity Tracking Service (ATracker Service for short) is an activity tracker configuration
-// service for your application events as well as events from IBM services under your account. It is designed to enable
-// you to route  activity tracker events to your designated Cloud Object Storage location in different regions.
+// AtrackerV1 : Activity Tracking is a platform service that you can configure in each region in your account to define
+// how auditing events are collected and stored. Events are stored in a Cloud Object Storage bucket that is also
+// available in the account.
 //
 // Version: 1.0.0
 type AtrackerV1 struct {
@@ -115,13 +115,13 @@ func NewAtrackerV1(options *AtrackerV1Options) (service *AtrackerV1, err error) 
 func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
 		"private.us-south": "https://private.us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the us-south region.
-		"private.us-east":  "https://private.us-east.atracker.cloud.ibm.com",  // The server for IBM Cloud Activity Tracking Service in the us-east region.
-		"private.au-syd":   "https://private.au-syd.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracking Service in the au-syd region.
-		"private.eu-de":    "https://private.eu-de.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracking Service in the eu-de region.
-		"private.eu-gb":    "https://private.eu-gb.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracking Service in the eu-gb region.
-		"private.in-che":   "https://private.in-che.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracking Service in the in-che region.
-		"private.jp-tok":   "https://private.jp-tok.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracking Service in the jp-tok region.
-		"private.kr-seo":   "https://private.kr-seo.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracking Service in the kr-seo region.
+		"private.us-east": "https://private.us-east.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the us-east region.
+		"private.au-syd": "https://private.au-syd.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the au-syd region.
+		"private.eu-de": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the eu-de region.
+		"private.eu-gb": "https://private.eu-gb.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the eu-gb region.
+		"private.in-che": "https://private.in-che.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the in-che region.
+		"private.jp-tok": "https://private.jp-tok.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the jp-tok region.
+		"private.kr-seo": "https://private.kr-seo.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracking Service in the kr-seo region.
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -176,11 +176,11 @@ func (atracker *AtrackerV1) DisableRetries() {
 	atracker.Service.DisableRetries()
 }
 
-// CreateTarget : Create a Cloud Object Storage target for a region
-// Creates a new Cloud Object Storage (COS) target with specified COS endpoint information and credentials.  Commonly
-// the COS endpoint should be on the same region as ATracker Services where this API is invoked. The  Target definition
-// could only be referenced by the routing rules defined in the same region through the same  API endpoint. If a COS
-// endpoint to be used across multiple regions, you must define a target for each region's API endpoint.
+// CreateTarget : Create a target
+// Creates a Cloud Object Storage (COS) target that includes information about the COS endpoint and the credentials to
+// access the bucket. You must define a COS target per region.  Notice that although you can use the same COS bucket for
+// collecting auditing events in your account across multiple regions, you should consider defining a bucket in each
+// region to reduce performance and network latency issues. You can define up to 16 targets per region.
 func (atracker *AtrackerV1) CreateTarget(createTargetOptions *CreateTargetOptions) (result *Target, response *core.DetailedResponse, err error) {
 	return atracker.CreateTargetWithContext(context.Background(), createTargetOptions)
 }
@@ -251,8 +251,8 @@ func (atracker *AtrackerV1) CreateTargetWithContext(ctx context.Context, createT
 	return
 }
 
-// ListTargets : List Cloud Object Storage targets for the region
-// List all Cloud Object Storage (COS) targets defined under this region.
+// ListTargets : List targets
+// List all Cloud Object Storage (COS) targets that are defined in a region.
 func (atracker *AtrackerV1) ListTargets(listTargetsOptions *ListTargetsOptions) (result *TargetList, response *core.DetailedResponse, err error) {
 	return atracker.ListTargetsWithContext(context.Background(), listTargetsOptions)
 }
@@ -303,8 +303,8 @@ func (atracker *AtrackerV1) ListTargetsWithContext(ctx context.Context, listTarg
 	return
 }
 
-// GetTarget : Retrieve a target
-// Retrieves a target and its details by specifying the ID of the target.
+// GetTarget : Get details of a target
+// Retrieve the configuration details of a target.
 func (atracker *AtrackerV1) GetTarget(getTargetOptions *GetTargetOptions) (result *Target, response *core.DetailedResponse, err error) {
 	return atracker.GetTargetWithContext(context.Background(), getTargetOptions)
 }
@@ -364,7 +364,7 @@ func (atracker *AtrackerV1) GetTargetWithContext(ctx context.Context, getTargetO
 }
 
 // ReplaceTarget : Update a target
-// Update a target details by specifying the ID of the target.
+// Update the configuration details of a target.
 func (atracker *AtrackerV1) ReplaceTarget(replaceTargetOptions *ReplaceTargetOptions) (result *Target, response *core.DetailedResponse, err error) {
 	return atracker.ReplaceTargetWithContext(context.Background(), replaceTargetOptions)
 }
@@ -440,7 +440,7 @@ func (atracker *AtrackerV1) ReplaceTargetWithContext(ctx context.Context, replac
 }
 
 // DeleteTarget : Delete a target
-// Deletes a target by specifying the ID of the target.
+// Delete a target.
 func (atracker *AtrackerV1) DeleteTarget(deleteTargetOptions *DeleteTargetOptions) (result *WarningReport, response *core.DetailedResponse, err error) {
 	return atracker.DeleteTargetWithContext(context.Background(), deleteTargetOptions)
 }
@@ -499,9 +499,9 @@ func (atracker *AtrackerV1) DeleteTargetWithContext(ctx context.Context, deleteT
 	return
 }
 
-// ValidateTarget : Update a target with cos validation results
-// Validate a target by specifying the ID of the target. Atracker will try to write to the cos bucket  and return the
-// result in "cos_write_status". The target will be updated with the results.
+// ValidateTarget : Validate a target
+// Validate a target by checking the credentials to write to the bucket. The result is included as additional data of
+// the target in the section "cos_write_status".
 func (atracker *AtrackerV1) ValidateTarget(validateTargetOptions *ValidateTargetOptions) (result *Target, response *core.DetailedResponse, err error) {
 	return atracker.ValidateTargetWithContext(context.Background(), validateTargetOptions)
 }
@@ -560,10 +560,11 @@ func (atracker *AtrackerV1) ValidateTargetWithContext(ctx context.Context, valid
 	return
 }
 
-// CreateRoute : Create a Route for the region
-// Creates a route with rules defined how to route AT events to targets for a region.  For each account and region, only
-// one route could be defined. A route could contain multiple rules which enable atracker service to match incoming AT
-// events based on the source crn and forward the events to customer configured targets.
+// CreateRoute : Create a route
+// Create a route to define the rule that specifies how to manage auditing events in a region.  You can define 1 route
+// only per region. You can configure 1 target only per route. To define how to manage global events, that is, auditing
+// events in your account that are not region specific, you must configure 1 route in your account to collect and route
+// global events. You must set the receive_global_events field to true.
 func (atracker *AtrackerV1) CreateRoute(createRouteOptions *CreateRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return atracker.CreateRouteWithContext(context.Background(), createRouteOptions)
 }
@@ -634,8 +635,8 @@ func (atracker *AtrackerV1) CreateRouteWithContext(ctx context.Context, createRo
 	return
 }
 
-// ListRoutes : List routes for the region
-// List routes defined under this region.
+// ListRoutes : List routes
+// List the route that is configured in a region.
 func (atracker *AtrackerV1) ListRoutes(listRoutesOptions *ListRoutesOptions) (result *RouteList, response *core.DetailedResponse, err error) {
 	return atracker.ListRoutesWithContext(context.Background(), listRoutesOptions)
 }
@@ -686,8 +687,8 @@ func (atracker *AtrackerV1) ListRoutesWithContext(ctx context.Context, listRoute
 	return
 }
 
-// GetRoute : Retrieve a route
-// Retrieves a route and its details by specifying the ID of the route.
+// GetRoute : Get details of a route
+// Get the configuration details of a route.
 func (atracker *AtrackerV1) GetRoute(getRouteOptions *GetRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return atracker.GetRouteWithContext(context.Background(), getRouteOptions)
 }
@@ -746,8 +747,8 @@ func (atracker *AtrackerV1) GetRouteWithContext(ctx context.Context, getRouteOpt
 	return
 }
 
-// ReplaceRoute : Replace a route
-// Replace a route details by specifying the ID of the route.
+// ReplaceRoute : Update a route
+// Update the configuration details of a route.
 func (atracker *AtrackerV1) ReplaceRoute(replaceRouteOptions *ReplaceRouteOptions) (result *Route, response *core.DetailedResponse, err error) {
 	return atracker.ReplaceRouteWithContext(context.Background(), replaceRouteOptions)
 }
@@ -823,7 +824,7 @@ func (atracker *AtrackerV1) ReplaceRouteWithContext(ctx context.Context, replace
 }
 
 // DeleteRoute : Delete a route
-// Deletes a route by specifying the ID of the route.
+// Deletes a route.
 func (atracker *AtrackerV1) DeleteRoute(deleteRouteOptions *DeleteRouteOptions) (response *core.DetailedResponse, err error) {
 	return atracker.DeleteRouteWithContext(context.Background(), deleteRouteOptions)
 }
@@ -870,13 +871,171 @@ func (atracker *AtrackerV1) DeleteRouteWithContext(ctx context.Context, deleteRo
 	return
 }
 
+// GetEndpoints : Get endpoints
+// Get information about the public and private endpoints that are enabled in a region when you use the Activity
+// Tracking API.
+func (atracker *AtrackerV1) GetEndpoints(getEndpointsOptions *GetEndpointsOptions) (result *Endpoints, response *core.DetailedResponse, err error) {
+	return atracker.GetEndpointsWithContext(context.Background(), getEndpointsOptions)
+}
+
+// GetEndpointsWithContext is an alternate form of the GetEndpoints method which supports a Context parameter
+func (atracker *AtrackerV1) GetEndpointsWithContext(ctx context.Context, getEndpointsOptions *GetEndpointsOptions) (result *Endpoints, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(getEndpointsOptions, "getEndpointsOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = atracker.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(atracker.Service.Options.URL, `/api/v1/endpoints`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getEndpointsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("atracker", "V1", "GetEndpoints")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = atracker.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalEndpoints)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// PatchEndpoints : Modify endpoints
+// Configure the public endpoint availability in a region to use the Activity Tracking API. By default, the private
+// endpoint is enabled and cannot be disabled.
+func (atracker *AtrackerV1) PatchEndpoints(patchEndpointsOptions *PatchEndpointsOptions) (result *Endpoints, response *core.DetailedResponse, err error) {
+	return atracker.PatchEndpointsWithContext(context.Background(), patchEndpointsOptions)
+}
+
+// PatchEndpointsWithContext is an alternate form of the PatchEndpoints method which supports a Context parameter
+func (atracker *AtrackerV1) PatchEndpointsWithContext(ctx context.Context, patchEndpointsOptions *PatchEndpointsOptions) (result *Endpoints, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(patchEndpointsOptions, "patchEndpointsOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(patchEndpointsOptions, "patchEndpointsOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.PATCH)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = atracker.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(atracker.Service.Options.URL, `/api/v1/endpoints`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range patchEndpointsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("atracker", "V1", "PatchEndpoints")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if patchEndpointsOptions.APIEndpoint != nil {
+		body["api_endpoint"] = patchEndpointsOptions.APIEndpoint
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = atracker.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalEndpoints)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// APIEndpoint : Activity Tracking API endpoint.
+type APIEndpoint struct {
+	// The public URL of Activity Tracking in a region.
+	PublicURL *string `json:"public_url" validate:"required"`
+
+	// Indicates whether or not the public endpoint is enabled in the account.
+	PublicEnabled *bool `json:"public_enabled" validate:"required"`
+
+	// The private URL of Activity Tracking. This URL cannot be disabled.
+	PrivateURL *string `json:"private_url" validate:"required"`
+
+	// The private endpoint is always enabled.
+	PrivateEnabled *bool `json:"private_enabled,omitempty"`
+}
+
+// UnmarshalAPIEndpoint unmarshals an instance of APIEndpoint from the specified map of raw messages.
+func UnmarshalAPIEndpoint(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(APIEndpoint)
+	err = core.UnmarshalPrimitive(m, "public_url", &obj.PublicURL)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "public_enabled", &obj.PublicEnabled)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "private_url", &obj.PrivateURL)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "private_enabled", &obj.PrivateEnabled)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // CreateRouteOptions : The CreateRoute options.
 type CreateRouteOptions struct {
-	// The name of the route. Must be 1000 characters or less and cannot include any special characters other than `(space)
-	// - . _ :`.
+	// The name of the route. The name must be 1000 characters or less and cannot include any special characters other than
+	// `(space) - . _ :`.
 	Name *string `validate:"required"`
 
-	// Whether or not all global events should be forwarded to this region.
+	// Indicates whether or not all global events should be forwarded to this region.
 	ReceiveGlobalEvents *bool `validate:"required"`
 
 	// Routing rules that will be evaluated in their order of the array.
@@ -889,9 +1048,9 @@ type CreateRouteOptions struct {
 // NewCreateRouteOptions : Instantiate CreateRouteOptions
 func (*AtrackerV1) NewCreateRouteOptions(name string, receiveGlobalEvents bool, rules []Rule) *CreateRouteOptions {
 	return &CreateRouteOptions{
-		Name:                core.StringPtr(name),
+		Name: core.StringPtr(name),
 		ReceiveGlobalEvents: core.BoolPtr(receiveGlobalEvents),
-		Rules:               rules,
+		Rules: rules,
 	}
 }
 
@@ -921,8 +1080,8 @@ func (options *CreateRouteOptions) SetHeaders(param map[string]string) *CreateRo
 
 // CreateTargetOptions : The CreateTarget options.
 type CreateTargetOptions struct {
-	// The name of the target. Must be 1000 characters or less and cannot include any special characters other than
-	// `(space) - . _ :`.
+	// The name of the target. The name must be 1000 characters or less, and cannot include any special characters other
+	// than `(space) - . _ :`.
 	Name *string `validate:"required"`
 
 	// The type of the target.
@@ -944,8 +1103,8 @@ const (
 // NewCreateTargetOptions : Instantiate CreateTargetOptions
 func (*AtrackerV1) NewCreateTargetOptions(name string, targetType string, cosEndpoint *CosEndpoint) *CreateTargetOptions {
 	return &CreateTargetOptions{
-		Name:        core.StringPtr(name),
-		TargetType:  core.StringPtr(targetType),
+		Name: core.StringPtr(name),
+		TargetType: core.StringPtr(targetType),
 		CosEndpoint: cosEndpoint,
 	}
 }
@@ -1026,6 +1185,58 @@ func (_options *DeleteTargetOptions) SetID(id string) *DeleteTargetOptions {
 
 // SetHeaders : Allow user to set Headers
 func (options *DeleteTargetOptions) SetHeaders(param map[string]string) *DeleteTargetOptions {
+	options.Headers = param
+	return options
+}
+
+// Endpoints : Activity Tracking endpoints.
+type Endpoints struct {
+	// Activity Tracking API endpoint.
+	APIEndpoint *APIEndpoint `json:"api_endpoint" validate:"required"`
+}
+
+// UnmarshalEndpoints unmarshals an instance of Endpoints from the specified map of raw messages.
+func UnmarshalEndpoints(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Endpoints)
+	err = core.UnmarshalModel(m, "api_endpoint", &obj.APIEndpoint, UnmarshalAPIEndpoint)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// EndpointsRequestAPIEndpoint : Activity Tracking service API endpoint.
+type EndpointsRequestAPIEndpoint struct {
+	// Indicate whether or not the public endpoint is enabled in an account.
+	PublicEnabled *bool `json:"public_enabled,omitempty"`
+}
+
+// UnmarshalEndpointsRequestAPIEndpoint unmarshals an instance of EndpointsRequestAPIEndpoint from the specified map of raw messages.
+func UnmarshalEndpointsRequestAPIEndpoint(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(EndpointsRequestAPIEndpoint)
+	err = core.UnmarshalPrimitive(m, "public_enabled", &obj.PublicEnabled)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetEndpointsOptions : The GetEndpoints options.
+type GetEndpointsOptions struct {
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetEndpointsOptions : Instantiate GetEndpointsOptions
+func (*AtrackerV1) NewGetEndpointsOptions() *GetEndpointsOptions {
+	return &GetEndpointsOptions{}
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetEndpointsOptions) SetHeaders(param map[string]string) *GetEndpointsOptions {
 	options.Headers = param
 	return options
 }
@@ -1122,16 +1333,42 @@ func (options *ListTargetsOptions) SetHeaders(param map[string]string) *ListTarg
 	return options
 }
 
+// PatchEndpointsOptions : The PatchEndpoints options.
+type PatchEndpointsOptions struct {
+	// Activity Tracking service API endpoint.
+	APIEndpoint *EndpointsRequestAPIEndpoint
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewPatchEndpointsOptions : Instantiate PatchEndpointsOptions
+func (*AtrackerV1) NewPatchEndpointsOptions() *PatchEndpointsOptions {
+	return &PatchEndpointsOptions{}
+}
+
+// SetAPIEndpoint : Allow user to set APIEndpoint
+func (_options *PatchEndpointsOptions) SetAPIEndpoint(apiEndpoint *EndpointsRequestAPIEndpoint) *PatchEndpointsOptions {
+	_options.APIEndpoint = apiEndpoint
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *PatchEndpointsOptions) SetHeaders(param map[string]string) *PatchEndpointsOptions {
+	options.Headers = param
+	return options
+}
+
 // ReplaceRouteOptions : The ReplaceRoute options.
 type ReplaceRouteOptions struct {
 	// The v4 UUID that uniquely identifies the route.
 	ID *string `validate:"required,ne="`
 
-	// The name of the route. Must be 1000 characters or less and cannot include any special characters other than `(space)
-	// - . _ :`.
+	// The name of the route. The name must be 1000 characters or less and cannot include any special characters other than
+	// `(space) - . _ :`.
 	Name *string `validate:"required"`
 
-	// Whether or not all global events should be forwarded to this region.
+	// Indicates whether or not all global events should be forwarded to this region.
 	ReceiveGlobalEvents *bool `validate:"required"`
 
 	// Routing rules that will be evaluated in their order of the array.
@@ -1144,10 +1381,10 @@ type ReplaceRouteOptions struct {
 // NewReplaceRouteOptions : Instantiate ReplaceRouteOptions
 func (*AtrackerV1) NewReplaceRouteOptions(id string, name string, receiveGlobalEvents bool, rules []Rule) *ReplaceRouteOptions {
 	return &ReplaceRouteOptions{
-		ID:                  core.StringPtr(id),
-		Name:                core.StringPtr(name),
+		ID: core.StringPtr(id),
+		Name: core.StringPtr(name),
 		ReceiveGlobalEvents: core.BoolPtr(receiveGlobalEvents),
-		Rules:               rules,
+		Rules: rules,
 	}
 }
 
@@ -1186,8 +1423,8 @@ type ReplaceTargetOptions struct {
 	// The v4 UUID that uniquely identifies the target.
 	ID *string `validate:"required,ne="`
 
-	// The name of the target. Must be 1000 characters or less and cannot include any special characters other than
-	// `(space) - . _ :`.
+	// The name of the target. The name must be 1000 characters or less, and cannot include any special characters other
+	// than `(space) - . _ :`.
 	Name *string `validate:"required"`
 
 	// The type of the target.
@@ -1209,9 +1446,9 @@ const (
 // NewReplaceTargetOptions : Instantiate ReplaceTargetOptions
 func (*AtrackerV1) NewReplaceTargetOptions(id string, name string, targetType string, cosEndpoint *CosEndpoint) *ReplaceTargetOptions {
 	return &ReplaceTargetOptions{
-		ID:          core.StringPtr(id),
-		Name:        core.StringPtr(name),
-		TargetType:  core.StringPtr(targetType),
+		ID: core.StringPtr(id),
+		Name: core.StringPtr(name),
+		TargetType: core.StringPtr(targetType),
 		CosEndpoint: cosEndpoint,
 	}
 }
@@ -1248,19 +1485,19 @@ func (options *ReplaceTargetOptions) SetHeaders(param map[string]string) *Replac
 
 // Route : The route resource.
 type Route struct {
-	// The uuid of this route resource.
+	// The uuid of the route resource.
 	ID *string `json:"id" validate:"required"`
 
-	// The name of this route.
+	// The name of the route.
 	Name *string `json:"name" validate:"required"`
 
-	// The crn of this route type resource.
+	// The crn of the route resource.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The version of this route.
+	// The version of the route.
 	Version *int64 `json:"version,omitempty"`
 
-	// Whether or not all global events should be forwarded to this region.
+	// Indicates whether or not all global events should be forwarded to this region.
 	ReceiveGlobalEvents *bool `json:"receive_global_events" validate:"required"`
 
 	// The routing rules that will be evaluated in their order of the array.
@@ -1331,7 +1568,7 @@ func UnmarshalRouteList(m map[string]json.RawMessage, result interface{}) (err e
 
 // Rule : The request payload to create a regional route.
 type Rule struct {
-	// The target ID List. Only one target id is supported.
+	// The target ID List. Only 1 target id is supported.
 	TargetIds []string `json:"target_ids" validate:"required"`
 }
 
@@ -1355,23 +1592,23 @@ func UnmarshalRule(m map[string]json.RawMessage, result interface{}) (err error)
 	return
 }
 
-// Target : Property values for a target in response. Credentials associated with the target are encrypted and masked as REDACTED
-// in the response.
+// Target : Property values for a target in the response. Credentials associated with the target are encrypted and masked as
+// REDACTED in the response.
 type Target struct {
-	// The uuid of this target resource.
+	// The uuid of the target resource.
 	ID *string `json:"id" validate:"required"`
 
-	// The name of this target resource.
+	// The name of the target resource.
 	Name *string `json:"name" validate:"required"`
 
-	// The crn of this target type resource.
+	// The crn of the target resource.
 	CRN *string `json:"crn" validate:"required"`
 
-	// The type of this target.
+	// The type of the target.
 	TargetType *string `json:"target_type" validate:"required"`
 
-	// The encryption key used to encrypt events before ATracker services buffer them on storage. This credential will be
-	// masked in the response.
+	// The encryption key that is used to encrypt events before Activity Tracking services buffer them on storage. This
+	// credential is masked in the response.
 	EncryptKey *string `json:"encrypt_key,omitempty"`
 
 	// Property values for a Cloud Object Storage Endpoint.
@@ -1388,7 +1625,7 @@ type Target struct {
 }
 
 // Constants associated with the Target.TargetType property.
-// The type of this target.
+// The type of the target.
 const (
 	TargetTargetTypeCloudObjectStorageConst = "cloud_object_storage"
 )
@@ -1483,10 +1720,10 @@ func (options *ValidateTargetOptions) SetHeaders(param map[string]string) *Valid
 
 // Warning : The warning object.
 type Warning struct {
-	// The warning code of this warning.
+	// The warning code.
 	Code *string `json:"code,omitempty"`
 
-	// The warning message of this warning.
+	// The warning message.
 	Message *string `json:"message,omitempty"`
 }
 
@@ -1505,10 +1742,10 @@ func UnmarshalWarning(m map[string]json.RawMessage, result interface{}) (err err
 	return
 }
 
-// WarningReport : Description of an warning that occurred in a service request.
+// WarningReport : Description of a warning that occurred in a service request.
 type WarningReport struct {
 	// The status code.
-	StatusCode *string `json:"status_code,omitempty"`
+	StatusCode *int64 `json:"status_code,omitempty"`
 
 	// The transaction-id of the API request.
 	Trace *string `json:"trace,omitempty"`
@@ -1538,26 +1775,27 @@ func UnmarshalWarningReport(m map[string]json.RawMessage, result interface{}) (e
 
 // CosEndpoint : Property values for a Cloud Object Storage Endpoint.
 type CosEndpoint struct {
-	// The host name of this COS endpoint.
+	// The host name of the Cloud Object Storage endpoint.
 	Endpoint *string `json:"endpoint" validate:"required"`
 
-	// The CRN of this COS instance.
+	// The CRN of the Cloud Object Storage instance.
 	TargetCRN *string `json:"target_crn" validate:"required"`
 
-	// The bucket name under this COS instance.
+	// The bucket name under the Cloud Object Storage instance.
 	Bucket *string `json:"bucket" validate:"required"`
 
-	// The IAM Api key that have writer access to this cos instance. This credential will be masked in the response.
+	// The IAM API key that has writer access to the Cloud Object Storage instance. This credential is masked in the
+	// response.
 	APIKey *string `json:"api_key" validate:"required"`
 }
 
 // NewCosEndpoint : Instantiate CosEndpoint (Generic Model Constructor)
 func (*AtrackerV1) NewCosEndpoint(endpoint string, targetCRN string, bucket string, apiKey string) (_model *CosEndpoint, err error) {
 	_model = &CosEndpoint{
-		Endpoint:  core.StringPtr(endpoint),
+		Endpoint: core.StringPtr(endpoint),
 		TargetCRN: core.StringPtr(targetCRN),
-		Bucket:    core.StringPtr(bucket),
-		APIKey:    core.StringPtr(apiKey),
+		Bucket: core.StringPtr(bucket),
+		APIKey: core.StringPtr(apiKey),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -1591,10 +1829,10 @@ type CosWriteStatus struct {
 	// The status such as failed or success.
 	Status *string `json:"status,omitempty"`
 
-	// The timestamp of the last_failure.
+	// The timestamp of the failure.
 	LastFailure *strfmt.DateTime `json:"last_failure,omitempty"`
 
-	// detailed description of the cause of last_failure.
+	// Detailed description of the cause of the failure.
 	ReasonForLastFailure *string `json:"reason_for_last_failure,omitempty"`
 }
 

--- a/atrackerv1/atracker_v1_examples_test.go
+++ b/atrackerv1/atracker_v1_examples_test.go
@@ -379,5 +379,49 @@ var _ = Describe(`AtrackerV1 Examples Tests`, func() {
 			Expect(warningReport).ToNot(BeNil())
 
 		})
+		It(`GetEndpoints request example`, func() {
+			fmt.Println("\nGetEndpoints() result:")
+			// begin-get_endpoints
+
+			getEndpointsOptions := atrackerService.NewGetEndpointsOptions()
+
+			endpoints, response, err := atrackerService.GetEndpoints(getEndpointsOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(endpoints, "", "  ")
+			fmt.Println(string(b))
+
+			// end-get_endpoints
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(endpoints).ToNot(BeNil())
+
+		})
+		It(`PatchEndpoints request example`, func() {
+			fmt.Println("\nPatchEndpoints() result:")
+			// begin-patch_endpoints
+
+			patchEndpointsOptions := atrackerService.NewPatchEndpointsOptions()
+
+			// set public enabled flag
+			publicEnabled := true
+			patchEndpointsOptions.SetAPIEndpoint(&atrackerv1.EndpointsRequestAPIEndpoint{PublicEnabled: &publicEnabled})
+
+			endpoints, response, err := atrackerService.PatchEndpoints(patchEndpointsOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(endpoints, "", "  ")
+			fmt.Println(string(b))
+
+			// end-patch_endpoints
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(endpoints).ToNot(BeNil())
+
+		})
 	})
 })

--- a/atrackerv1/atracker_v1_integration_test.go
+++ b/atrackerv1/atracker_v1_integration_test.go
@@ -340,6 +340,55 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 
 		})
 	})
+
+	Describe(`GetEndpoints - Get endpoints`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`GetEndpoints(getEndpointsOptions *GetEndpointsOptions)`, func() {
+
+			getEndpointsOptions := &atrackerv1.GetEndpointsOptions{}
+
+			endpoints, response, err := atrackerService.GetEndpoints(getEndpointsOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(endpoints).ToNot(BeNil())
+			// more validations
+			Expect(endpoints.APIEndpoint.PublicURL).ToNot(BeNil())
+			Expect(endpoints.APIEndpoint.PrivateURL).ToNot(BeNil())
+			Expect(*endpoints.APIEndpoint.PrivateEnabled).To(Equal(true))
+		})
+	})
+
+	Describe(`PatchEndpoints - Modify endpoints`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`PatchEndpoints(patchEndpointsOptions *PatchEndpointsOptions)`, func() {
+
+			endpointsRequestAPIEndpointModel := &atrackerv1.EndpointsRequestAPIEndpoint{
+				PublicEnabled: core.BoolPtr(true),
+			}
+
+			patchEndpointsOptions := &atrackerv1.PatchEndpointsOptions{
+				APIEndpoint: endpointsRequestAPIEndpointModel,
+			}
+
+			endpoints, response, err := atrackerService.PatchEndpoints(patchEndpointsOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(endpoints).ToNot(BeNil())
+			Expect(endpoints.APIEndpoint).ToNot(BeNil())
+			// more validations
+			Expect(endpoints.APIEndpoint.PublicURL).ToNot(BeNil())
+			Expect(endpoints.APIEndpoint.PrivateURL).ToNot(BeNil())
+			Expect(*endpoints.APIEndpoint.PublicEnabled).To(Equal(true))
+			Expect(*endpoints.APIEndpoint.PrivateEnabled).To(Equal(true))
+		})
+	})
+
 })
 
 //

--- a/atrackerv1/atracker_v1_integration_test.go
+++ b/atrackerv1/atracker_v1_integration_test.go
@@ -40,11 +40,20 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 
 	const externalConfigFile = "../atracker_v1.env"
 
+	const notFoundTargetID = "deadbeef-2222-2222-2222-222222222222"
+
+	const notFoundRouteID = "deadbeef-2222-2222-2222-222222222222"
+
+	const badTargetType = "bad_target_type"
+
 	var (
-		err             error
-		atrackerService *atrackerv1.AtrackerV1
-		serviceURL      string
-		config          map[string]string
+		err                          error
+		atrackerService              *atrackerv1.AtrackerV1
+		atrackerServiceNotAuthorized *atrackerv1.AtrackerV1
+		serviceURL                   string
+		config                       map[string]string
+
+		refreshTokenNotAuthorized string
 	)
 
 	// Globlal variables to hold link values
@@ -92,6 +101,19 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(atrackerService).ToNot(BeNil())
 			Expect(atrackerService.Service.Options.URL).To(Equal(serviceURL))
+
+			atrackerUnauthorizedServiceOptions := &atrackerv1.AtrackerV1Options{
+				ServiceName: "NOT_AUTHORIZED",
+			}
+			atrackerServiceNotAuthorized, err = atrackerv1.NewAtrackerV1UsingExternalConfig(atrackerUnauthorizedServiceOptions)
+			Expect(err).To(BeNil())
+			Expect(atrackerServiceNotAuthorized).ToNot(BeNil())
+			Expect(atrackerServiceNotAuthorized.Service.Options.URL).To(Equal(serviceURL))
+
+			tokenNotAuthorized, err := atrackerServiceNotAuthorized.Service.Options.Authenticator.(*core.IamAuthenticator).RequestToken()
+			Expect(err).To(BeNil())
+			refreshTokenNotAuthorized = tokenNotAuthorized.RefreshToken
+			Expect(refreshTokenNotAuthorized).ToNot(BeNil())
 		})
 	})
 
@@ -99,6 +121,48 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 400 when backend input validation fails`, func() {
+			cosEndpointModel := &atrackerv1.CosEndpoint{
+				Endpoint:  core.StringPtr("s3.private.us-east.cloud-object-storage.appdomain.cloud"),
+				TargetCRN: core.StringPtr("crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
+				Bucket:    core.StringPtr("my-atracker-bucket"),
+				APIKey:    core.StringPtr("xxxxxxxxxxxxxx"),
+			}
+
+			createTargetOptions := &atrackerv1.CreateTargetOptions{
+				Name:        core.StringPtr("my-cos-target"),
+				TargetType:  core.StringPtr(badTargetType),
+				CosEndpoint: cosEndpointModel,
+			}
+
+			_, response, err := atrackerService.CreateTarget(createTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(400))
+		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			cosEndpointModel := &atrackerv1.CosEndpoint{
+				Endpoint:  core.StringPtr("s3.private.us-east.cloud-object-storage.appdomain.cloud"),
+				TargetCRN: core.StringPtr("crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
+				Bucket:    core.StringPtr("my-atracker-bucket"),
+				APIKey:    core.StringPtr("xxxxxxxxxxxxxx"),
+			}
+
+			createTargetOptions := &atrackerv1.CreateTargetOptions{
+				Name:        core.StringPtr("my-cos-target"),
+				TargetType:  core.StringPtr("cloud_object_storage"),
+				CosEndpoint: cosEndpointModel,
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.CreateTarget(createTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
 		It(`CreateTarget(createTargetOptions *CreateTargetOptions)`, func() {
 
 			cosEndpointModel := &atrackerv1.CosEndpoint{
@@ -129,6 +193,17 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			listTargetsOptions := &atrackerv1.ListTargetsOptions{}
+
+			_, response, err := atrackerServiceNotAuthorized.ListTargets(listTargetsOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
 		It(`ListTargets(listTargetsOptions *ListTargetsOptions)`, func() {
 
 			listTargetsOptions := &atrackerv1.ListTargetsOptions{}
@@ -147,6 +222,32 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			getTargetOptions := &atrackerv1.GetTargetOptions{
+				ID: core.StringPtr(targetIDLink),
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.GetTarget(getTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when target id is not found`, func() {
+
+			getTargetOptions := &atrackerv1.GetTargetOptions{
+				ID: core.StringPtr(notFoundTargetID),
+			}
+
+			_, response, err := atrackerService.GetTarget(getTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`GetTarget(getTargetOptions *GetTargetOptions)`, func() {
 
 			getTargetOptions := &atrackerv1.GetTargetOptions{
@@ -167,6 +268,73 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			cosEndpointModel := &atrackerv1.CosEndpoint{
+				Endpoint:  core.StringPtr("s3.private.us-east.cloud-object-storage.appdomain.cloud"),
+				TargetCRN: core.StringPtr("crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
+				Bucket:    core.StringPtr("my-atracker-bucket"),
+				APIKey:    core.StringPtr("xxxxxxxxxxxxxx"),
+			}
+
+			replaceTargetOptions := &atrackerv1.ReplaceTargetOptions{
+				ID:          core.StringPtr(targetIDLink),
+				Name:        core.StringPtr("my-cos-target-modified"),
+				TargetType:  core.StringPtr("cloud_object_storage"),
+				CosEndpoint: cosEndpointModel,
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.ReplaceTarget(replaceTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 400 when target fields are not valid`, func() {
+
+			cosEndpointModel := &atrackerv1.CosEndpoint{
+				Endpoint:  core.StringPtr("s3.private.us-east.cloud-object-storage.appdomain.cloud"),
+				TargetCRN: core.StringPtr("crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
+				Bucket:    core.StringPtr("my-atracker-bucket"),
+				APIKey:    core.StringPtr("xxxxxxxxxxxxxx"),
+			}
+
+			replaceTargetOptions := &atrackerv1.ReplaceTargetOptions{
+				ID:          core.StringPtr(targetIDLink),
+				Name:        core.StringPtr("my-cos-target-modified"),
+				TargetType:  core.StringPtr(badTargetType),
+				CosEndpoint: cosEndpointModel,
+			}
+			_, response, err := atrackerService.ReplaceTarget(replaceTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(400))
+
+		})
+
+		It(`Returns 404 when target id is not found`, func() {
+
+			cosEndpointModel := &atrackerv1.CosEndpoint{
+				Endpoint:  core.StringPtr("s3.private.us-east.cloud-object-storage.appdomain.cloud"),
+				TargetCRN: core.StringPtr("crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
+				Bucket:    core.StringPtr("my-atracker-bucket"),
+				APIKey:    core.StringPtr("xxxxxxxxxxxxxx"),
+			}
+
+			replaceTargetOptions := &atrackerv1.ReplaceTargetOptions{
+				ID:          core.StringPtr(notFoundTargetID),
+				Name:        core.StringPtr("my-cos-target-modified"),
+				TargetType:  core.StringPtr("cloud_object_storage"),
+				CosEndpoint: cosEndpointModel,
+			}
+			_, response, err := atrackerService.ReplaceTarget(replaceTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`ReplaceTarget(replaceTargetOptions *ReplaceTargetOptions)`, func() {
 
 			cosEndpointModel := &atrackerv1.CosEndpoint{
@@ -197,6 +365,32 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			validateTargetOptions := &atrackerv1.ValidateTargetOptions{
+				ID: core.StringPtr(targetIDLink),
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.ValidateTarget(validateTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when target id is not found`, func() {
+
+			validateTargetOptions := &atrackerv1.ValidateTargetOptions{
+				ID: core.StringPtr(notFoundTargetID),
+			}
+
+			_, response, err := atrackerService.ValidateTarget(validateTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`ValidateTarget(validateTargetOptions *ValidateTargetOptions)`, func() {
 
 			validateTargetOptions := &atrackerv1.ValidateTargetOptions{
@@ -216,6 +410,44 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			ruleModel := &atrackerv1.Rule{
+				TargetIds: []string{targetIDLink},
+			}
+
+			createRouteOptions := &atrackerv1.CreateRouteOptions{
+				Name:                core.StringPtr("my-route"),
+				ReceiveGlobalEvents: core.BoolPtr(false),
+				Rules:               []atrackerv1.Rule{*ruleModel},
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.CreateRoute(createRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 400 when input validation fails`, func() {
+
+			ruleModel := &atrackerv1.Rule{
+				TargetIds: []string{notFoundTargetID},
+			}
+
+			createRouteOptions := &atrackerv1.CreateRouteOptions{
+				Name:                core.StringPtr("my-route"),
+				ReceiveGlobalEvents: core.BoolPtr(false),
+				Rules:               []atrackerv1.Rule{*ruleModel},
+			}
+
+			_, response, err := atrackerService.CreateRoute(createRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(400))
+
+		})
+
 		It(`CreateRoute(createRouteOptions *CreateRouteOptions)`, func() {
 
 			ruleModel := &atrackerv1.Rule{
@@ -243,6 +475,17 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			listRoutesOptions := &atrackerv1.ListRoutesOptions{}
+
+			_, response, err := atrackerServiceNotAuthorized.ListRoutes(listRoutesOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
 		It(`ListRoutes(listRoutesOptions *ListRoutesOptions)`, func() {
 
 			listRoutesOptions := &atrackerv1.ListRoutesOptions{}
@@ -261,6 +504,32 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			getRouteOptions := &atrackerv1.GetRouteOptions{
+				ID: core.StringPtr(routeIDLink),
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.GetRoute(getRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when route id is not found`, func() {
+
+			getRouteOptions := &atrackerv1.GetRouteOptions{
+				ID: core.StringPtr(notFoundRouteID),
+			}
+
+			_, response, err := atrackerService.GetRoute(getRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`GetRoute(getRouteOptions *GetRouteOptions)`, func() {
 
 			getRouteOptions := &atrackerv1.GetRouteOptions{
@@ -281,6 +550,46 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			ruleModel := &atrackerv1.Rule{
+				TargetIds: []string{targetIDLink},
+			}
+
+			replaceRouteOptions := &atrackerv1.ReplaceRouteOptions{
+				ID:                  core.StringPtr(routeIDLink),
+				Name:                core.StringPtr("my-route-modified"),
+				ReceiveGlobalEvents: core.BoolPtr(false),
+				Rules:               []atrackerv1.Rule{*ruleModel},
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.ReplaceRoute(replaceRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when route id is not found`, func() {
+
+			ruleModel := &atrackerv1.Rule{
+				TargetIds: []string{targetIDLink},
+			}
+
+			replaceRouteOptions := &atrackerv1.ReplaceRouteOptions{
+				ID:                  core.StringPtr(notFoundRouteID),
+				Name:                core.StringPtr("my-route-modified"),
+				ReceiveGlobalEvents: core.BoolPtr(false),
+				Rules:               []atrackerv1.Rule{*ruleModel},
+			}
+
+			_, response, err := atrackerService.ReplaceRoute(replaceRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`ReplaceRoute(replaceRouteOptions *ReplaceRouteOptions)`, func() {
 
 			ruleModel := &atrackerv1.Rule{
@@ -308,6 +617,32 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			deleteRouteOptions := &atrackerv1.DeleteRouteOptions{
+				ID: core.StringPtr(routeIDLink),
+			}
+
+			response, err := atrackerServiceNotAuthorized.DeleteRoute(deleteRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when route id is not found`, func() {
+
+			deleteRouteOptions := &atrackerv1.DeleteRouteOptions{
+				ID: core.StringPtr(notFoundRouteID),
+			}
+
+			response, err := atrackerService.DeleteRoute(deleteRouteOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`DeleteRoute(deleteRouteOptions *DeleteRouteOptions)`, func() {
 
 			deleteRouteOptions := &atrackerv1.DeleteRouteOptions{
@@ -326,6 +661,32 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			deleteTargetOptions := &atrackerv1.DeleteTargetOptions{
+				ID: core.StringPtr(targetIDLink),
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.DeleteTarget(deleteTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
+		It(`Returns 404 when target id is not found`, func() {
+
+			deleteTargetOptions := &atrackerv1.DeleteTargetOptions{
+				ID: core.StringPtr(notFoundTargetID),
+			}
+
+			_, response, err := atrackerService.DeleteTarget(deleteTargetOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+
+		})
+
 		It(`DeleteTarget(deleteTargetOptions *DeleteTargetOptions)`, func() {
 
 			deleteTargetOptions := &atrackerv1.DeleteTargetOptions{
@@ -345,6 +706,17 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			getEndpointsOptions := &atrackerv1.GetEndpointsOptions{}
+
+			_, response, err := atrackerServiceNotAuthorized.GetEndpoints(getEndpointsOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
 		It(`GetEndpoints(getEndpointsOptions *GetEndpointsOptions)`, func() {
 
 			getEndpointsOptions := &atrackerv1.GetEndpointsOptions{}
@@ -365,6 +737,23 @@ var _ = Describe(`AtrackerV1 Integration Tests`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
+
+		It(`Returns 403 when user is not authorized`, func() {
+
+			endpointsRequestAPIEndpointModel := &atrackerv1.EndpointsRequestAPIEndpoint{
+				PublicEnabled: core.BoolPtr(true),
+			}
+
+			patchEndpointsOptions := &atrackerv1.PatchEndpointsOptions{
+				APIEndpoint: endpointsRequestAPIEndpointModel,
+			}
+
+			_, response, err := atrackerServiceNotAuthorized.PatchEndpoints(patchEndpointsOptions)
+
+			Expect(err).NotTo(BeNil())
+			Expect(response.StatusCode).To(Equal(403))
+		})
+
 		It(`PatchEndpoints(patchEndpointsOptions *PatchEndpointsOptions)`, func() {
 
 			endpointsRequestAPIEndpointModel := &atrackerv1.EndpointsRequestAPIEndpoint{

--- a/atrackerv1/atracker_v1_test.go
+++ b/atrackerv1/atracker_v1_test.go
@@ -1253,7 +1253,7 @@ var _ = Describe(`AtrackerV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"status_code": "StatusCode", "trace": "Trace", "warnings": [{"code": "Code", "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"status_code": 10, "trace": "Trace", "warnings": [{"code": "Code", "message": "Message"}]}`)
 				}))
 			})
 			It(`Invoke DeleteTarget successfully with retries`, func() {
@@ -1307,7 +1307,7 @@ var _ = Describe(`AtrackerV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"status_code": "StatusCode", "trace": "Trace", "warnings": [{"code": "Code", "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"status_code": 10, "trace": "Trace", "warnings": [{"code": "Code", "message": "Message"}]}`)
 				}))
 			})
 			It(`Invoke DeleteTarget successfully`, func() {
@@ -2648,6 +2648,463 @@ var _ = Describe(`AtrackerV1`, func() {
 			})
 		})
 	})
+	Describe(`GetEndpoints(getEndpointsOptions *GetEndpointsOptions) - Operation response error`, func() {
+		getEndpointsPath := "/api/v1/endpoints"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getEndpointsPath))
+					Expect(req.Method).To(Equal("GET"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetEndpoints with error: Operation response processing error`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := new(atrackerv1.GetEndpointsOptions)
+				getEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				atrackerService.EnableRetries(0, 0)
+				result, response, operationErr = atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetEndpoints(getEndpointsOptions *GetEndpointsOptions)`, func() {
+		getEndpointsPath := "/api/v1/endpoints"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getEndpointsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"api_endpoint": {"public_url": "https://us-south.atracker.cloud.ibm.com", "public_enabled": true, "private_url": "https://private.us-south.atracker.cloud.ibm.com", "private_enabled": true}}`)
+				}))
+			})
+			It(`Invoke GetEndpoints successfully with retries`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+				atrackerService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := new(atrackerv1.GetEndpointsOptions)
+				getEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := atrackerService.GetEndpointsWithContext(ctx, getEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				atrackerService.DisableRetries()
+				result, response, operationErr := atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = atrackerService.GetEndpointsWithContext(ctx, getEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getEndpointsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"api_endpoint": {"public_url": "https://us-south.atracker.cloud.ibm.com", "public_enabled": true, "private_url": "https://private.us-south.atracker.cloud.ibm.com", "private_enabled": true}}`)
+				}))
+			})
+			It(`Invoke GetEndpoints successfully`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := atrackerService.GetEndpoints(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := new(atrackerv1.GetEndpointsOptions)
+				getEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetEndpoints with error: Operation request error`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := new(atrackerv1.GetEndpointsOptions)
+				getEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := atrackerService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetEndpoints successfully`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := new(atrackerv1.GetEndpointsOptions)
+				getEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := atrackerService.GetEndpoints(getEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`PatchEndpoints(patchEndpointsOptions *PatchEndpointsOptions) - Operation response error`, func() {
+		patchEndpointsPath := "/api/v1/endpoints"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(patchEndpointsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke PatchEndpoints with error: Operation response processing error`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := new(atrackerv1.PatchEndpointsOptions)
+				patchEndpointsOptionsModel.APIEndpoint = endpointsRequestAPIEndpointModel
+				patchEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				atrackerService.EnableRetries(0, 0)
+				result, response, operationErr = atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`PatchEndpoints(patchEndpointsOptions *PatchEndpointsOptions)`, func() {
+		patchEndpointsPath := "/api/v1/endpoints"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(patchEndpointsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"api_endpoint": {"public_url": "https://us-south.atracker.cloud.ibm.com", "public_enabled": true, "private_url": "https://private.us-south.atracker.cloud.ibm.com", "private_enabled": true}}`)
+				}))
+			})
+			It(`Invoke PatchEndpoints successfully with retries`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+				atrackerService.EnableRetries(0, 0)
+
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := new(atrackerv1.PatchEndpointsOptions)
+				patchEndpointsOptionsModel.APIEndpoint = endpointsRequestAPIEndpointModel
+				patchEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := atrackerService.PatchEndpointsWithContext(ctx, patchEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				atrackerService.DisableRetries()
+				result, response, operationErr := atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = atrackerService.PatchEndpointsWithContext(ctx, patchEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(patchEndpointsPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"api_endpoint": {"public_url": "https://us-south.atracker.cloud.ibm.com", "public_enabled": true, "private_url": "https://private.us-south.atracker.cloud.ibm.com", "private_enabled": true}}`)
+				}))
+			})
+			It(`Invoke PatchEndpoints successfully`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := atrackerService.PatchEndpoints(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := new(atrackerv1.PatchEndpointsOptions)
+				patchEndpointsOptionsModel.APIEndpoint = endpointsRequestAPIEndpointModel
+				patchEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke PatchEndpoints with error: Operation request error`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := new(atrackerv1.PatchEndpointsOptions)
+				patchEndpointsOptionsModel.APIEndpoint = endpointsRequestAPIEndpointModel
+				patchEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := atrackerService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke PatchEndpoints successfully`, func() {
+				atrackerService, serviceErr := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(atrackerService).ToNot(BeNil())
+
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := new(atrackerv1.PatchEndpointsOptions)
+				patchEndpointsOptionsModel.APIEndpoint = endpointsRequestAPIEndpointModel
+				patchEndpointsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := atrackerService.PatchEndpoints(patchEndpointsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
 			atrackerService, _ := atrackerv1.NewAtrackerV1(&atrackerv1.AtrackerV1Options{
@@ -2724,6 +3181,13 @@ var _ = Describe(`AtrackerV1`, func() {
 				Expect(deleteTargetOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteTargetOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewGetEndpointsOptions successfully`, func() {
+				// Construct an instance of the GetEndpointsOptions model
+				getEndpointsOptionsModel := atrackerService.NewGetEndpointsOptions()
+				getEndpointsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getEndpointsOptionsModel).ToNot(BeNil())
+				Expect(getEndpointsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewGetRouteOptions successfully`, func() {
 				// Construct an instance of the GetRouteOptions model
 				id := "testString"
@@ -2757,6 +3221,21 @@ var _ = Describe(`AtrackerV1`, func() {
 				listTargetsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listTargetsOptionsModel).ToNot(BeNil())
 				Expect(listTargetsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewPatchEndpointsOptions successfully`, func() {
+				// Construct an instance of the EndpointsRequestAPIEndpoint model
+				endpointsRequestAPIEndpointModel := new(atrackerv1.EndpointsRequestAPIEndpoint)
+				Expect(endpointsRequestAPIEndpointModel).ToNot(BeNil())
+				endpointsRequestAPIEndpointModel.PublicEnabled = core.BoolPtr(true)
+				Expect(endpointsRequestAPIEndpointModel.PublicEnabled).To(Equal(core.BoolPtr(true)))
+
+				// Construct an instance of the PatchEndpointsOptions model
+				patchEndpointsOptionsModel := atrackerService.NewPatchEndpointsOptions()
+				patchEndpointsOptionsModel.SetAPIEndpoint(endpointsRequestAPIEndpointModel)
+				patchEndpointsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(patchEndpointsOptionsModel).ToNot(BeNil())
+				Expect(patchEndpointsOptionsModel.APIEndpoint).To(Equal(endpointsRequestAPIEndpointModel))
+				Expect(patchEndpointsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewReplaceRouteOptions successfully`, func() {
 				// Construct an instance of the Rule model


### PR DESCRIPTION
## PR summary

add endpoint sdk functions based on 2 new endpoints api for atracker service


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
unit test results:
```
yings-mbp:atrackerv1 yingwang@us.ibm.com$ go test
Running Suite: AtrackerV1 Suite
===============================
Random Seed: 1625603641
Will run 91 of 91 specs

•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 91 of 91 Specs in 3.505 seconds
SUCCESS! -- 91 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/IBM/platform-services-go-sdk/atrackerv1	3.986s
```

integration test results:
```
yings-mbp:platform-services-go-sdk yingwang@us.ibm.com$ go test github.com/IBM/platform-services-go-sdk/atrackerv1 -tags="integration" -v
=== RUN   TestAtrackerV1
Running Suite: AtrackerV1 Suite
===============================
Random Seed: 1625603255
Will run 106 of 106 specs

Service URL: http://localhost:6969
••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 106 of 106 Specs in 9.148 seconds
SUCCESS! -- 106 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAtrackerV1 (9.45s)
PASS
ok  	github.com/IBM/platform-services-go-sdk/atrackerv1	(cached)
```