### PR TITLE
feat(Context based Restrictions): add support for the X-Correlation-Id header

### DIFF
--- a/contextbasedrestrictionsv1/context_based_restrictions_v1.go
+++ b/contextbasedrestrictionsv1/context_based_restrictions_v1.go
@@ -35,11 +35,11 @@ import (
 )
 
 // ContextBasedRestrictionsV1 : With the Context Based Restrictions API, you can:
-// * Create, list, get, update, and delete network zones
-// * Create, list, get, update, and delete context-based restriction rules
+// * Create, list, get, replace, and delete network zones
+// * Create, list, get, replace, and delete context-based restriction rules
 // * Get account settings
 //
-// API Version: 1.0.0
+// API Version: 1.0.1
 type ContextBasedRestrictionsV1 struct {
 	Service *core.BaseService
 }
@@ -163,7 +163,7 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) DisableRetries() {
 	contextBasedRestrictions.Service.DisableRetries()
 }
 
-// CreateZone : Create a zone
+// CreateZone : Create a network zone
 // This operation creates a network zone for the specified account.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) CreateZone(createZoneOptions *CreateZoneOptions) (result *Zone, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.CreateZoneWithContext(context.Background(), createZoneOptions)
@@ -194,6 +194,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) CreateZoneWithContex
 	}
 	builder.AddHeader("Accept", "application/json")
 	builder.AddHeader("Content-Type", "application/json")
+	if createZoneOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*createZoneOptions.XCorrelationID))
+	}
 	if createZoneOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*createZoneOptions.TransactionID))
 	}
@@ -274,6 +277,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListZonesWithContext
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if listZonesOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*listZonesOptions.XCorrelationID))
+	}
 	if listZonesOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*listZonesOptions.TransactionID))
 	}
@@ -307,8 +313,8 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListZonesWithContext
 	return
 }
 
-// GetZone : Get the specified network zone
-// This operation returns the network zone for the specified ID.
+// GetZone : Get a network zone
+// This operation retrieves the network zone identified by the specified zone ID.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetZone(getZoneOptions *GetZoneOptions) (result *Zone, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.GetZoneWithContext(context.Background(), getZoneOptions)
 }
@@ -345,6 +351,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetZoneWithContext(c
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if getZoneOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*getZoneOptions.XCorrelationID))
+	}
 	if getZoneOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*getZoneOptions.TransactionID))
 	}
@@ -370,8 +379,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetZoneWithContext(c
 	return
 }
 
-// ReplaceZone : Update the specified network zone
-// This operation updates the network zone with the specified ID.
+// ReplaceZone : Replace a network zone
+// This operation replaces the network zone identified by the specified zone ID. Partial updates are not supported. The
+// entire network zone object must be replaced.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceZone(replaceZoneOptions *ReplaceZoneOptions) (result *Zone, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.ReplaceZoneWithContext(context.Background(), replaceZoneOptions)
 }
@@ -411,6 +421,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceZoneWithConte
 	builder.AddHeader("Content-Type", "application/json")
 	if replaceZoneOptions.IfMatch != nil {
 		builder.AddHeader("If-Match", fmt.Sprint(*replaceZoneOptions.IfMatch))
+	}
+	if replaceZoneOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*replaceZoneOptions.XCorrelationID))
 	}
 	if replaceZoneOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*replaceZoneOptions.TransactionID))
@@ -458,8 +471,8 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceZoneWithConte
 	return
 }
 
-// DeleteZone : Delete the specified network zone
-// This operation deletes the network zone with the specified home ID.
+// DeleteZone : Delete a network zone
+// This operation deletes the network zone identified by the specified zone ID.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) DeleteZone(deleteZoneOptions *DeleteZoneOptions) (response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.DeleteZoneWithContext(context.Background(), deleteZoneOptions)
 }
@@ -494,6 +507,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) DeleteZoneWithContex
 	sdkHeaders := common.GetSdkHeaders("context_based_restrictions", "V1", "DeleteZone")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
+	}
+	if deleteZoneOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*deleteZoneOptions.XCorrelationID))
 	}
 	if deleteZoneOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*deleteZoneOptions.TransactionID))
@@ -539,6 +555,12 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListAvailableService
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if listAvailableServicerefTargetsOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*listAvailableServicerefTargetsOptions.XCorrelationID))
+	}
+	if listAvailableServicerefTargetsOptions.TransactionID != nil {
+		builder.AddHeader("Transaction-Id", fmt.Sprint(*listAvailableServicerefTargetsOptions.TransactionID))
+	}
 
 	if listAvailableServicerefTargetsOptions.Type != nil {
 		builder.AddQuery("type", fmt.Sprint(*listAvailableServicerefTargetsOptions.Type))
@@ -596,6 +618,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) CreateRuleWithContex
 	}
 	builder.AddHeader("Accept", "application/json")
 	builder.AddHeader("Content-Type", "application/json")
+	if createRuleOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*createRuleOptions.XCorrelationID))
+	}
 	if createRuleOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*createRuleOptions.TransactionID))
 	}
@@ -637,7 +662,7 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) CreateRuleWithContex
 }
 
 // ListRules : List rules
-// This operation lists rules for the specified account.
+// This operation lists rules in the specified account.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListRules(listRulesOptions *ListRulesOptions) (result *RuleList, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.ListRulesWithContext(context.Background(), listRulesOptions)
 }
@@ -670,6 +695,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListRulesWithContext
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if listRulesOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*listRulesOptions.XCorrelationID))
+	}
 	if listRulesOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*listRulesOptions.TransactionID))
 	}
@@ -721,8 +749,8 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ListRulesWithContext
 	return
 }
 
-// GetRule : Get the specified rule
-// This operation gets the rule for the specified ID.
+// GetRule : Get a rule
+// This operation retrieves the rule identified by the specified rule ID.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetRule(getRuleOptions *GetRuleOptions) (result *Rule, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.GetRuleWithContext(context.Background(), getRuleOptions)
 }
@@ -759,6 +787,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetRuleWithContext(c
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if getRuleOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*getRuleOptions.XCorrelationID))
+	}
 	if getRuleOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*getRuleOptions.TransactionID))
 	}
@@ -784,8 +815,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetRuleWithContext(c
 	return
 }
 
-// ReplaceRule : Update the specified rule
-// This operation updates the rule for the specified ID.
+// ReplaceRule : Replace a rule
+// This operation replaces the rule identified by the specified rule ID. Partial updates are not supported. The entire
+// rule object must be replaced.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceRule(replaceRuleOptions *ReplaceRuleOptions) (result *Rule, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.ReplaceRuleWithContext(context.Background(), replaceRuleOptions)
 }
@@ -825,6 +857,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceRuleWithConte
 	builder.AddHeader("Content-Type", "application/json")
 	if replaceRuleOptions.IfMatch != nil {
 		builder.AddHeader("If-Match", fmt.Sprint(*replaceRuleOptions.IfMatch))
+	}
+	if replaceRuleOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*replaceRuleOptions.XCorrelationID))
 	}
 	if replaceRuleOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*replaceRuleOptions.TransactionID))
@@ -866,8 +901,8 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) ReplaceRuleWithConte
 	return
 }
 
-// DeleteRule : Delete the specified rule
-// This operation deletes the rule for the specified home ID.
+// DeleteRule : Delete a rule
+// This operation deletes the rule identified by the specified rule ID.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) DeleteRule(deleteRuleOptions *DeleteRuleOptions) (response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.DeleteRuleWithContext(context.Background(), deleteRuleOptions)
 }
@@ -903,6 +938,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) DeleteRuleWithContex
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
+	if deleteRuleOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*deleteRuleOptions.XCorrelationID))
+	}
 	if deleteRuleOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*deleteRuleOptions.TransactionID))
 	}
@@ -917,8 +955,8 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) DeleteRuleWithContex
 	return
 }
 
-// GetAccountSettings : Get the specified account settings
-// This operation gets the settings for the specified account ID.
+// GetAccountSettings : Get account settings
+// This operation retrieves the settings for the specified account ID.
 func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetAccountSettings(getAccountSettingsOptions *GetAccountSettingsOptions) (result *AccountSettings, response *core.DetailedResponse, err error) {
 	return contextBasedRestrictions.GetAccountSettingsWithContext(context.Background(), getAccountSettingsOptions)
 }
@@ -955,6 +993,9 @@ func (contextBasedRestrictions *ContextBasedRestrictionsV1) GetAccountSettingsWi
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+	if getAccountSettingsOptions.XCorrelationID != nil {
+		builder.AddHeader("X-Correlation-Id", fmt.Sprint(*getAccountSettingsOptions.XCorrelationID))
+	}
 	if getAccountSettingsOptions.TransactionID != nil {
 		builder.AddHeader("Transaction-Id", fmt.Sprint(*getAccountSettingsOptions.TransactionID))
 	}
@@ -1143,10 +1184,14 @@ type CreateRuleOptions struct {
 	// The resources this rule apply to.
 	Resources []Resource `json:"resources,omitempty"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1176,6 +1221,12 @@ func (options *CreateRuleOptions) SetResources(resources []Resource) *CreateRule
 	return options
 }
 
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *CreateRuleOptions) SetXCorrelationID(xCorrelationID string) *CreateRuleOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
+	return options
+}
+
 // SetTransactionID : Allow user to set TransactionID
 func (options *CreateRuleOptions) SetTransactionID(transactionID string) *CreateRuleOptions {
 	options.TransactionID = core.StringPtr(transactionID)
@@ -1202,13 +1253,18 @@ type CreateZoneOptions struct {
 	// The list of addresses in the zone.
 	Addresses []AddressIntf `json:"addresses,omitempty"`
 
-	// The list of excluded addresses in the zone.
+	// The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+	// excluded.
 	Excluded []AddressIntf `json:"excluded,omitempty"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1250,6 +1306,12 @@ func (options *CreateZoneOptions) SetExcluded(excluded []AddressIntf) *CreateZon
 	return options
 }
 
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *CreateZoneOptions) SetXCorrelationID(xCorrelationID string) *CreateZoneOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
+	return options
+}
+
 // SetTransactionID : Allow user to set TransactionID
 func (options *CreateZoneOptions) SetTransactionID(transactionID string) *CreateZoneOptions {
 	options.TransactionID = core.StringPtr(transactionID)
@@ -1267,10 +1329,14 @@ type DeleteRuleOptions struct {
 	// The ID of a rule.
 	RuleID *string `json:"-" validate:"required,ne="`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1287,6 +1353,12 @@ func (*ContextBasedRestrictionsV1) NewDeleteRuleOptions(ruleID string) *DeleteRu
 // SetRuleID : Allow user to set RuleID
 func (options *DeleteRuleOptions) SetRuleID(ruleID string) *DeleteRuleOptions {
 	options.RuleID = core.StringPtr(ruleID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *DeleteRuleOptions) SetXCorrelationID(xCorrelationID string) *DeleteRuleOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1307,10 +1379,14 @@ type DeleteZoneOptions struct {
 	// The ID of a zone.
 	ZoneID *string `json:"-" validate:"required,ne="`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1327,6 +1403,12 @@ func (*ContextBasedRestrictionsV1) NewDeleteZoneOptions(zoneID string) *DeleteZo
 // SetZoneID : Allow user to set ZoneID
 func (options *DeleteZoneOptions) SetZoneID(zoneID string) *DeleteZoneOptions {
 	options.ZoneID = core.StringPtr(zoneID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *DeleteZoneOptions) SetXCorrelationID(xCorrelationID string) *DeleteZoneOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1347,10 +1429,14 @@ type GetAccountSettingsOptions struct {
 	// The ID of the account the settings are for.
 	AccountID *string `json:"-" validate:"required,ne="`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1367,6 +1453,12 @@ func (*ContextBasedRestrictionsV1) NewGetAccountSettingsOptions(accountID string
 // SetAccountID : Allow user to set AccountID
 func (options *GetAccountSettingsOptions) SetAccountID(accountID string) *GetAccountSettingsOptions {
 	options.AccountID = core.StringPtr(accountID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *GetAccountSettingsOptions) SetXCorrelationID(xCorrelationID string) *GetAccountSettingsOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1387,10 +1479,14 @@ type GetRuleOptions struct {
 	// The ID of a rule.
 	RuleID *string `json:"-" validate:"required,ne="`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1407,6 +1503,12 @@ func (*ContextBasedRestrictionsV1) NewGetRuleOptions(ruleID string) *GetRuleOpti
 // SetRuleID : Allow user to set RuleID
 func (options *GetRuleOptions) SetRuleID(ruleID string) *GetRuleOptions {
 	options.RuleID = core.StringPtr(ruleID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *GetRuleOptions) SetXCorrelationID(xCorrelationID string) *GetRuleOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1427,10 +1529,14 @@ type GetZoneOptions struct {
 	// The ID of a zone.
 	ZoneID *string `json:"-" validate:"required,ne="`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1450,6 +1556,12 @@ func (options *GetZoneOptions) SetZoneID(zoneID string) *GetZoneOptions {
 	return options
 }
 
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *GetZoneOptions) SetXCorrelationID(xCorrelationID string) *GetZoneOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
+	return options
+}
+
 // SetTransactionID : Allow user to set TransactionID
 func (options *GetZoneOptions) SetTransactionID(transactionID string) *GetZoneOptions {
 	options.TransactionID = core.StringPtr(transactionID)
@@ -1464,6 +1576,16 @@ func (options *GetZoneOptions) SetHeaders(param map[string]string) *GetZoneOptio
 
 // ListAvailableServicerefTargetsOptions : The ListAvailableServicerefTargets options.
 type ListAvailableServicerefTargetsOptions struct {
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
+	TransactionID *string `json:"-"`
+
 	// Specifies the types of services to retrieve.
 	Type *string `json:"-"`
 
@@ -1483,6 +1605,18 @@ func (*ContextBasedRestrictionsV1) NewListAvailableServicerefTargetsOptions() *L
 	return &ListAvailableServicerefTargetsOptions{}
 }
 
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *ListAvailableServicerefTargetsOptions) SetXCorrelationID(xCorrelationID string) *ListAvailableServicerefTargetsOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
+	return options
+}
+
+// SetTransactionID : Allow user to set TransactionID
+func (options *ListAvailableServicerefTargetsOptions) SetTransactionID(transactionID string) *ListAvailableServicerefTargetsOptions {
+	options.TransactionID = core.StringPtr(transactionID)
+	return options
+}
+
 // SetType : Allow user to set Type
 func (options *ListAvailableServicerefTargetsOptions) SetType(typeVar string) *ListAvailableServicerefTargetsOptions {
 	options.Type = core.StringPtr(typeVar)
@@ -1500,10 +1634,14 @@ type ListRulesOptions struct {
 	// The ID of the managing account.
 	AccountID *string `json:"-" validate:"required"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// The `region` resource attribute.
@@ -1545,6 +1683,12 @@ func (*ContextBasedRestrictionsV1) NewListRulesOptions(accountID string) *ListRu
 // SetAccountID : Allow user to set AccountID
 func (options *ListRulesOptions) SetAccountID(accountID string) *ListRulesOptions {
 	options.AccountID = core.StringPtr(accountID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *ListRulesOptions) SetXCorrelationID(xCorrelationID string) *ListRulesOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1613,10 +1757,14 @@ type ListZonesOptions struct {
 	// The ID of the managing account.
 	AccountID *string `json:"-" validate:"required"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// The name of the zone.
@@ -1640,6 +1788,12 @@ func (*ContextBasedRestrictionsV1) NewListZonesOptions(accountID string) *ListZo
 // SetAccountID : Allow user to set AccountID
 func (options *ListZonesOptions) SetAccountID(accountID string) *ListZonesOptions {
 	options.AccountID = core.StringPtr(accountID)
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *ListZonesOptions) SetXCorrelationID(xCorrelationID string) *ListZonesOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -1685,10 +1839,14 @@ type ReplaceRuleOptions struct {
 	// The resources this rule apply to.
 	Resources []Resource `json:"resources,omitempty"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1733,6 +1891,12 @@ func (options *ReplaceRuleOptions) SetResources(resources []Resource) *ReplaceRu
 	return options
 }
 
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *ReplaceRuleOptions) SetXCorrelationID(xCorrelationID string) *ReplaceRuleOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
+	return options
+}
+
 // SetTransactionID : Allow user to set TransactionID
 func (options *ReplaceRuleOptions) SetTransactionID(transactionID string) *ReplaceRuleOptions {
 	options.TransactionID = core.StringPtr(transactionID)
@@ -1766,13 +1930,18 @@ type ReplaceZoneOptions struct {
 	// The list of addresses in the zone.
 	Addresses []AddressIntf `json:"addresses,omitempty"`
 
-	// The list of excluded addresses in the zone.
+	// The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+	// excluded.
 	Excluded []AddressIntf `json:"excluded,omitempty"`
 
-	// The UUID that is used to correlate and track transactions. If you omit this field, the service generates and sends a
-	// transaction ID in the response.
-	// **Note:** To help with debugging, we strongly recommend that you generate and supply a `Transaction-Id` with each
-	// request.
+	// The supplied or generated value of this header is logged for a request and repeated in a response header for the
+	// corresponding response. The same value is used for downstream requests and retries of those requests. If a value of
+	// this headers is not supplied in a request, the service generates a random (version 4) UUID.
+	XCorrelationID *string `json:"-"`
+
+	// The `Transaction-Id` header behaves as the `X-Correlation-Id` header. It is supported for backward compatibility
+	// with other IBM platform services that support the `Transaction-Id` header only. If both `X-Correlation-Id` and
+	// `Transaction-Id` are provided, `X-Correlation-Id` has the precedence over `Transaction-Id`.
 	TransactionID *string `json:"-"`
 
 	// Allows users to set headers on API requests
@@ -1826,6 +1995,12 @@ func (options *ReplaceZoneOptions) SetAddresses(addresses []AddressIntf) *Replac
 // SetExcluded : Allow user to set Excluded
 func (options *ReplaceZoneOptions) SetExcluded(excluded []AddressIntf) *ReplaceZoneOptions {
 	options.Excluded = excluded
+	return options
+}
+
+// SetXCorrelationID : Allow user to set XCorrelationID
+func (options *ReplaceZoneOptions) SetXCorrelationID(xCorrelationID string) *ReplaceZoneOptions {
+	options.XCorrelationID = core.StringPtr(xCorrelationID)
 	return options
 }
 
@@ -2241,7 +2416,8 @@ type Zone struct {
 	// The list of addresses in the zone.
 	Addresses []AddressIntf `json:"addresses" validate:"required"`
 
-	// The list of excluded addresses in the zone.
+	// The list of excluded addresses in the zone. Only addresses of type `ipAddress`, `ipRange`, and `subnet` can be
+	// excluded.
 	Excluded []AddressIntf `json:"excluded" validate:"required"`
 
 	// The href link to the resource.

--- a/contextbasedrestrictionsv1/context_based_restrictions_v1_integration_test.go
+++ b/contextbasedrestrictionsv1/context_based_restrictions_v1_integration_test.go
@@ -960,8 +960,9 @@ var _ = Describe(`ContextBasedRestrictionsV1 Integration Tests`, func() {
 		})
 		It(`DeleteZone(deleteZoneOptions *DeleteZoneOptions)`, func() {
 			deleteZoneOptions := &contextbasedrestrictionsv1.DeleteZoneOptions{
-				ZoneID:        core.StringPtr(zoneID),
-				TransactionID: getTransactionID(),
+				ZoneID: core.StringPtr(zoneID),
+				// Using the standard X-Correlation-Id header in this case
+				XCorrelationID: getTransactionID(),
 			}
 
 			response, err := contextBasedRestrictionsService.DeleteZone(deleteZoneOptions)

--- a/contextbasedrestrictionsv1/context_based_restrictions_v1_test.go
+++ b/contextbasedrestrictionsv1/context_based_restrictions_v1_test.go
@@ -171,6 +171,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(createZonePath))
 					Expect(req.Method).To(Equal("POST"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -198,6 +200,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				createZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				createZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				createZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				createZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -245,6 +248,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -277,6 +282,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				createZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				createZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				createZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				createZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -330,6 +336,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -364,6 +372,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				createZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				createZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				createZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				createZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -394,6 +403,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				createZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				createZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				createZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				createZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -438,6 +448,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				createZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				createZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				createZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				createZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -464,6 +475,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(listZonesPath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -485,6 +498,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListZonesOptions model
 				listZonesOptionsModel := new(contextbasedrestrictionsv1.ListZonesOptions)
 				listZonesOptionsModel.AccountID = core.StringPtr("testString")
+				listZonesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listZonesOptionsModel.TransactionID = core.StringPtr("testString")
 				listZonesOptionsModel.Name = core.StringPtr("testString")
 				listZonesOptionsModel.Sort = core.StringPtr("testString")
@@ -518,6 +532,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listZonesPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -544,6 +560,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListZonesOptions model
 				listZonesOptionsModel := new(contextbasedrestrictionsv1.ListZonesOptions)
 				listZonesOptionsModel.AccountID = core.StringPtr("testString")
+				listZonesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listZonesOptionsModel.TransactionID = core.StringPtr("testString")
 				listZonesOptionsModel.Name = core.StringPtr("testString")
 				listZonesOptionsModel.Sort = core.StringPtr("testString")
@@ -583,6 +600,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listZonesPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -611,6 +630,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListZonesOptions model
 				listZonesOptionsModel := new(contextbasedrestrictionsv1.ListZonesOptions)
 				listZonesOptionsModel.AccountID = core.StringPtr("testString")
+				listZonesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listZonesOptionsModel.TransactionID = core.StringPtr("testString")
 				listZonesOptionsModel.Name = core.StringPtr("testString")
 				listZonesOptionsModel.Sort = core.StringPtr("testString")
@@ -634,6 +654,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListZonesOptions model
 				listZonesOptionsModel := new(contextbasedrestrictionsv1.ListZonesOptions)
 				listZonesOptionsModel.AccountID = core.StringPtr("testString")
+				listZonesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listZonesOptionsModel.TransactionID = core.StringPtr("testString")
 				listZonesOptionsModel.Name = core.StringPtr("testString")
 				listZonesOptionsModel.Sort = core.StringPtr("testString")
@@ -678,6 +699,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListZonesOptions model
 				listZonesOptionsModel := new(contextbasedrestrictionsv1.ListZonesOptions)
 				listZonesOptionsModel.AccountID = core.StringPtr("testString")
+				listZonesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listZonesOptionsModel.TransactionID = core.StringPtr("testString")
 				listZonesOptionsModel.Name = core.StringPtr("testString")
 				listZonesOptionsModel.Sort = core.StringPtr("testString")
@@ -706,6 +728,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(getZonePath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -724,6 +748,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetZoneOptions model
 				getZoneOptionsModel := new(contextbasedrestrictionsv1.GetZoneOptions)
 				getZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				getZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				getZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -755,6 +780,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getZonePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -778,6 +805,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetZoneOptions model
 				getZoneOptionsModel := new(contextbasedrestrictionsv1.GetZoneOptions)
 				getZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				getZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				getZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -815,6 +843,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getZonePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -840,6 +870,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetZoneOptions model
 				getZoneOptionsModel := new(contextbasedrestrictionsv1.GetZoneOptions)
 				getZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				getZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				getZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -861,6 +892,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetZoneOptions model
 				getZoneOptionsModel := new(contextbasedrestrictionsv1.GetZoneOptions)
 				getZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				getZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				getZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -903,6 +935,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetZoneOptions model
 				getZoneOptionsModel := new(contextbasedrestrictionsv1.GetZoneOptions)
 				getZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				getZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				getZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -931,6 +964,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.Method).To(Equal("PUT"))
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -960,6 +995,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				replaceZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				replaceZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				replaceZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -1009,6 +1045,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -1043,6 +1081,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				replaceZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				replaceZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				replaceZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1098,6 +1137,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -1134,6 +1175,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				replaceZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				replaceZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				replaceZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1166,6 +1208,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				replaceZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				replaceZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				replaceZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1219,6 +1262,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.Description = core.StringPtr("this is an example of zone")
 				replaceZoneOptionsModel.Addresses = []contextbasedrestrictionsv1.AddressIntf{addressModel}
 				replaceZoneOptionsModel.Excluded = []contextbasedrestrictionsv1.AddressIntf{addressModel}
+				replaceZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1246,6 +1290,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(deleteZonePath))
 					Expect(req.Method).To(Equal("DELETE"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.WriteHeader(204)
@@ -1267,6 +1313,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the DeleteZoneOptions model
 				deleteZoneOptionsModel := new(contextbasedrestrictionsv1.DeleteZoneOptions)
 				deleteZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				deleteZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1286,6 +1333,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the DeleteZoneOptions model
 				deleteZoneOptionsModel := new(contextbasedrestrictionsv1.DeleteZoneOptions)
 				deleteZoneOptionsModel.ZoneID = core.StringPtr("testString")
+				deleteZoneOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteZoneOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteZoneOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1317,6 +1365,10 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(listAvailableServicerefTargetsPath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
+					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["type"]).To(Equal([]string{"all"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -1333,6 +1385,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := new(contextbasedrestrictionsv1.ListAvailableServicerefTargetsOptions)
+				listAvailableServicerefTargetsOptionsModel.XCorrelationID = core.StringPtr("testString")
+				listAvailableServicerefTargetsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAvailableServicerefTargetsOptionsModel.Type = core.StringPtr("all")
 				listAvailableServicerefTargetsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -1364,6 +1418,10 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listAvailableServicerefTargetsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
+					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["type"]).To(Equal([]string{"all"}))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
@@ -1385,6 +1443,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := new(contextbasedrestrictionsv1.ListAvailableServicerefTargetsOptions)
+				listAvailableServicerefTargetsOptionsModel.XCorrelationID = core.StringPtr("testString")
+				listAvailableServicerefTargetsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAvailableServicerefTargetsOptionsModel.Type = core.StringPtr("all")
 				listAvailableServicerefTargetsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1422,6 +1482,10 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listAvailableServicerefTargetsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
+					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["type"]).To(Equal([]string{"all"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
@@ -1445,6 +1509,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := new(contextbasedrestrictionsv1.ListAvailableServicerefTargetsOptions)
+				listAvailableServicerefTargetsOptionsModel.XCorrelationID = core.StringPtr("testString")
+				listAvailableServicerefTargetsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAvailableServicerefTargetsOptionsModel.Type = core.StringPtr("all")
 				listAvailableServicerefTargetsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1465,6 +1531,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := new(contextbasedrestrictionsv1.ListAvailableServicerefTargetsOptions)
+				listAvailableServicerefTargetsOptionsModel.XCorrelationID = core.StringPtr("testString")
+				listAvailableServicerefTargetsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAvailableServicerefTargetsOptionsModel.Type = core.StringPtr("all")
 				listAvailableServicerefTargetsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1499,6 +1567,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := new(contextbasedrestrictionsv1.ListAvailableServicerefTargetsOptions)
+				listAvailableServicerefTargetsOptionsModel.XCorrelationID = core.StringPtr("testString")
+				listAvailableServicerefTargetsOptionsModel.TransactionID = core.StringPtr("testString")
 				listAvailableServicerefTargetsOptionsModel.Type = core.StringPtr("all")
 				listAvailableServicerefTargetsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1525,6 +1595,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(createRulePath))
 					Expect(req.Method).To(Equal("POST"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -1571,6 +1643,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				createRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				createRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				createRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				createRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -1618,6 +1691,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -1669,6 +1744,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				createRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				createRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				createRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				createRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1722,6 +1798,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					}
 					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -1775,6 +1853,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				createRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				createRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				createRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				createRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1824,6 +1903,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				createRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				createRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				createRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				createRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -1887,6 +1967,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				createRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				createRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				createRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				createRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				createRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -1913,6 +1994,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(listRulesPath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -1940,6 +2023,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(contextbasedrestrictionsv1.ListRulesOptions)
 				listRulesOptionsModel.AccountID = core.StringPtr("testString")
+				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.TransactionID = core.StringPtr("testString")
 				listRulesOptionsModel.Region = core.StringPtr("testString")
 				listRulesOptionsModel.Resource = core.StringPtr("testString")
@@ -1979,6 +2063,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listRulesPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -2011,6 +2097,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(contextbasedrestrictionsv1.ListRulesOptions)
 				listRulesOptionsModel.AccountID = core.StringPtr("testString")
+				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.TransactionID = core.StringPtr("testString")
 				listRulesOptionsModel.Region = core.StringPtr("testString")
 				listRulesOptionsModel.Resource = core.StringPtr("testString")
@@ -2056,6 +2143,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(listRulesPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
@@ -2090,6 +2179,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(contextbasedrestrictionsv1.ListRulesOptions)
 				listRulesOptionsModel.AccountID = core.StringPtr("testString")
+				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.TransactionID = core.StringPtr("testString")
 				listRulesOptionsModel.Region = core.StringPtr("testString")
 				listRulesOptionsModel.Resource = core.StringPtr("testString")
@@ -2119,6 +2209,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(contextbasedrestrictionsv1.ListRulesOptions)
 				listRulesOptionsModel.AccountID = core.StringPtr("testString")
+				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.TransactionID = core.StringPtr("testString")
 				listRulesOptionsModel.Region = core.StringPtr("testString")
 				listRulesOptionsModel.Resource = core.StringPtr("testString")
@@ -2169,6 +2260,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the ListRulesOptions model
 				listRulesOptionsModel := new(contextbasedrestrictionsv1.ListRulesOptions)
 				listRulesOptionsModel.AccountID = core.StringPtr("testString")
+				listRulesOptionsModel.XCorrelationID = core.StringPtr("testString")
 				listRulesOptionsModel.TransactionID = core.StringPtr("testString")
 				listRulesOptionsModel.Region = core.StringPtr("testString")
 				listRulesOptionsModel.Resource = core.StringPtr("testString")
@@ -2203,6 +2295,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(getRulePath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -2221,6 +2315,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(contextbasedrestrictionsv1.GetRuleOptions)
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
+				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				getRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -2252,6 +2347,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getRulePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -2275,6 +2372,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(contextbasedrestrictionsv1.GetRuleOptions)
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
+				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				getRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2312,6 +2410,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getRulePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -2337,6 +2437,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(contextbasedrestrictionsv1.GetRuleOptions)
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
+				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				getRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2358,6 +2459,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(contextbasedrestrictionsv1.GetRuleOptions)
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
+				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				getRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -2400,6 +2502,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetRuleOptions model
 				getRuleOptionsModel := new(contextbasedrestrictionsv1.GetRuleOptions)
 				getRuleOptionsModel.RuleID = core.StringPtr("testString")
+				getRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				getRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2428,6 +2531,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.Method).To(Equal("PUT"))
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -2476,6 +2581,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				replaceRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				replaceRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				replaceRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -2525,6 +2631,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -2578,6 +2686,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				replaceRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				replaceRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				replaceRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2633,6 +2742,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 
 					Expect(req.Header["If-Match"]).ToNot(BeNil())
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -2688,6 +2799,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				replaceRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				replaceRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				replaceRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2739,6 +2851,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				replaceRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				replaceRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				replaceRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -2811,6 +2924,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.Description = core.StringPtr("this is an example of rule")
 				replaceRuleOptionsModel.Contexts = []contextbasedrestrictionsv1.RuleContext{*ruleContextModel}
 				replaceRuleOptionsModel.Resources = []contextbasedrestrictionsv1.Resource{*resourceModel}
+				replaceRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				replaceRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				replaceRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2838,6 +2952,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(deleteRulePath))
 					Expect(req.Method).To(Equal("DELETE"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.WriteHeader(204)
@@ -2859,6 +2975,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the DeleteRuleOptions model
 				deleteRuleOptionsModel := new(contextbasedrestrictionsv1.DeleteRuleOptions)
 				deleteRuleOptionsModel.RuleID = core.StringPtr("testString")
+				deleteRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -2878,6 +2995,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the DeleteRuleOptions model
 				deleteRuleOptionsModel := new(contextbasedrestrictionsv1.DeleteRuleOptions)
 				deleteRuleOptionsModel.RuleID = core.StringPtr("testString")
+				deleteRuleOptionsModel.XCorrelationID = core.StringPtr("testString")
 				deleteRuleOptionsModel.TransactionID = core.StringPtr("testString")
 				deleteRuleOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -2909,6 +3027,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsPath))
 					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
@@ -2927,6 +3047,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
 				getAccountSettingsOptionsModel := new(contextbasedrestrictionsv1.GetAccountSettingsOptions)
 				getAccountSettingsOptionsModel.AccountID = core.StringPtr("testString")
+				getAccountSettingsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.TransactionID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -2958,6 +3079,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Sleep a short time to support a timeout test
@@ -2981,6 +3104,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
 				getAccountSettingsOptionsModel := new(contextbasedrestrictionsv1.GetAccountSettingsOptions)
 				getAccountSettingsOptionsModel.AccountID = core.StringPtr("testString")
+				getAccountSettingsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.TransactionID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3018,6 +3142,8 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsPath))
 					Expect(req.Method).To(Equal("GET"))
 
+					Expect(req.Header["X-Correlation-Id"]).ToNot(BeNil())
+					Expect(req.Header["X-Correlation-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					Expect(req.Header["Transaction-Id"]).ToNot(BeNil())
 					Expect(req.Header["Transaction-Id"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					// Set mock response
@@ -3043,6 +3169,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
 				getAccountSettingsOptionsModel := new(contextbasedrestrictionsv1.GetAccountSettingsOptions)
 				getAccountSettingsOptionsModel.AccountID = core.StringPtr("testString")
+				getAccountSettingsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.TransactionID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3064,6 +3191,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
 				getAccountSettingsOptionsModel := new(contextbasedrestrictionsv1.GetAccountSettingsOptions)
 				getAccountSettingsOptionsModel.AccountID = core.StringPtr("testString")
+				getAccountSettingsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.TransactionID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -3106,6 +3234,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
 				getAccountSettingsOptionsModel := new(contextbasedrestrictionsv1.GetAccountSettingsOptions)
 				getAccountSettingsOptionsModel.AccountID = core.StringPtr("testString")
+				getAccountSettingsOptionsModel.XCorrelationID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.TransactionID = core.StringPtr("testString")
 				getAccountSettingsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -3176,12 +3305,14 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createRuleOptionsModel.SetDescription("this is an example of rule")
 				createRuleOptionsModel.SetContexts([]contextbasedrestrictionsv1.RuleContext{*ruleContextModel})
 				createRuleOptionsModel.SetResources([]contextbasedrestrictionsv1.Resource{*resourceModel})
+				createRuleOptionsModel.SetXCorrelationID("testString")
 				createRuleOptionsModel.SetTransactionID("testString")
 				createRuleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createRuleOptionsModel).ToNot(BeNil())
 				Expect(createRuleOptionsModel.Description).To(Equal(core.StringPtr("this is an example of rule")))
 				Expect(createRuleOptionsModel.Contexts).To(Equal([]contextbasedrestrictionsv1.RuleContext{*ruleContextModel}))
 				Expect(createRuleOptionsModel.Resources).To(Equal([]contextbasedrestrictionsv1.Resource{*resourceModel}))
+				Expect(createRuleOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(createRuleOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(createRuleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3201,6 +3332,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				createZoneOptionsModel.SetDescription("this is an example of zone")
 				createZoneOptionsModel.SetAddresses([]contextbasedrestrictionsv1.AddressIntf{addressModel})
 				createZoneOptionsModel.SetExcluded([]contextbasedrestrictionsv1.AddressIntf{addressModel})
+				createZoneOptionsModel.SetXCorrelationID("testString")
 				createZoneOptionsModel.SetTransactionID("testString")
 				createZoneOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createZoneOptionsModel).ToNot(BeNil())
@@ -3209,6 +3341,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				Expect(createZoneOptionsModel.Description).To(Equal(core.StringPtr("this is an example of zone")))
 				Expect(createZoneOptionsModel.Addresses).To(Equal([]contextbasedrestrictionsv1.AddressIntf{addressModel}))
 				Expect(createZoneOptionsModel.Excluded).To(Equal([]contextbasedrestrictionsv1.AddressIntf{addressModel}))
+				Expect(createZoneOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(createZoneOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(createZoneOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3217,10 +3350,12 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				ruleID := "testString"
 				deleteRuleOptionsModel := contextBasedRestrictionsService.NewDeleteRuleOptions(ruleID)
 				deleteRuleOptionsModel.SetRuleID("testString")
+				deleteRuleOptionsModel.SetXCorrelationID("testString")
 				deleteRuleOptionsModel.SetTransactionID("testString")
 				deleteRuleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteRuleOptionsModel).ToNot(BeNil())
 				Expect(deleteRuleOptionsModel.RuleID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteRuleOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteRuleOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteRuleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3229,10 +3364,12 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				zoneID := "testString"
 				deleteZoneOptionsModel := contextBasedRestrictionsService.NewDeleteZoneOptions(zoneID)
 				deleteZoneOptionsModel.SetZoneID("testString")
+				deleteZoneOptionsModel.SetXCorrelationID("testString")
 				deleteZoneOptionsModel.SetTransactionID("testString")
 				deleteZoneOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(deleteZoneOptionsModel).ToNot(BeNil())
 				Expect(deleteZoneOptionsModel.ZoneID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteZoneOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteZoneOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteZoneOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3241,10 +3378,12 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				accountID := "testString"
 				getAccountSettingsOptionsModel := contextBasedRestrictionsService.NewGetAccountSettingsOptions(accountID)
 				getAccountSettingsOptionsModel.SetAccountID("testString")
+				getAccountSettingsOptionsModel.SetXCorrelationID("testString")
 				getAccountSettingsOptionsModel.SetTransactionID("testString")
 				getAccountSettingsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getAccountSettingsOptionsModel).ToNot(BeNil())
 				Expect(getAccountSettingsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(getAccountSettingsOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(getAccountSettingsOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(getAccountSettingsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3253,10 +3392,12 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				ruleID := "testString"
 				getRuleOptionsModel := contextBasedRestrictionsService.NewGetRuleOptions(ruleID)
 				getRuleOptionsModel.SetRuleID("testString")
+				getRuleOptionsModel.SetXCorrelationID("testString")
 				getRuleOptionsModel.SetTransactionID("testString")
 				getRuleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getRuleOptionsModel).ToNot(BeNil())
 				Expect(getRuleOptionsModel.RuleID).To(Equal(core.StringPtr("testString")))
+				Expect(getRuleOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(getRuleOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(getRuleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3265,19 +3406,25 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				zoneID := "testString"
 				getZoneOptionsModel := contextBasedRestrictionsService.NewGetZoneOptions(zoneID)
 				getZoneOptionsModel.SetZoneID("testString")
+				getZoneOptionsModel.SetXCorrelationID("testString")
 				getZoneOptionsModel.SetTransactionID("testString")
 				getZoneOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getZoneOptionsModel).ToNot(BeNil())
 				Expect(getZoneOptionsModel.ZoneID).To(Equal(core.StringPtr("testString")))
+				Expect(getZoneOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(getZoneOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(getZoneOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewListAvailableServicerefTargetsOptions successfully`, func() {
 				// Construct an instance of the ListAvailableServicerefTargetsOptions model
 				listAvailableServicerefTargetsOptionsModel := contextBasedRestrictionsService.NewListAvailableServicerefTargetsOptions()
+				listAvailableServicerefTargetsOptionsModel.SetXCorrelationID("testString")
+				listAvailableServicerefTargetsOptionsModel.SetTransactionID("testString")
 				listAvailableServicerefTargetsOptionsModel.SetType("all")
 				listAvailableServicerefTargetsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listAvailableServicerefTargetsOptionsModel).ToNot(BeNil())
+				Expect(listAvailableServicerefTargetsOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
+				Expect(listAvailableServicerefTargetsOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(listAvailableServicerefTargetsOptionsModel.Type).To(Equal(core.StringPtr("all")))
 				Expect(listAvailableServicerefTargetsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3286,6 +3433,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				accountID := "testString"
 				listRulesOptionsModel := contextBasedRestrictionsService.NewListRulesOptions(accountID)
 				listRulesOptionsModel.SetAccountID("testString")
+				listRulesOptionsModel.SetXCorrelationID("testString")
 				listRulesOptionsModel.SetTransactionID("testString")
 				listRulesOptionsModel.SetRegion("testString")
 				listRulesOptionsModel.SetResource("testString")
@@ -3298,6 +3446,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				listRulesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listRulesOptionsModel).ToNot(BeNil())
 				Expect(listRulesOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listRulesOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(listRulesOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(listRulesOptionsModel.Region).To(Equal(core.StringPtr("testString")))
 				Expect(listRulesOptionsModel.Resource).To(Equal(core.StringPtr("testString")))
@@ -3314,12 +3463,14 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				accountID := "testString"
 				listZonesOptionsModel := contextBasedRestrictionsService.NewListZonesOptions(accountID)
 				listZonesOptionsModel.SetAccountID("testString")
+				listZonesOptionsModel.SetXCorrelationID("testString")
 				listZonesOptionsModel.SetTransactionID("testString")
 				listZonesOptionsModel.SetName("testString")
 				listZonesOptionsModel.SetSort("testString")
 				listZonesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listZonesOptionsModel).ToNot(BeNil())
 				Expect(listZonesOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listZonesOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(listZonesOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(listZonesOptionsModel.Name).To(Equal(core.StringPtr("testString")))
 				Expect(listZonesOptionsModel.Sort).To(Equal(core.StringPtr("testString")))
@@ -3377,6 +3528,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceRuleOptionsModel.SetDescription("this is an example of rule")
 				replaceRuleOptionsModel.SetContexts([]contextbasedrestrictionsv1.RuleContext{*ruleContextModel})
 				replaceRuleOptionsModel.SetResources([]contextbasedrestrictionsv1.Resource{*resourceModel})
+				replaceRuleOptionsModel.SetXCorrelationID("testString")
 				replaceRuleOptionsModel.SetTransactionID("testString")
 				replaceRuleOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceRuleOptionsModel).ToNot(BeNil())
@@ -3385,6 +3537,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				Expect(replaceRuleOptionsModel.Description).To(Equal(core.StringPtr("this is an example of rule")))
 				Expect(replaceRuleOptionsModel.Contexts).To(Equal([]contextbasedrestrictionsv1.RuleContext{*ruleContextModel}))
 				Expect(replaceRuleOptionsModel.Resources).To(Equal([]contextbasedrestrictionsv1.Resource{*resourceModel}))
+				Expect(replaceRuleOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceRuleOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceRuleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3408,6 +3561,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				replaceZoneOptionsModel.SetDescription("this is an example of zone")
 				replaceZoneOptionsModel.SetAddresses([]contextbasedrestrictionsv1.AddressIntf{addressModel})
 				replaceZoneOptionsModel.SetExcluded([]contextbasedrestrictionsv1.AddressIntf{addressModel})
+				replaceZoneOptionsModel.SetXCorrelationID("testString")
 				replaceZoneOptionsModel.SetTransactionID("testString")
 				replaceZoneOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceZoneOptionsModel).ToNot(BeNil())
@@ -3418,6 +3572,7 @@ var _ = Describe(`ContextBasedRestrictionsV1`, func() {
 				Expect(replaceZoneOptionsModel.Description).To(Equal(core.StringPtr("this is an example of zone")))
 				Expect(replaceZoneOptionsModel.Addresses).To(Equal([]contextbasedrestrictionsv1.AddressIntf{addressModel}))
 				Expect(replaceZoneOptionsModel.Excluded).To(Equal([]contextbasedrestrictionsv1.AddressIntf{addressModel}))
+				Expect(replaceZoneOptionsModel.XCorrelationID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceZoneOptionsModel.TransactionID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceZoneOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})


### PR DESCRIPTION
Added support for the `X-Correlation-Id` header

## PR summary
- Added support for passing the standard `X-Correlation-Id` header in each request
- Updated some swagger properties summaries and descriptions


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
This enhancement adds support for passing the standard `X-Correlation-Id` header in each request. This is an optional header and it does not break backward compatibility. 

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No