### PR TITLE
feat(IAM Identity): add support for inactivity reports

### DIFF
--- a/iamidentityv1/iam_identity_v1.go
+++ b/iamidentityv1/iam_identity_v1.go
@@ -43,7 +43,7 @@ type IamIdentityV1 struct {
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://iam.test.cloud.ibm.com"
+const DefaultServiceURL = "https://iam.cloud.ibm.com"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "iam_identity"

--- a/iamidentityv1/iam_identity_v1.go
+++ b/iamidentityv1/iam_identity_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.37.0-a85661cd-20210802-190136
+ * IBM OpenAPI SDK Code Generator Version: 3.46.1-a5569134-20220316-164819
  */
 
 // Package iamidentityv1 : Operations and models for the IamIdentityV1 service
@@ -37,13 +37,13 @@ import (
 // IamIdentityV1 : The IAM Identity Service API allows for the management of Account Settings and Identities (Service
 // IDs, ApiKeys).
 //
-// Version: 1.0.0
+// API Version: 1.0.0
 type IamIdentityV1 struct {
 	Service *core.BaseService
 }
 
 // DefaultServiceURL is the default URL to make service requests to.
-const DefaultServiceURL = "https://iam.cloud.ibm.com"
+const DefaultServiceURL = "https://iam.test.cloud.ibm.com"
 
 // DefaultServiceName is the default key used to find external configuration information.
 const DefaultServiceName = "iam_identity"
@@ -434,6 +434,9 @@ func (iamIdentity *IamIdentityV1) GetAPIKeyWithContext(ctx context.Context, getA
 	if getAPIKeyOptions.IncludeHistory != nil {
 		builder.AddQuery("include_history", fmt.Sprint(*getAPIKeyOptions.IncludeHistory))
 	}
+	if getAPIKeyOptions.IncludeActivity != nil {
+		builder.AddQuery("include_activity", fmt.Sprint(*getAPIKeyOptions.IncludeActivity))
+	}
 
 	request, err := builder.Build()
 	if err != nil {
@@ -687,7 +690,7 @@ func (iamIdentity *IamIdentityV1) UnlockAPIKeyWithContext(ctx context.Context, u
 // ListServiceIds : List service IDs
 // Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
 // that are bound to an entity they have access to. Note: apikey details are only included in the response when
-// creating a Service ID with an apikey.
+// creating a Service ID with an api key.
 func (iamIdentity *IamIdentityV1) ListServiceIds(listServiceIdsOptions *ListServiceIdsOptions) (result *ServiceIDList, response *core.DetailedResponse, err error) {
 	return iamIdentity.ListServiceIdsWithContext(context.Background(), listServiceIdsOptions)
 }
@@ -845,7 +848,7 @@ func (iamIdentity *IamIdentityV1) CreateServiceIDWithContext(ctx context.Context
 // GetServiceID : Get details of a service ID
 // Returns the details of a service ID. Users can manage user API keys for themself, or service ID API keys for service
 // IDs that are bound to an entity they have access to. Note: apikey details are only included in the response when
-// creating a Service ID with an apikey.
+// creating a Service ID with an api key.
 func (iamIdentity *IamIdentityV1) GetServiceID(getServiceIDOptions *GetServiceIDOptions) (result *ServiceID, response *core.DetailedResponse, err error) {
 	return iamIdentity.GetServiceIDWithContext(context.Background(), getServiceIDOptions)
 }
@@ -885,6 +888,9 @@ func (iamIdentity *IamIdentityV1) GetServiceIDWithContext(ctx context.Context, g
 
 	if getServiceIDOptions.IncludeHistory != nil {
 		builder.AddQuery("include_history", fmt.Sprint(*getServiceIDOptions.IncludeHistory))
+	}
+	if getServiceIDOptions.IncludeActivity != nil {
+		builder.AddQuery("include_activity", fmt.Sprint(*getServiceIDOptions.IncludeActivity))
 	}
 
 	request, err := builder.Build()
@@ -1330,6 +1336,10 @@ func (iamIdentity *IamIdentityV1) GetProfileWithContext(ctx context.Context, get
 		builder.AddHeader(headerName, headerValue)
 	}
 	builder.AddHeader("Accept", "application/json")
+
+	if getProfileOptions.IncludeActivity != nil {
+		builder.AddQuery("include_activity", fmt.Sprint(*getProfileOptions.IncludeActivity))
+	}
 
 	request, err := builder.Build()
 	if err != nil {
@@ -2232,6 +2242,134 @@ func (iamIdentity *IamIdentityV1) UpdateAccountSettingsWithContext(ctx context.C
 	return
 }
 
+// CreateReport : Trigger activity report across on account scope
+// Trigger activity report across on account scope for a given accountid.
+func (iamIdentity *IamIdentityV1) CreateReport(createReportOptions *CreateReportOptions) (result *ReportReference, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateReportWithContext(context.Background(), createReportOptions)
+}
+
+// CreateReportWithContext is an alternate form of the CreateReport method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateReportWithContext(ctx context.Context, createReportOptions *CreateReportOptions) (result *ReportReference, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createReportOptions, "createReportOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createReportOptions, "createReportOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"account-id": *createReportOptions.AccountID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/activity/accounts/{account-id}/report`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createReportOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateReport")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if createReportOptions.Type != nil {
+		builder.AddQuery("type", fmt.Sprint(*createReportOptions.Type))
+	}
+	if createReportOptions.Duration != nil {
+		builder.AddQuery("duration", fmt.Sprint(*createReportOptions.Duration))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalReportReference)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetReport : Get activity report across on account scope
+// Get activity report across on account scope for a given accountid.
+func (iamIdentity *IamIdentityV1) GetReport(getReportOptions *GetReportOptions) (result *Report, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetReportWithContext(context.Background(), getReportOptions)
+}
+
+// GetReportWithContext is an alternate form of the GetReport method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetReportWithContext(ctx context.Context, getReportOptions *GetReportOptions) (result *Report, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getReportOptions, "getReportOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getReportOptions, "getReportOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"account-id": *getReportOptions.AccountID,
+		"reference": *getReportOptions.Reference,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/activity/accounts/{account-id}/report/{reference}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getReportOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetReport")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalReport)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
 // AccountSettingsResponse : Response body format for Account Settings REST requests.
 type AccountSettingsResponse struct {
 	// Context with key properties for problem determination.
@@ -2376,6 +2514,30 @@ func UnmarshalAccountSettingsResponse(m map[string]json.RawMessage, result inter
 	return
 }
 
+// Activity : Activity struct
+type Activity struct {
+	// Time when the entity was last authenticated.
+	LastAuthn *string `json:"last_authn,omitempty"`
+
+	// Authentication count, number of times the entity was authenticated.
+	AuthnCount *int64 `json:"authn_count" validate:"required"`
+}
+
+// UnmarshalActivity unmarshals an instance of Activity from the specified map of raw messages.
+func UnmarshalActivity(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Activity)
+	err = core.UnmarshalPrimitive(m, "last_authn", &obj.LastAuthn)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "authn_count", &obj.AuthnCount)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // APIKey : Response body format for API key V1 REST requests.
 type APIKey struct {
 	// Context with key properties for problem determination.
@@ -2426,6 +2588,8 @@ type APIKey struct {
 
 	// History of the API key.
 	History []EnityHistoryRecord `json:"history,omitempty"`
+
+	Activity *Activity `json:"activity,omitempty"`
 }
 
 // UnmarshalAPIKey unmarshals an instance of APIKey from the specified map of raw messages.
@@ -2484,6 +2648,10 @@ func UnmarshalAPIKey(m map[string]json.RawMessage, result interface{}) (err erro
 		return
 	}
 	err = core.UnmarshalModel(m, "history", &obj.History, UnmarshalEnityHistoryRecord)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "activity", &obj.Activity, UnmarshalActivity)
 	if err != nil {
 		return
 	}
@@ -2634,7 +2802,7 @@ type CreateAPIKeyOptions struct {
 	StoreValue *bool `json:"store_value,omitempty"`
 
 	// Indicates if the API key is locked for further write operations. False by default.
-	EntityLock *string `json:"-"`
+	EntityLock *string `json:"Entity-Lock,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -2699,7 +2867,7 @@ func (options *CreateAPIKeyOptions) SetHeaders(param map[string]string) *CreateA
 // CreateClaimRuleOptions : The CreateClaimRule options.
 type CreateClaimRuleOptions struct {
 	// ID of the trusted profile to create a claim rule.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// Type of the calim rule, either 'Profile-SAML' or 'Profile-CR'.
 	Type *string `json:"type" validate:"required"`
@@ -2794,7 +2962,7 @@ func (options *CreateClaimRuleOptions) SetHeaders(param map[string]string) *Crea
 // CreateLinkOptions : The CreateLink options.
 type CreateLinkOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// The compute resource type. Valid values are VSI, IKS_SA, ROKS_SA.
 	CrType *string `json:"cr_type" validate:"required"`
@@ -2938,6 +3106,53 @@ func (options *CreateProfileOptions) SetHeaders(param map[string]string) *Create
 	return options
 }
 
+// CreateReportOptions : The CreateReport options.
+type CreateReportOptions struct {
+	// ID of the account.
+	AccountID *string `json:"account-id" validate:"required,ne="`
+
+	// Optional report type, supported value is 'inactive' - List all identities that have not authenticated within the
+	// time indicated by duration.
+	Type *string `json:"type,omitempty"`
+
+	// Optional duration of the report, supported unit of duration is hours.
+	Duration *string `json:"duration,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateReportOptions : Instantiate CreateReportOptions
+func (*IamIdentityV1) NewCreateReportOptions(accountID string) *CreateReportOptions {
+	return &CreateReportOptions{
+		AccountID: core.StringPtr(accountID),
+	}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *CreateReportOptions) SetAccountID(accountID string) *CreateReportOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetType : Allow user to set Type
+func (_options *CreateReportOptions) SetType(typeVar string) *CreateReportOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetDuration : Allow user to set Duration
+func (_options *CreateReportOptions) SetDuration(duration string) *CreateReportOptions {
+	_options.Duration = core.StringPtr(duration)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateReportOptions) SetHeaders(param map[string]string) *CreateReportOptions {
+	options.Headers = param
+	return options
+}
+
 // CreateServiceIDOptions : The CreateServiceID options.
 type CreateServiceIDOptions struct {
 	// ID of the account the service ID belongs to.
@@ -2958,7 +3173,7 @@ type CreateServiceIDOptions struct {
 	Apikey *APIKeyInsideCreateServiceIDRequest `json:"apikey,omitempty"`
 
 	// Indicates if the service ID is locked for further write operations. False by default.
-	EntityLock *string `json:"-"`
+	EntityLock *string `json:"Entity-Lock,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3017,7 +3232,7 @@ func (options *CreateServiceIDOptions) SetHeaders(param map[string]string) *Crea
 // DeleteAPIKeyOptions : The DeleteAPIKey options.
 type DeleteAPIKeyOptions struct {
 	// Unique ID of the API key.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3045,10 +3260,10 @@ func (options *DeleteAPIKeyOptions) SetHeaders(param map[string]string) *DeleteA
 // DeleteClaimRuleOptions : The DeleteClaimRule options.
 type DeleteClaimRuleOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// ID of the claim rule to delete.
-	RuleID *string `json:"-" validate:"required,ne="`
+	RuleID *string `json:"rule-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3083,10 +3298,10 @@ func (options *DeleteClaimRuleOptions) SetHeaders(param map[string]string) *Dele
 // DeleteLinkOptions : The DeleteLink options.
 type DeleteLinkOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// ID of the link.
-	LinkID *string `json:"-" validate:"required,ne="`
+	LinkID *string `json:"link-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3121,7 +3336,7 @@ func (options *DeleteLinkOptions) SetHeaders(param map[string]string) *DeleteLin
 // DeleteProfileOptions : The DeleteProfile options.
 type DeleteProfileOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3149,7 +3364,7 @@ func (options *DeleteProfileOptions) SetHeaders(param map[string]string) *Delete
 // DeleteServiceIDOptions : The DeleteServiceID options.
 type DeleteServiceIDOptions struct {
 	// Unique ID of the service ID.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3226,13 +3441,44 @@ func UnmarshalEnityHistoryRecord(m map[string]json.RawMessage, result interface{
 	return
 }
 
+// EntityActivity : EntityActivity struct
+type EntityActivity struct {
+	// Unique id of the entity.
+	ID *string `json:"id" validate:"required"`
+
+	// Name provided during creation of the entity.
+	Name *string `json:"name,omitempty"`
+
+	// Time when the entity was last authenticated.
+	LastAuthn *string `json:"last_authn,omitempty"`
+}
+
+// UnmarshalEntityActivity unmarshals an instance of EntityActivity from the specified map of raw messages.
+func UnmarshalEntityActivity(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(EntityActivity)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_authn", &obj.LastAuthn)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // GetAccountSettingsOptions : The GetAccountSettings options.
 type GetAccountSettingsOptions struct {
 	// Unique ID of the account.
-	AccountID *string `json:"-" validate:"required,ne="`
+	AccountID *string `json:"account_id" validate:"required,ne="`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3266,10 +3512,14 @@ func (options *GetAccountSettingsOptions) SetHeaders(param map[string]string) *G
 // GetAPIKeyOptions : The GetAPIKey options.
 type GetAPIKeyOptions struct {
 	// Unique ID of the API key.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation, so
+	// please only request this when needed.
+	IncludeActivity *bool `json:"include_activity,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3294,6 +3544,12 @@ func (_options *GetAPIKeyOptions) SetIncludeHistory(includeHistory bool) *GetAPI
 	return _options
 }
 
+// SetIncludeActivity : Allow user to set IncludeActivity
+func (_options *GetAPIKeyOptions) SetIncludeActivity(includeActivity bool) *GetAPIKeyOptions {
+	_options.IncludeActivity = core.BoolPtr(includeActivity)
+	return _options
+}
+
 // SetHeaders : Allow user to set Headers
 func (options *GetAPIKeyOptions) SetHeaders(param map[string]string) *GetAPIKeyOptions {
 	options.Headers = param
@@ -3303,10 +3559,10 @@ func (options *GetAPIKeyOptions) SetHeaders(param map[string]string) *GetAPIKeyO
 // GetAPIKeysDetailsOptions : The GetAPIKeysDetails options.
 type GetAPIKeysDetailsOptions struct {
 	// API key value.
-	IamAPIKey *string `json:"-"`
+	IamAPIKey *string `json:"IAM-ApiKey,omitempty"`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3338,10 +3594,10 @@ func (options *GetAPIKeysDetailsOptions) SetHeaders(param map[string]string) *Ge
 // GetClaimRuleOptions : The GetClaimRule options.
 type GetClaimRuleOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// ID of the claim rule to get.
-	RuleID *string `json:"-" validate:"required,ne="`
+	RuleID *string `json:"rule-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3376,10 +3632,10 @@ func (options *GetClaimRuleOptions) SetHeaders(param map[string]string) *GetClai
 // GetLinkOptions : The GetLink options.
 type GetLinkOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// ID of the link.
-	LinkID *string `json:"-" validate:"required,ne="`
+	LinkID *string `json:"link-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3414,7 +3670,11 @@ func (options *GetLinkOptions) SetHeaders(param map[string]string) *GetLinkOptio
 // GetProfileOptions : The GetProfile options.
 type GetProfileOptions struct {
 	// ID of the trusted profile to get.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
+
+	// Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation, so
+	// please only request this when needed.
+	IncludeActivity *bool `json:"include_activity,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3433,8 +3693,52 @@ func (_options *GetProfileOptions) SetProfileID(profileID string) *GetProfileOpt
 	return _options
 }
 
+// SetIncludeActivity : Allow user to set IncludeActivity
+func (_options *GetProfileOptions) SetIncludeActivity(includeActivity bool) *GetProfileOptions {
+	_options.IncludeActivity = core.BoolPtr(includeActivity)
+	return _options
+}
+
 // SetHeaders : Allow user to set Headers
 func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfileOptions {
+	options.Headers = param
+	return options
+}
+
+// GetReportOptions : The GetReport options.
+type GetReportOptions struct {
+	// ID of the account.
+	AccountID *string `json:"account-id" validate:"required,ne="`
+
+	// Reference for the report to be generated, You can use 'latest' to get the latest report for the given account.
+	Reference *string `json:"reference" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetReportOptions : Instantiate GetReportOptions
+func (*IamIdentityV1) NewGetReportOptions(accountID string, reference string) *GetReportOptions {
+	return &GetReportOptions{
+		AccountID: core.StringPtr(accountID),
+		Reference: core.StringPtr(reference),
+	}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *GetReportOptions) SetAccountID(accountID string) *GetReportOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetReference : Allow user to set Reference
+func (_options *GetReportOptions) SetReference(reference string) *GetReportOptions {
+	_options.Reference = core.StringPtr(reference)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetReportOptions) SetHeaders(param map[string]string) *GetReportOptions {
 	options.Headers = param
 	return options
 }
@@ -3442,10 +3746,14 @@ func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfil
 // GetServiceIDOptions : The GetServiceID options.
 type GetServiceIDOptions struct {
 	// Unique ID of the service ID.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Defines if the entity's activity is included in the response. Retrieving activity data is an expensive operation, so
+	// please only request this when needed.
+	IncludeActivity *bool `json:"include_activity,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3470,6 +3778,12 @@ func (_options *GetServiceIDOptions) SetIncludeHistory(includeHistory bool) *Get
 	return _options
 }
 
+// SetIncludeActivity : Allow user to set IncludeActivity
+func (_options *GetServiceIDOptions) SetIncludeActivity(includeActivity bool) *GetServiceIDOptions {
+	_options.IncludeActivity = core.BoolPtr(includeActivity)
+	return _options
+}
+
 // SetHeaders : Allow user to set Headers
 func (options *GetServiceIDOptions) SetHeaders(param map[string]string) *GetServiceIDOptions {
 	options.Headers = param
@@ -3478,50 +3792,50 @@ func (options *GetServiceIDOptions) SetHeaders(param map[string]string) *GetServ
 
 // ListAPIKeysOptions : The ListAPIKeys options.
 type ListAPIKeysOptions struct {
-	// Account ID of the API keys(s) to query. If a service IAM ID is specified in iam_id then account_id must match the
+	// Account ID of the API keys to query. If a service IAM ID is specified in iam_id then account_id must match the
 	// account of the IAM ID. If a user IAM ID is specified in iam_id then then account_id must match the account of the
 	// Authorization token.
-	AccountID *string `json:"-"`
+	AccountID *string `json:"account_id,omitempty"`
 
-	// IAM ID of the API key(s) to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id must
+	// IAM ID of the API keys to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id must
 	// match the Authorization token.
-	IamID *string `json:"-"`
+	IamID *string `json:"iam_id,omitempty"`
 
 	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
-	Pagesize *int64 `json:"-"`
+	Pagesize *int64 `json:"pagesize,omitempty"`
 
 	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
-	Pagetoken *string `json:"-"`
+	Pagetoken *string `json:"pagetoken,omitempty"`
 
-	// Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
-	Scope *string `json:"-"`
+	// Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
+	Scope *string `json:"scope,omitempty"`
 
-	// Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
-	Type *string `json:"-"`
+	// Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
+	Type *string `json:"type,omitempty"`
 
 	// Optional sort property, valid values are name, description, created_at and created_by. If specified, the items are
 	// sorted by the value of this property.
-	Sort *string `json:"-"`
+	Sort *string `json:"sort,omitempty"`
 
 	// Optional sort order, valid values are asc and desc. Default: asc.
-	Order *string `json:"-"`
+	Order *string `json:"order,omitempty"`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
 
 // Constants associated with the ListAPIKeysOptions.Scope property.
-// Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
+// Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
 const (
 	ListAPIKeysOptionsScopeAccountConst = "account"
 	ListAPIKeysOptionsScopeEntityConst = "entity"
 )
 
 // Constants associated with the ListAPIKeysOptions.Type property.
-// Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
+// Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
 const (
 	ListAPIKeysOptionsTypeServiceidConst = "serviceid"
 	ListAPIKeysOptionsTypeUserConst = "user"
@@ -3602,7 +3916,7 @@ func (options *ListAPIKeysOptions) SetHeaders(param map[string]string) *ListAPIK
 // ListClaimRulesOptions : The ListClaimRules options.
 type ListClaimRulesOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3630,7 +3944,7 @@ func (options *ListClaimRulesOptions) SetHeaders(param map[string]string) *ListC
 // ListLinksOptions : The ListLinks options.
 type ListLinksOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3658,26 +3972,26 @@ func (options *ListLinksOptions) SetHeaders(param map[string]string) *ListLinksO
 // ListProfilesOptions : The ListProfiles options.
 type ListProfilesOptions struct {
 	// Account ID to query for trusted profiles.
-	AccountID *string `json:"-" validate:"required"`
+	AccountID *string `json:"account_id" validate:"required"`
 
 	// Name of the trusted profile to query.
-	Name *string `json:"-"`
+	Name *string `json:"name,omitempty"`
 
 	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
-	Pagesize *int64 `json:"-"`
+	Pagesize *int64 `json:"pagesize,omitempty"`
 
 	// Optional sort property, valid values are name, description, created_at and modified_at. If specified, the items are
 	// sorted by the value of this property.
-	Sort *string `json:"-"`
+	Sort *string `json:"sort,omitempty"`
 
 	// Optional sort order, valid values are asc and desc. Default: asc.
-	Order *string `json:"-"`
+	Order *string `json:"order,omitempty"`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
 
 	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
-	Pagetoken *string `json:"-"`
+	Pagetoken *string `json:"pagetoken,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3748,26 +4062,26 @@ func (options *ListProfilesOptions) SetHeaders(param map[string]string) *ListPro
 // ListServiceIdsOptions : The ListServiceIds options.
 type ListServiceIdsOptions struct {
 	// Account ID of the service ID(s) to query. This parameter is required (unless using a pagetoken).
-	AccountID *string `json:"-"`
+	AccountID *string `json:"account_id,omitempty"`
 
 	// Name of the service ID(s) to query. Optional.20 items per page. Valid range is 1 to 100.
-	Name *string `json:"-"`
+	Name *string `json:"name,omitempty"`
 
 	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
-	Pagesize *int64 `json:"-"`
+	Pagesize *int64 `json:"pagesize,omitempty"`
 
 	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
-	Pagetoken *string `json:"-"`
+	Pagetoken *string `json:"pagetoken,omitempty"`
 
 	// Optional sort property, valid values are name, description, created_at and modified_at. If specified, the items are
 	// sorted by the value of this property.
-	Sort *string `json:"-"`
+	Sort *string `json:"sort,omitempty"`
 
 	// Optional sort order, valid values are asc and desc. Default: asc.
-	Order *string `json:"-"`
+	Order *string `json:"order,omitempty"`
 
 	// Defines if the entity history is included in the response.
-	IncludeHistory *bool `json:"-"`
+	IncludeHistory *bool `json:"include_history,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3836,7 +4150,7 @@ func (options *ListServiceIdsOptions) SetHeaders(param map[string]string) *ListS
 // LockAPIKeyOptions : The LockAPIKey options.
 type LockAPIKeyOptions struct {
 	// Unique ID of the API key.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -3864,7 +4178,7 @@ func (options *LockAPIKeyOptions) SetHeaders(param map[string]string) *LockAPIKe
 // LockServiceIDOptions : The LockServiceID options.
 type LockServiceIDOptions struct {
 	// Unique ID of the service ID.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -4142,6 +4456,96 @@ func UnmarshalProfileLinkList(m map[string]json.RawMessage, result interface{}) 
 	return
 }
 
+// Report : Report struct
+type Report struct {
+	// IAMid of the user who triggered the report.
+	CreatedBy *string `json:"created_by" validate:"required"`
+
+	// Unique reference used to generate the report.
+	Reference *string `json:"reference" validate:"required"`
+
+	// Duration in hours for which the report is generated.
+	ReportDuration *string `json:"report_duration" validate:"required"`
+
+	// Start time of the report.
+	ReportStartTime *string `json:"report_start_time" validate:"required"`
+
+	// End time of the report.
+	ReportEndTime *string `json:"report_end_time" validate:"required"`
+
+	// List of users.
+	Users []UserActivity `json:"users,omitempty"`
+
+	// List of apikeys.
+	Apikeys []EntityActivity `json:"apikeys,omitempty"`
+
+	// List of serviceids.
+	Serviceids []EntityActivity `json:"serviceids,omitempty"`
+
+	// List of profiles.
+	Profiles []EntityActivity `json:"profiles,omitempty"`
+}
+
+// UnmarshalReport unmarshals an instance of Report from the specified map of raw messages.
+func UnmarshalReport(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Report)
+	err = core.UnmarshalPrimitive(m, "created_by", &obj.CreatedBy)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "reference", &obj.Reference)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "report_duration", &obj.ReportDuration)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "report_start_time", &obj.ReportStartTime)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "report_end_time", &obj.ReportEndTime)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "users", &obj.Users, UnmarshalUserActivity)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "apikeys", &obj.Apikeys, UnmarshalEntityActivity)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "serviceids", &obj.Serviceids, UnmarshalEntityActivity)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "profiles", &obj.Profiles, UnmarshalEntityActivity)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// ReportReference : ReportReference struct
+type ReportReference struct {
+	// Reference for the report to be generated.
+	Reference *string `json:"reference" validate:"required"`
+}
+
+// UnmarshalReportReference unmarshals an instance of ReportReference from the specified map of raw messages.
+func UnmarshalReportReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ReportReference)
+	err = core.UnmarshalPrimitive(m, "reference", &obj.Reference)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // ResponseContext : Context with key properties for problem determination.
 type ResponseContext struct {
 	// The transaction ID of the inbound REST request.
@@ -4276,6 +4680,8 @@ type ServiceID struct {
 
 	// Response body format for API key V1 REST requests.
 	Apikey *APIKey `json:"apikey,omitempty"`
+
+	Activity *Activity `json:"activity,omitempty"`
 }
 
 // UnmarshalServiceID unmarshals an instance of ServiceID from the specified map of raw messages.
@@ -4334,6 +4740,10 @@ func UnmarshalServiceID(m map[string]json.RawMessage, result interface{}) (err e
 		return
 	}
 	err = core.UnmarshalModel(m, "apikey", &obj.Apikey, UnmarshalAPIKey)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "activity", &obj.Activity, UnmarshalActivity)
 	if err != nil {
 		return
 	}
@@ -4446,6 +4856,8 @@ type TrustedProfile struct {
 
 	// History of the trusted profile.
 	History []EnityHistoryRecord `json:"history,omitempty"`
+
+	Activity *Activity `json:"activity,omitempty"`
 }
 
 // UnmarshalTrustedProfile unmarshals an instance of TrustedProfile from the specified map of raw messages.
@@ -4500,6 +4912,10 @@ func UnmarshalTrustedProfile(m map[string]json.RawMessage, result interface{}) (
 		return
 	}
 	err = core.UnmarshalModel(m, "history", &obj.History, UnmarshalEnityHistoryRecord)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "activity", &obj.Activity, UnmarshalActivity)
 	if err != nil {
 		return
 	}
@@ -4570,7 +4986,7 @@ func UnmarshalTrustedProfilesList(m map[string]json.RawMessage, result interface
 // UnlockAPIKeyOptions : The UnlockAPIKey options.
 type UnlockAPIKeyOptions struct {
 	// Unique ID of the API key.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -4598,7 +5014,7 @@ func (options *UnlockAPIKeyOptions) SetHeaders(param map[string]string) *UnlockA
 // UnlockServiceIDOptions : The UnlockServiceID options.
 type UnlockServiceIDOptions struct {
 	// Unique ID of the service ID.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -4628,10 +5044,10 @@ type UpdateAccountSettingsOptions struct {
 	// Version of the account settings to be updated. Specify the version that you  retrieved as entity_tag (ETag header)
 	// when reading the account. This value helps  identifying parallel usage of this API. Pass * to indicate to update any
 	// version  available. This might result in stale updates.
-	IfMatch *string `json:"-" validate:"required"`
+	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// The id of the account to update the settings for.
-	AccountID *string `json:"-" validate:"required,ne="`
+	AccountID *string `json:"account_id" validate:"required,ne="`
 
 	// Defines whether or not creating a Service Id is access controlled. Valid values:
 	//   * RESTRICTED - to apply access control
@@ -4786,12 +5202,12 @@ func (options *UpdateAccountSettingsOptions) SetHeaders(param map[string]string)
 // UpdateAPIKeyOptions : The UpdateAPIKey options.
 type UpdateAPIKeyOptions struct {
 	// Unique ID of the API key to be updated.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Version of the API key to be updated. Specify the version that you retrieved when reading the API key. This value
 	// helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might result
 	// in stale updates.
-	IfMatch *string `json:"-" validate:"required"`
+	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// The name of the API key to update. If specified in the request the parameter must not be empty. The name is not
 	// checked for uniqueness. Failure to this will result in an Error condition.
@@ -4846,15 +5262,15 @@ func (options *UpdateAPIKeyOptions) SetHeaders(param map[string]string) *UpdateA
 // UpdateClaimRuleOptions : The UpdateClaimRule options.
 type UpdateClaimRuleOptions struct {
 	// ID of the trusted profile.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// ID of the claim rule to update.
-	RuleID *string `json:"-" validate:"required,ne="`
+	RuleID *string `json:"rule-id" validate:"required,ne="`
 
 	// Version of the claim rule to be updated.  Specify the version that you retrived when reading list of claim rules.
 	// This value helps to identify any parallel usage of claim rule. Pass * to indicate to update any version available.
 	// This might result in stale updates.
-	IfMatch *string `json:"-" validate:"required"`
+	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// Type of the calim rule, either 'Profile-SAML' or 'Profile-CR'.
 	Type *string `json:"type" validate:"required"`
@@ -4963,12 +5379,12 @@ func (options *UpdateClaimRuleOptions) SetHeaders(param map[string]string) *Upda
 // UpdateProfileOptions : The UpdateProfile options.
 type UpdateProfileOptions struct {
 	// ID of the trusted profile to be updated.
-	ProfileID *string `json:"-" validate:"required,ne="`
+	ProfileID *string `json:"profile-id" validate:"required,ne="`
 
 	// Version of the trusted profile to be updated.  Specify the version that you retrived when reading list of trusted
 	// profiles. This value helps to identify any parallel usage of trusted profile. Pass * to indicate to update any
 	// version available. This might result in stale updates.
-	IfMatch *string `json:"-" validate:"required"`
+	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// The name of the trusted profile to update. If specified in the request the parameter must not be empty. The name is
 	// checked for uniqueness. Failure to this will result in an Error condition.
@@ -5023,12 +5439,12 @@ func (options *UpdateProfileOptions) SetHeaders(param map[string]string) *Update
 // UpdateServiceIDOptions : The UpdateServiceID options.
 type UpdateServiceIDOptions struct {
 	// Unique ID of the service ID to be updated.
-	ID *string `json:"-" validate:"required,ne="`
+	ID *string `json:"id" validate:"required,ne="`
 
 	// Version of the service ID to be updated. Specify the version that you retrieved as entity_tag (ETag header) when
 	// reading the service ID. This value helps identifying parallel usage of this API. Pass * to indicate to update any
 	// version available. This might result in stale updates.
-	IfMatch *string `json:"-" validate:"required"`
+	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// The name of the service ID to update. If specified in the request the parameter must not be empty. The name is not
 	// checked for uniqueness. Failure to this will result in an Error condition.
@@ -5088,4 +5504,35 @@ func (_options *UpdateServiceIDOptions) SetUniqueInstanceCrns(uniqueInstanceCrns
 func (options *UpdateServiceIDOptions) SetHeaders(param map[string]string) *UpdateServiceIDOptions {
 	options.Headers = param
 	return options
+}
+
+// UserActivity : UserActivity struct
+type UserActivity struct {
+	// IAMid of the user.
+	IamID *string `json:"iam_id" validate:"required"`
+
+	// Username of the user.
+	Username *string `json:"username" validate:"required"`
+
+	// Time when the user was last authenticated.
+	LastAuthn *string `json:"last_authn,omitempty"`
+}
+
+// UnmarshalUserActivity unmarshals an instance of UserActivity from the specified map of raw messages.
+func UnmarshalUserActivity(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(UserActivity)
+	err = core.UnmarshalPrimitive(m, "iam_id", &obj.IamID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "username", &obj.Username)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_authn", &obj.LastAuthn)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
 }

--- a/iamidentityv1/iam_identity_v1_examples_test.go
+++ b/iamidentityv1/iam_identity_v1_examples_test.go
@@ -637,7 +637,7 @@ var _ = Describe(`IamIdentityV1 Examples Tests`, func() {
 			// begin-create_link
 
 			createProfileLinkRequestLink := new(iamidentityv1.CreateProfileLinkRequestLink)
-			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/18e3020749ce4744b0b472466d61fdb4::computeresource:Fake-Compute-Resource")
+			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/" + accountID + "::computeresource:Fake-Compute-Resource")
 			createProfileLinkRequestLink.Namespace = core.StringPtr("default")
 			createProfileLinkRequestLink.Name = core.StringPtr("niceName")
 
@@ -775,6 +775,46 @@ var _ = Describe(`IamIdentityV1 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(accountSettingsResponse).ToNot(BeNil())
+		})
+		It(`CreateReport request example`, func() {
+			fmt.Println("\nCreateReport() result:")
+			// begin-create_report
+
+			createReportOptions := iamIdentityService.NewCreateReportOptions(accountID)
+            createReportOptions.SetType("inactive")
+            createReportOptions.SetDuration("120")
+
+			report, response, err := iamIdentityService.CreateReport(createReportOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(report, "", "  ")
+			fmt.Println(string(b))
+
+			// end-create_report
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(report).ToNot(BeNil())
+		})
+		It(`GetReport request example`, func() {
+			fmt.Println("\nGetReport() result:")
+			// begin-get_report
+
+			getReportOptions := iamIdentityService.NewGetReportOptions(accountID,"latest")
+
+			report, response, err := iamIdentityService.GetReport(getReportOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(report, "", "  ")
+			fmt.Println(string(b))
+
+			// end-get_report
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(report).ToNot(BeNil())
 		})
 	})
 })

--- a/iamidentityv1/iam_identity_v1_integration_test.go
+++ b/iamidentityv1/iam_identity_v1_integration_test.go
@@ -83,6 +83,8 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		linkId string
 
 		accountSettingEtag string
+        
+		reportId      string
 	)
 
 	var shouldSkipTest = func() {
@@ -200,8 +202,9 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(apikeyId1).ToNot(BeNil())
 
 			getAPIKeyOptions := &iamidentityv1.GetAPIKeyOptions{
-				ID:             &apikeyId1,
-				IncludeHistory: core.BoolPtr(true),
+				ID:              &apikeyId1,
+				IncludeHistory:  core.BoolPtr(true),
+                IncludeActivity: core.BoolPtr(true),
 			}
 
 			apiKey, response, err := iamIdentityService.GetAPIKey(getAPIKeyOptions)
@@ -220,6 +223,8 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(*apiKey.Locked).To(BeFalse())
 			Expect(*apiKey.CRN).ToNot(BeNil())
 			Expect(apiKey.History).ToNot(BeEmpty())
+			Expect(apiKey.Activity).ToNot(BeNil())
+			Expect(apiKey.Activity.AuthnCount).ToNot(BeNil())
 
 			// Grab the Etag value from the response for use in the update operation.
 			apikeyEtag1 = response.GetHeaders().Get("Etag")
@@ -438,8 +443,9 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		It(`GetServiceID(getServiceIdOptions *GetServiceIdOptions)`, func() {
 			Expect(serviceId1).ToNot(BeEmpty())
 			getServiceIDOptions := &iamidentityv1.GetServiceIDOptions{
-				ID:             &serviceId1,
-				IncludeHistory: core.BoolPtr(true),
+				ID:              &serviceId1,
+				IncludeHistory:  core.BoolPtr(true),
+                IncludeActivity: core.BoolPtr(true),
 			}
 
 			serviceID, response, err := iamIdentityService.GetServiceID(getServiceIDOptions)
@@ -452,6 +458,8 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(*serviceID.Name).To(Equal(serviceIDName))
 			Expect(*serviceID.Description).To(Equal("GoSDK test serviceId"))
 			Expect(serviceID.History).ToNot(BeEmpty())
+			Expect(serviceID.Activity).ToNot(BeNil())
+			Expect(serviceID.Activity.AuthnCount).ToNot(BeNil())
 
 			// Grab the Etag value from the response for use in the update operation.
 			serviceIdEtag1 = response.GetHeaders().Get("Etag")
@@ -928,7 +936,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		It(`CreateLink(createLinkOptions *CreateLinkOptions)`, func() {
 
 			createProfileLinkRequestLink := new(iamidentityv1.CreateProfileLinkRequestLink)
-			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/18e3020749ce4744b0b472466d61fdb4::computeresource:Fake-Compute-Resource")
+			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/" + accountID + "::computeresource:Fake-Compute-Resource")
 			createProfileLinkRequestLink.Namespace = core.StringPtr("default")
 			createProfileLinkRequestLink.Name = core.StringPtr("nice name")
 
@@ -1219,7 +1227,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		It(`CreateLinkBadRequest(createLinkOptions *CreateLinkOptions)`, func() {
 
 			createProfileLinkRequestLink := new(iamidentityv1.CreateProfileLinkRequestLink)
-			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/18e3020749ce4744b0b472466d61fdb4::computeresource:Fake-Compute-Resource")
+			createProfileLinkRequestLink.CRN = core.StringPtr("crn:v1:staging:public:iam-identity::a/" + accountID + "::computeresource:Fake-Compute-Resource")
 			createProfileLinkRequestLink.Namespace = core.StringPtr("default")
 			createProfileLinkRequestLink.Name = core.StringPtr("nice name")
 
@@ -1293,7 +1301,6 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(accountSettingsResponse).ToNot(BeNil())
 			Expect(accountSettingsResponse.History).ToNot(BeNil())
 			Expect(accountSettingsResponse.EntityTag).ToNot(BeNil())
-			Expect(accountSettingsResponse.AllowedIPAddresses).To(BeNil())
 			Expect(accountSettingsResponse.RestrictCreateServiceID).ToNot(BeNil())
 			Expect(accountSettingsResponse.RestrictCreatePlatformApikey).ToNot(BeNil())
 			Expect(accountSettingsResponse.SessionExpirationInSeconds).ToNot(BeNil())
@@ -1330,7 +1337,6 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(accountSettingsResponse).ToNot(BeNil())
 			Expect(accountSettingsResponse.History).ToNot(BeNil())
 			Expect(accountSettingsResponse.EntityTag).ToNot(Equal(accountSettingEtag))
-			Expect(accountSettingsResponse.AllowedIPAddresses).To(BeNil())
 			Expect(accountSettingsResponse.Mfa).To(Equal(accountSettingsRequestOptions.Mfa))
 			Expect(accountSettingsResponse.AccountID).To(Equal(accountSettingsRequestOptions.AccountID))
 			Expect(accountSettingsResponse.RestrictCreateServiceID).To(Equal(accountSettingsRequestOptions.RestrictCreateServiceID))
@@ -1340,6 +1346,103 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			fmt.Fprintf(GinkgoWriter, "UpdateAccountSettings response:\n%s\n", common.ToJSON(accountSettingsResponse))
 		})
 	})
+    
+	Describe(`CreateInactivityReport - Create an inactivity report`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`CreateReport(createReportOptions *CreateReportOptions)`, func() {
+
+			createReportOptions := &iamidentityv1.CreateReportOptions{
+				AccountID:   &accountID,
+				Type:        core.StringPtr("inactive"),
+				Duration:    core.StringPtr("120"),
+			}
+
+			reportRef, response, err := iamIdentityService.CreateReport(createReportOptions)
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(202))
+			Expect(reportRef).ToNot(BeNil())
+			fmt.Fprintf(GinkgoWriter, "CreateReport response:\n%s\n", common.ToJSON(reportRef))
+
+			reportId = *reportRef.Reference
+			Expect(reportId).ToNot(BeNil())
+		})
+	})
+    
+	Describe(`GetInactivityReportIncomplete - Get an incomplete inactivity report`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+        It(`GetReport(getReportOptions *GetReportOptions)`, func() {
+            Expect(reportId).ToNot(BeEmpty())
+            getReportOptions := &iamidentityv1.GetReportOptions{
+              AccountID: &accountID,
+              Reference: &reportId,
+            }
+
+            report, response, err := iamIdentityService.GetReport(getReportOptions)
+
+            Expect(err).To(BeNil())
+            Expect(response.StatusCode).To(Equal(204))
+            Expect(report).To(BeNil())
+		})
+	})
+
+	Describe(`GetInactivityReportComplete - Get a complete inactivity report`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`GetReport(getReportOptions *GetReportOptions)`, func() {
+			Expect(reportId).ToNot(BeEmpty())
+			getReportOptions := &iamidentityv1.GetReportOptions{
+				AccountID: &accountID,
+				Reference: &reportId,
+			}
+            
+            for {
+			  report, response, err := iamIdentityService.GetReport(getReportOptions)
+			  Expect(err).To(BeNil())
+              if response.StatusCode != 204 {
+                Expect(response.StatusCode).To(Equal(200))
+                Expect(report).ToNot(BeNil())
+                Expect(report.CreatedBy).ToNot(BeNil())
+                Expect(*report.CreatedBy).To(Equal(iamID))
+                Expect(report.Reference).ToNot(BeNil())
+                Expect(*report.Reference).To(Equal(reportId))
+                Expect(report.ReportDuration).ToNot(BeNil())
+                Expect(report.ReportStartTime).ToNot(BeNil())
+                Expect(report.ReportEndTime).ToNot(BeNil())
+                Expect(report.Users).ToNot(BeNil())
+                Expect(report.Apikeys).ToNot(BeNil())
+                Expect(report.Serviceids).ToNot(BeNil())
+                Expect(report.Profiles).ToNot(BeNil())
+                break
+              }
+            }
+		})
+	})
+    
+	Describe(`GetInactivityReportNotFound`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`GetReportNotFound(getReportOptions *GetReportOptions)`, func() {
+
+			getReportOptions := &iamidentityv1.GetReportOptions{
+				AccountID: &accountID,
+				Reference: core.StringPtr("1234567890"),
+			}
+
+			report, response, err := iamIdentityService.GetReport(getReportOptions)
+
+			Expect(report).To(BeNil())
+			Expect(response.StatusCode).To(Equal(404))
+			Expect(err).ToNot(BeNil())
+		})
+	})
+    
 })
 
 var _ = AfterSuite(func() {

--- a/iamidentityv1/iam_identity_v1_integration_test.go
+++ b/iamidentityv1/iam_identity_v1_integration_test.go
@@ -1401,7 +1401,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 				Reference: &reportId,
 			}
             
-            for {
+            for i := 0; i < 30; i++ {
 			  report, response, err := iamIdentityService.GetReport(getReportOptions)
 			  Expect(err).To(BeNil())
               if response.StatusCode != 204 {
@@ -1420,6 +1420,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
                 Expect(report.Profiles).ToNot(BeNil())
                 break
               }
+              time.Sleep(1 * time.Second)
             }
 		})
 	})

--- a/iamidentityv1/iam_identity_v1_suite_test.go
+++ b/iamidentityv1/iam_identity_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iamidentityv1/iam_identity_v1_test.go
+++ b/iamidentityv1/iam_identity_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -185,7 +185,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// TODO: Add check for include_history query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListAPIKeys with error: Operation response processing error`, func() {
@@ -252,7 +252,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "apikeys": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "apikeys": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListAPIKeys successfully with retries`, func() {
@@ -323,7 +323,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "apikeys": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "apikeys": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListAPIKeys successfully`, func() {
@@ -450,7 +450,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["Entity-Lock"][0]).To(Equal(fmt.Sprintf("%v", "false")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateAPIKey with error: Operation response processing error`, func() {
@@ -524,7 +524,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateAPIKey successfully with retries`, func() {
@@ -602,7 +602,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateAPIKey successfully`, func() {
@@ -731,7 +731,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// TODO: Add check for include_history query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetAPIKeysDetails with error: Operation response processing error`, func() {
@@ -785,7 +785,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetAPIKeysDetails successfully with retries`, func() {
@@ -843,7 +843,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetAPIKeysDetails successfully`, func() {
@@ -946,9 +946,10 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getAPIKeyPath))
 					Expect(req.Method).To(Equal("GET"))
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetAPIKey with error: Operation response processing error`, func() {
@@ -963,6 +964,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := new(iamidentityv1.GetAPIKeyOptions)
 				getAPIKeyOptionsModel.ID = core.StringPtr("testString")
 				getAPIKeyOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAPIKeyOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getAPIKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := iamIdentityService.GetAPIKey(getAPIKeyOptionsModel)
@@ -994,13 +996,14 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetAPIKey successfully with retries`, func() {
@@ -1016,6 +1019,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := new(iamidentityv1.GetAPIKeyOptions)
 				getAPIKeyOptionsModel.ID = core.StringPtr("testString")
 				getAPIKeyOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAPIKeyOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getAPIKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -1053,10 +1057,11 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetAPIKey successfully`, func() {
@@ -1077,6 +1082,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := new(iamidentityv1.GetAPIKeyOptions)
 				getAPIKeyOptionsModel.ID = core.StringPtr("testString")
 				getAPIKeyOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAPIKeyOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getAPIKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -1098,6 +1104,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := new(iamidentityv1.GetAPIKeyOptions)
 				getAPIKeyOptionsModel.ID = core.StringPtr("testString")
 				getAPIKeyOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAPIKeyOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getAPIKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := iamIdentityService.SetServiceURL("")
@@ -1140,6 +1147,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := new(iamidentityv1.GetAPIKeyOptions)
 				getAPIKeyOptionsModel.ID = core.StringPtr("testString")
 				getAPIKeyOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAPIKeyOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getAPIKeyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -1169,7 +1177,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateAPIKey with error: Operation response processing error`, func() {
@@ -1240,7 +1248,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateAPIKey successfully with retries`, func() {
@@ -1315,7 +1323,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateAPIKey successfully`, func() {
@@ -1643,7 +1651,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// TODO: Add check for include_history query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListServiceIds with error: Operation response processing error`, func() {
@@ -1706,7 +1714,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "serviceids": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "serviceids": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListServiceIds successfully with retries`, func() {
@@ -1773,7 +1781,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "serviceids": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "serviceids": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListServiceIds successfully`, func() {
@@ -1894,7 +1902,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["Entity-Lock"][0]).To(Equal(fmt.Sprintf("%v", "false")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateServiceID with error: Operation response processing error`, func() {
@@ -1974,7 +1982,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateServiceID successfully with retries`, func() {
@@ -2058,7 +2066,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateServiceID successfully`, func() {
@@ -2201,9 +2209,10 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getServiceIDPath))
 					Expect(req.Method).To(Equal("GET"))
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetServiceID with error: Operation response processing error`, func() {
@@ -2218,6 +2227,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := new(iamidentityv1.GetServiceIDOptions)
 				getServiceIDOptionsModel.ID = core.StringPtr("testString")
 				getServiceIDOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getServiceIDOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getServiceIDOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := iamIdentityService.GetServiceID(getServiceIDOptionsModel)
@@ -2249,13 +2259,14 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetServiceID successfully with retries`, func() {
@@ -2271,6 +2282,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := new(iamidentityv1.GetServiceIDOptions)
 				getServiceIDOptionsModel.ID = core.StringPtr("testString")
 				getServiceIDOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getServiceIDOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getServiceIDOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -2308,10 +2320,11 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					// TODO: Add check for include_history query parameter
+					// TODO: Add check for include_activity query parameter
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetServiceID successfully`, func() {
@@ -2332,6 +2345,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := new(iamidentityv1.GetServiceIDOptions)
 				getServiceIDOptionsModel.ID = core.StringPtr("testString")
 				getServiceIDOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getServiceIDOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getServiceIDOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -2353,6 +2367,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := new(iamidentityv1.GetServiceIDOptions)
 				getServiceIDOptionsModel.ID = core.StringPtr("testString")
 				getServiceIDOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getServiceIDOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getServiceIDOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := iamIdentityService.SetServiceURL("")
@@ -2395,6 +2410,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := new(iamidentityv1.GetServiceIDOptions)
 				getServiceIDOptionsModel.ID = core.StringPtr("testString")
 				getServiceIDOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getServiceIDOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getServiceIDOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -2424,7 +2440,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateServiceID with error: Operation response processing error`, func() {
@@ -2496,7 +2512,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateServiceID successfully with retries`, func() {
@@ -2572,7 +2588,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "iam_id": "IamID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "account_id": "AccountID", "name": "Name", "description": "Description", "unique_instance_crns": ["UniqueInstanceCrns"], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "apikey": {"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "locked": true, "created_at": "2019-01-01T12:00:00.000Z", "created_by": "CreatedBy", "modified_at": "2019-01-01T12:00:00.000Z", "name": "Name", "description": "Description", "iam_id": "IamID", "account_id": "AccountID", "apikey": "Apikey", "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}, "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateServiceID successfully`, func() {
@@ -2896,7 +2912,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("POST"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateProfile with error: Operation response processing error`, func() {
@@ -2964,7 +2980,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateProfile successfully with retries`, func() {
@@ -3036,7 +3052,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke CreateProfile successfully`, func() {
@@ -3157,7 +3173,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListProfiles with error: Operation response processing error`, func() {
@@ -3220,7 +3236,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "profiles": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "profiles": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListProfiles successfully with retries`, func() {
@@ -3287,7 +3303,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "profiles": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "profiles": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}]}`)
 				}))
 			})
 			It(`Invoke ListProfiles successfully`, func() {
@@ -3411,9 +3427,10 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Verify the contents of the request
 					Expect(req.URL.EscapedPath()).To(Equal(getProfilePath))
 					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_activity query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetProfile with error: Operation response processing error`, func() {
@@ -3427,6 +3444,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(iamidentityv1.GetProfileOptions)
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
+				getProfileOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := iamIdentityService.GetProfile(getProfileOptionsModel)
@@ -3457,13 +3475,14 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getProfilePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					// TODO: Add check for include_activity query parameter
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetProfile successfully with retries`, func() {
@@ -3478,6 +3497,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(iamidentityv1.GetProfileOptions)
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
+				getProfileOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -3514,10 +3534,11 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getProfilePath))
 					Expect(req.Method).To(Equal("GET"))
 
+					// TODO: Add check for include_activity query parameter
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke GetProfile successfully`, func() {
@@ -3537,6 +3558,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(iamidentityv1.GetProfileOptions)
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
+				getProfileOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -3557,6 +3579,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(iamidentityv1.GetProfileOptions)
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
+				getProfileOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := iamIdentityService.SetServiceURL("")
@@ -3598,6 +3621,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 				// Construct an instance of the GetProfileOptions model
 				getProfileOptionsModel := new(iamidentityv1.GetProfileOptions)
 				getProfileOptionsModel.ProfileID = core.StringPtr("testString")
+				getProfileOptionsModel.IncludeActivity = core.BoolPtr(false)
 				getProfileOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -3627,7 +3651,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateProfile with error: Operation response processing error`, func() {
@@ -3698,7 +3722,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateProfile successfully with retries`, func() {
@@ -3773,7 +3797,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}]}`)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "entity_tag": "EntityTag", "crn": "CRN", "name": "Name", "description": "Description", "created_at": "2019-01-01T12:00:00.000Z", "modified_at": "2019-01-01T12:00:00.000Z", "iam_id": "IamID", "account_id": "AccountID", "ims_account_id": 12, "ims_user_id": 9, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "activity": {"last_authn": "LastAuthn", "authn_count": 10}}`)
 				}))
 			})
 			It(`Invoke UpdateProfile successfully`, func() {
@@ -3958,7 +3982,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("POST"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateClaimRule with error: Operation response processing error`, func() {
@@ -4337,7 +4361,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListClaimRules with error: Operation response processing error`, func() {
@@ -4549,7 +4573,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetClaimRule with error: Operation response processing error`, func() {
@@ -4768,7 +4792,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateClaimRule with error: Operation response processing error`, func() {
@@ -5231,7 +5255,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("POST"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateLink with error: Operation response processing error`, func() {
@@ -5520,7 +5544,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListLinks with error: Operation response processing error`, func() {
@@ -5732,7 +5756,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetLink with error: Operation response processing error`, func() {
@@ -6020,7 +6044,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					// TODO: Add check for include_history query parameter
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetAccountSettings with error: Operation response processing error`, func() {
@@ -6241,7 +6265,7 @@ var _ = Describe(`IamIdentityV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateAccountSettings with error: Operation response processing error`, func() {
@@ -6517,6 +6541,451 @@ var _ = Describe(`IamIdentityV1`, func() {
 			})
 		})
 	})
+	Describe(`CreateReport(createReportOptions *CreateReportOptions) - Operation response error`, func() {
+		createReportPath := "/v1/activity/accounts/testString/report"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createReportPath))
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"inactive"}))
+					Expect(req.URL.Query()["duration"]).To(Equal([]string{"720"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateReport with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateReportOptions model
+				createReportOptionsModel := new(iamidentityv1.CreateReportOptions)
+				createReportOptionsModel.AccountID = core.StringPtr("testString")
+				createReportOptionsModel.Type = core.StringPtr("inactive")
+				createReportOptionsModel.Duration = core.StringPtr("720")
+				createReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateReport(createReportOptions *CreateReportOptions)`, func() {
+		createReportPath := "/v1/activity/accounts/testString/report"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createReportPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"inactive"}))
+					Expect(req.URL.Query()["duration"]).To(Equal([]string{"720"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"reference": "Reference"}`)
+				}))
+			})
+			It(`Invoke CreateReport successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateReportOptions model
+				createReportOptionsModel := new(iamidentityv1.CreateReportOptions)
+				createReportOptionsModel.AccountID = core.StringPtr("testString")
+				createReportOptionsModel.Type = core.StringPtr("inactive")
+				createReportOptionsModel.Duration = core.StringPtr("720")
+				createReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateReportWithContext(ctx, createReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateReportWithContext(ctx, createReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createReportPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"inactive"}))
+					Expect(req.URL.Query()["duration"]).To(Equal([]string{"720"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"reference": "Reference"}`)
+				}))
+			})
+			It(`Invoke CreateReport successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateReport(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the CreateReportOptions model
+				createReportOptionsModel := new(iamidentityv1.CreateReportOptions)
+				createReportOptionsModel.AccountID = core.StringPtr("testString")
+				createReportOptionsModel.Type = core.StringPtr("inactive")
+				createReportOptionsModel.Duration = core.StringPtr("720")
+				createReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateReport with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateReportOptions model
+				createReportOptionsModel := new(iamidentityv1.CreateReportOptions)
+				createReportOptionsModel.AccountID = core.StringPtr("testString")
+				createReportOptionsModel.Type = core.StringPtr("inactive")
+				createReportOptionsModel.Duration = core.StringPtr("720")
+				createReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateReportOptions model with no property values
+				createReportOptionsModelNew := new(iamidentityv1.CreateReportOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.CreateReport(createReportOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke CreateReport successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateReportOptions model
+				createReportOptionsModel := new(iamidentityv1.CreateReportOptions)
+				createReportOptionsModel.AccountID = core.StringPtr("testString")
+				createReportOptionsModel.Type = core.StringPtr("inactive")
+				createReportOptionsModel.Duration = core.StringPtr("720")
+				createReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateReport(createReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetReport(getReportOptions *GetReportOptions) - Operation response error`, func() {
+		getReportPath := "/v1/activity/accounts/testString/report/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getReportPath))
+					Expect(req.Method).To(Equal("GET"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetReport with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetReportOptions model
+				getReportOptionsModel := new(iamidentityv1.GetReportOptions)
+				getReportOptionsModel.AccountID = core.StringPtr("testString")
+				getReportOptionsModel.Reference = core.StringPtr("testString")
+				getReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetReport(getReportOptions *GetReportOptions)`, func() {
+		getReportPath := "/v1/activity/accounts/testString/report/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getReportPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"created_by": "CreatedBy", "reference": "Reference", "report_duration": "ReportDuration", "report_start_time": "ReportStartTime", "report_end_time": "ReportEndTime", "users": [{"iam_id": "IamID", "username": "Username", "last_authn": "LastAuthn"}], "apikeys": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}], "serviceids": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}], "profiles": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}]}`)
+				}))
+			})
+			It(`Invoke GetReport successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetReportOptions model
+				getReportOptionsModel := new(iamidentityv1.GetReportOptions)
+				getReportOptionsModel.AccountID = core.StringPtr("testString")
+				getReportOptionsModel.Reference = core.StringPtr("testString")
+				getReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetReportWithContext(ctx, getReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetReportWithContext(ctx, getReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getReportPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"created_by": "CreatedBy", "reference": "Reference", "report_duration": "ReportDuration", "report_start_time": "ReportStartTime", "report_end_time": "ReportEndTime", "users": [{"iam_id": "IamID", "username": "Username", "last_authn": "LastAuthn"}], "apikeys": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}], "serviceids": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}], "profiles": [{"id": "ID", "name": "Name", "last_authn": "LastAuthn"}]}`)
+				}))
+			})
+			It(`Invoke GetReport successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetReport(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetReportOptions model
+				getReportOptionsModel := new(iamidentityv1.GetReportOptions)
+				getReportOptionsModel.AccountID = core.StringPtr("testString")
+				getReportOptionsModel.Reference = core.StringPtr("testString")
+				getReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetReport with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetReportOptions model
+				getReportOptionsModel := new(iamidentityv1.GetReportOptions)
+				getReportOptionsModel.AccountID = core.StringPtr("testString")
+				getReportOptionsModel.Reference = core.StringPtr("testString")
+				getReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetReportOptions model with no property values
+				getReportOptionsModelNew := new(iamidentityv1.GetReportOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetReport(getReportOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetReport successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetReportOptions model
+				getReportOptionsModel := new(iamidentityv1.GetReportOptions)
+				getReportOptionsModel.AccountID = core.StringPtr("testString")
+				getReportOptionsModel.Reference = core.StringPtr("testString")
+				getReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetReport(getReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
 			iamIdentityService, _ := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
@@ -6664,6 +7133,20 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(createProfileOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(createProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewCreateReportOptions successfully`, func() {
+				// Construct an instance of the CreateReportOptions model
+				accountID := "testString"
+				createReportOptionsModel := iamIdentityService.NewCreateReportOptions(accountID)
+				createReportOptionsModel.SetAccountID("testString")
+				createReportOptionsModel.SetType("inactive")
+				createReportOptionsModel.SetDuration("720")
+				createReportOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createReportOptionsModel).ToNot(BeNil())
+				Expect(createReportOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(createReportOptionsModel.Type).To(Equal(core.StringPtr("inactive")))
+				Expect(createReportOptionsModel.Duration).To(Equal(core.StringPtr("720")))
+				Expect(createReportOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewCreateServiceIDOptions successfully`, func() {
 				// Construct an instance of the APIKeyInsideCreateServiceIDRequest model
 				apiKeyInsideCreateServiceIDRequestModel := new(iamidentityv1.APIKeyInsideCreateServiceIDRequest)
@@ -6771,10 +7254,12 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getAPIKeyOptionsModel := iamIdentityService.NewGetAPIKeyOptions(id)
 				getAPIKeyOptionsModel.SetID("testString")
 				getAPIKeyOptionsModel.SetIncludeHistory(false)
+				getAPIKeyOptionsModel.SetIncludeActivity(false)
 				getAPIKeyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getAPIKeyOptionsModel).ToNot(BeNil())
 				Expect(getAPIKeyOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(getAPIKeyOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getAPIKeyOptionsModel.IncludeActivity).To(Equal(core.BoolPtr(false)))
 				Expect(getAPIKeyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetAPIKeysDetailsOptions successfully`, func() {
@@ -6819,10 +7304,25 @@ var _ = Describe(`IamIdentityV1`, func() {
 				profileID := "testString"
 				getProfileOptionsModel := iamIdentityService.NewGetProfileOptions(profileID)
 				getProfileOptionsModel.SetProfileID("testString")
+				getProfileOptionsModel.SetIncludeActivity(false)
 				getProfileOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getProfileOptionsModel).ToNot(BeNil())
 				Expect(getProfileOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
+				Expect(getProfileOptionsModel.IncludeActivity).To(Equal(core.BoolPtr(false)))
 				Expect(getProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetReportOptions successfully`, func() {
+				// Construct an instance of the GetReportOptions model
+				accountID := "testString"
+				reference := "testString"
+				getReportOptionsModel := iamIdentityService.NewGetReportOptions(accountID, reference)
+				getReportOptionsModel.SetAccountID("testString")
+				getReportOptionsModel.SetReference("testString")
+				getReportOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getReportOptionsModel).ToNot(BeNil())
+				Expect(getReportOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(getReportOptionsModel.Reference).To(Equal(core.StringPtr("testString")))
+				Expect(getReportOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetServiceIDOptions successfully`, func() {
 				// Construct an instance of the GetServiceIDOptions model
@@ -6830,10 +7330,12 @@ var _ = Describe(`IamIdentityV1`, func() {
 				getServiceIDOptionsModel := iamIdentityService.NewGetServiceIDOptions(id)
 				getServiceIDOptionsModel.SetID("testString")
 				getServiceIDOptionsModel.SetIncludeHistory(false)
+				getServiceIDOptionsModel.SetIncludeActivity(false)
 				getServiceIDOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(getServiceIDOptionsModel).ToNot(BeNil())
 				Expect(getServiceIDOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(getServiceIDOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getServiceIDOptionsModel.IncludeActivity).To(Equal(core.BoolPtr(false)))
 				Expect(getServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewListAPIKeysOptions successfully`, func() {


### PR DESCRIPTION
## PR summary
adding new endpoints: create report, get report
adding new optional query parameter include_activity for the existing get calls of apikey/serviceid/profile by id.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
users will now be able to generate report for inactive identities.
create report: will return a reference
get report: this will return a detailed report of inactive identities
existing get apikey/serviceid/profile by id will now include additional optional parameter include_activity
if include_activity is passed as true the response will include a new section activity with last authn time and count.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
![grafik](https://user-images.githubusercontent.com/17162481/161062193-68d85d49-6792-4862-b964-38988ccce0b6.png)
