### PR TITLE
fix: bump go core to v5.9.1

### DIFF
--- a/globalsearchv2/global_search_v2_integration_test.go
+++ b/globalsearchv2/global_search_v2_integration_test.go
@@ -20,6 +20,7 @@ package globalsearchv2_test
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/IBM/go-sdk-core/v5/core"
@@ -91,6 +92,9 @@ var _ = Describe(`GlobalSearchV2 Integration Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(globalSearchService).ToNot(BeNil())
 			Expect(globalSearchService.Service.Options.URL).To(Equal(serviceURL))
+
+			goLogger := log.New(GinkgoWriter, "", log.LstdFlags)
+			core.SetLogger(core.NewLogger(core.LevelDebug, goLogger, goLogger))
 		})
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/platform-services-go-sdk
 go 1.14
 
 require (
-	github.com/IBM/go-sdk-core/v5 v5.8.2
+	github.com/IBM/go-sdk-core/v5 v5.9.1
 	github.com/go-openapi/strfmt v0.21.1
 	github.com/google/uuid v1.3.0
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/IBM/go-sdk-core/v5 v5.8.2 h1:hbT9jU5o2Gxv0CmPHK8Z1i6CpBVHcVuEajDoXNLXQqU=
-github.com/IBM/go-sdk-core/v5 v5.8.2/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
+github.com/IBM/go-sdk-core/v5 v5.9.1 h1:06pXbD9Rgmqqe2HA5YAeQbB4eYRRFgIoOT+Kh3cp1zo=
+github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=


### PR DESCRIPTION
## PR summary
This PR bumps the go core version to 5.9.1 (current latest).

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->