### PR TITLE
chore: replace `ioutil` with `io` and `os`

### DIFF
--- a/atrackerv1/atracker_v1_test.go
+++ b/atrackerv1/atracker_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3368,7 +3367,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/atrackerv2/atracker_v2_test.go
+++ b/atrackerv2/atracker_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3894,7 +3893,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/casemanagementv1/case_management_v1_examples_test.go
+++ b/casemanagementv1/case_management_v1_examples_test.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 
@@ -322,7 +322,7 @@ var _ = Describe(`CaseManagementV1 Examples Tests`, func() {
 
 			exampleFileContent := "This is the content of the file to upload."
 
-			exampleFile, _ := caseManagementService.NewFileWithMetadata(ioutil.NopCloser(strings.NewReader(exampleFileContent)))
+			exampleFile, _ := caseManagementService.NewFileWithMetadata(io.NopCloser(strings.NewReader(exampleFileContent)))
 			exampleFile.Filename = core.StringPtr("example.log")
 			exampleFile.ContentType = core.StringPtr("application/octet-stream")
 

--- a/casemanagementv1/case_management_v1_integration_test.go
+++ b/casemanagementv1/case_management_v1_integration_test.go
@@ -22,7 +22,7 @@ package casemanagementv1_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -376,7 +376,7 @@ var _ = Describe("Case Management - Integration Tests", func() {
 
 		It("Successfully uploaded file", func() {
 			shouldSkipTest()
-			fileInput, _ := service.NewFileWithMetadata(ioutil.NopCloser(strings.NewReader("hello world")))
+			fileInput, _ := service.NewFileWithMetadata(io.NopCloser(strings.NewReader("hello world")))
 			fileInput.Filename = core.StringPtr("GO SDK test file.png")
 			fileInput.ContentType = core.StringPtr("application/octet-stream")
 

--- a/casemanagementv1/case_management_v1_test.go
+++ b/casemanagementv1/case_management_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2917,7 +2916,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/catalogmanagementv1/catalog_management_v1_test.go
+++ b/catalogmanagementv1/catalog_management_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -8514,7 +8513,7 @@ var _ = Describe(`CatalogManagementV1`, func() {
 
 				// Verify empty byte buffer.
 				Expect(result).ToNot(BeNil())
-				buffer, operationErr := ioutil.ReadAll(result)
+				buffer, operationErr := io.ReadAll(result)
 				Expect(operationErr).To(BeNil())
 				Expect(buffer).ToNot(BeNil())
 				Expect(len(buffer)).To(Equal(0))
@@ -19635,7 +19634,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/configurationgovernancev1/configuration_governance_v1_test.go
+++ b/configurationgovernancev1/configuration_governance_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2904,7 +2903,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/contextbasedrestrictionsv1/context_based_restrictions_v1_test.go
+++ b/contextbasedrestrictionsv1/context_based_restrictions_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -4096,7 +4095,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/enterprisebillingunitsv1/enterprise_billing_units_v1_test.go
+++ b/enterprisebillingunitsv1/enterprise_billing_units_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1147,7 +1146,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/enterprisemanagementv1/enterprise_management_v1_test.go
+++ b/enterprisemanagementv1/enterprise_management_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2815,7 +2814,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/enterpriseusagereportsv1/enterprise_usage_reports_v1_test.go
+++ b/enterpriseusagereportsv1/enterprise_usage_reports_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -430,7 +429,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/globalcatalogv1/global_catalog_v1_examples_test.go
+++ b/globalcatalogv1/global_catalog_v1_examples_test.go
@@ -23,7 +23,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -449,7 +449,7 @@ var _ = Describe(`GlobalCatalogV1 Examples Tests`, func() {
 				catalogEntryID,
 				"artifact.txt",
 			)
-			uploadArtifactOptions.SetArtifact(ioutil.NopCloser(strings.NewReader(artifactContents)))
+			uploadArtifactOptions.SetArtifact(io.NopCloser(strings.NewReader(artifactContents)))
 			uploadArtifactOptions.SetContentType("text/plain")
 
 			response, err := globalCatalogService.UploadArtifact(uploadArtifactOptions)

--- a/globalcatalogv1/global_catalog_v1_integration_test.go
+++ b/globalcatalogv1/global_catalog_v1_integration_test.go
@@ -22,7 +22,7 @@ package globalcatalogv1_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -204,11 +204,11 @@ var _ = Describe("Global Catalog - Integration Tests", func() {
 		deleteArtifact = service.NewDeleteArtifactOptions(id, artifactId)
 
 		defaultChild.SetParentID(id)
-		defaultArtifact.SetArtifact(ioutil.NopCloser(strings.NewReader(artifact)))
-		uploadArtifactList.SetArtifact(ioutil.NopCloser(strings.NewReader(artifact)))
-		uploadArtifactCreate.SetArtifact(ioutil.NopCloser(strings.NewReader(artifact)))
-		uploadArtifactCreateFailure.SetArtifact(ioutil.NopCloser(strings.NewReader(artifact)))
-		uploadArtifactDelete.SetArtifact(ioutil.NopCloser(strings.NewReader(artifact)))
+		defaultArtifact.SetArtifact(io.NopCloser(strings.NewReader(artifact)))
+		uploadArtifactList.SetArtifact(io.NopCloser(strings.NewReader(artifact)))
+		uploadArtifactCreate.SetArtifact(io.NopCloser(strings.NewReader(artifact)))
+		uploadArtifactCreateFailure.SetArtifact(io.NopCloser(strings.NewReader(artifact)))
+		uploadArtifactDelete.SetArtifact(io.NopCloser(strings.NewReader(artifact)))
 		forceDelete.SetForce(true)
 	})
 

--- a/globalcatalogv1/global_catalog_v1_test.go
+++ b/globalcatalogv1/global_catalog_v1_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -6157,7 +6156,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/globalsearchv2/global_search_v2_test.go
+++ b/globalsearchv2/global_search_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -729,7 +728,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/globaltaggingv1/global_tagging_v1_test.go
+++ b/globaltaggingv1/global_tagging_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1984,7 +1983,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/iamaccessgroupsv2/iam_access_groups_v2_test.go
+++ b/iamaccessgroupsv2/iam_access_groups_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -4899,7 +4898,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/iamidentityv1/iam_identity_v1_test.go
+++ b/iamidentityv1/iam_identity_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -7664,7 +7663,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3298,7 +3297,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/ibmcloudshellv1/ibm_cloud_shell_v1_test.go
+++ b/ibmcloudshellv1/ibm_cloud_shell_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -873,7 +872,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/openservicebrokerv1/open_service_broker_v1_test.go
+++ b/openservicebrokerv1/open_service_broker_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2427,7 +2426,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/posturemanagementv1/posture_management_v1_test.go
+++ b/posturemanagementv1/posture_management_v1_test.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1111,7 +1110,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/resourcecontrollerv2/resource_controller_v2_test.go
+++ b/resourcecontrollerv2/resource_controller_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -6794,7 +6793,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/resourcemanagerv2/resource_manager_v2_test.go
+++ b/resourcemanagerv2/resource_manager_v2_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1719,7 +1718,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/usagemeteringv4/usage_metering_v4_test.go
+++ b/usagemeteringv4/usage_metering_v4_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -481,7 +480,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {

--- a/usagereportsv4/usage_reports_v4_test.go
+++ b/usagereportsv4/usage_reports_v4_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2192,7 +2191,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate(mockData string) *strfmt.Date {

--- a/usermanagementv1/user_management_v1_test.go
+++ b/usermanagementv1/user_management_v1_test.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1649,7 +1648,7 @@ func CreateMockUUID(mockData string) *strfmt.UUID {
 }
 
 func CreateMockReader(mockData string) io.ReadCloser {
-	return ioutil.NopCloser(bytes.NewReader([]byte(mockData)))
+	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
 func CreateMockDate() *strfmt.Date {


### PR DESCRIPTION
This commit replaces the `ioutil` package with `io` and `os`,
because it's became deprecated in Go 1.16. As of the release
of Go 1.19, our linter started to throw errors due to this old imports.

Signed-off-by: Norbert Biczo <pyrooka@users.noreply.github.com>

## PR summary
<!-- please include a brief summary of the changes in this PR -->


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->