### PR TITLE
fix(Enterprise Usage Reports): regen service to get Pager

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$|_test.go|package-lock.json|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2022-08-01T21:19:05Z",
+  "generated_at": "2022-10-26T12:32:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "dc893c9c63b0a9f1ac2b956b807ee3d8bc8e1128",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3347,
+        "line_number": 4449,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -78,7 +78,7 @@
         "hashed_secret": "c334fe1f9004e339ead59696c029181963999ff3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3368,
+        "line_number": 4473,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "f971798ba28d8d6a66ee5bdea060b751a078c2fa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3447,
+        "line_number": 4552,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -94,7 +94,7 @@
         "hashed_secret": "e7369ac81427d43f7615f691cd1cf5c3ef9b2f00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3468,
+        "line_number": 4576,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -102,7 +102,7 @@
         "hashed_secret": "bc31992082895a108753616f5be455b3e897bb29",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3620,
+        "line_number": 4728,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -110,7 +110,7 @@
         "hashed_secret": "21ac4c0699bb3f370e2c21331fd8606739b1079b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 3641,
+        "line_number": 4752,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -118,7 +118,7 @@
         "hashed_secret": "6452e7c5a42f97b00af1a210afc7d4de315e57ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 13526,
+        "line_number": 18774,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -248,7 +248,7 @@
       }
     ]
   },
-  "version": "0.13.1+ibm.50.dss",
+  "version": "0.13.1+ibm.55.dss",
   "word_list": {
     "file": null,
     "hash": null

--- a/enterpriseusagereportsv1/enterprise_usage_reports_v1.go
+++ b/enterpriseusagereportsv1/enterprise_usage_reports_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020.
+ * (C) Copyright IBM Corp. 2020, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 99-SNAPSHOT-629bbb97-20201207-171303
+ * IBM OpenAPI SDK Code Generator Version: 3.60.0-13f6e1ba-20221019-164457
  */
 
 // Package enterpriseusagereportsv1 : Operations and models for the EnterpriseUsageReportsV1 service
@@ -35,7 +35,7 @@ import (
 
 // EnterpriseUsageReportsV1 : Usage reports for IBM Cloud enterprise entities
 //
-// Version: 1.0.0-beta.1
+// API Version: 1.0.0-beta.1
 type EnterpriseUsageReportsV1 struct {
 	Service *core.BaseService
 }
@@ -226,11 +226,13 @@ func (enterpriseUsageReports *EnterpriseUsageReportsV1) GetResourceUsageReportWi
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalReports)
-	if err != nil {
-		return
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalReports)
+		if err != nil {
+			return
+		}
+		response.Result = result
 	}
-	response.Result = result
 
 	return
 }
@@ -278,51 +280,51 @@ func (*EnterpriseUsageReportsV1) NewGetResourceUsageReportOptions() *GetResource
 }
 
 // SetEnterpriseID : Allow user to set EnterpriseID
-func (options *GetResourceUsageReportOptions) SetEnterpriseID(enterpriseID string) *GetResourceUsageReportOptions {
-	options.EnterpriseID = core.StringPtr(enterpriseID)
-	return options
+func (_options *GetResourceUsageReportOptions) SetEnterpriseID(enterpriseID string) *GetResourceUsageReportOptions {
+	_options.EnterpriseID = core.StringPtr(enterpriseID)
+	return _options
 }
 
 // SetAccountGroupID : Allow user to set AccountGroupID
-func (options *GetResourceUsageReportOptions) SetAccountGroupID(accountGroupID string) *GetResourceUsageReportOptions {
-	options.AccountGroupID = core.StringPtr(accountGroupID)
-	return options
+func (_options *GetResourceUsageReportOptions) SetAccountGroupID(accountGroupID string) *GetResourceUsageReportOptions {
+	_options.AccountGroupID = core.StringPtr(accountGroupID)
+	return _options
 }
 
 // SetAccountID : Allow user to set AccountID
-func (options *GetResourceUsageReportOptions) SetAccountID(accountID string) *GetResourceUsageReportOptions {
-	options.AccountID = core.StringPtr(accountID)
-	return options
+func (_options *GetResourceUsageReportOptions) SetAccountID(accountID string) *GetResourceUsageReportOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
 }
 
 // SetChildren : Allow user to set Children
-func (options *GetResourceUsageReportOptions) SetChildren(children bool) *GetResourceUsageReportOptions {
-	options.Children = core.BoolPtr(children)
-	return options
+func (_options *GetResourceUsageReportOptions) SetChildren(children bool) *GetResourceUsageReportOptions {
+	_options.Children = core.BoolPtr(children)
+	return _options
 }
 
 // SetMonth : Allow user to set Month
-func (options *GetResourceUsageReportOptions) SetMonth(month string) *GetResourceUsageReportOptions {
-	options.Month = core.StringPtr(month)
-	return options
+func (_options *GetResourceUsageReportOptions) SetMonth(month string) *GetResourceUsageReportOptions {
+	_options.Month = core.StringPtr(month)
+	return _options
 }
 
 // SetBillingUnitID : Allow user to set BillingUnitID
-func (options *GetResourceUsageReportOptions) SetBillingUnitID(billingUnitID string) *GetResourceUsageReportOptions {
-	options.BillingUnitID = core.StringPtr(billingUnitID)
-	return options
+func (_options *GetResourceUsageReportOptions) SetBillingUnitID(billingUnitID string) *GetResourceUsageReportOptions {
+	_options.BillingUnitID = core.StringPtr(billingUnitID)
+	return _options
 }
 
 // SetLimit : Allow user to set Limit
-func (options *GetResourceUsageReportOptions) SetLimit(limit int64) *GetResourceUsageReportOptions {
-	options.Limit = core.Int64Ptr(limit)
-	return options
+func (_options *GetResourceUsageReportOptions) SetLimit(limit int64) *GetResourceUsageReportOptions {
+	_options.Limit = core.Int64Ptr(limit)
+	return _options
 }
 
 // SetOffset : Allow user to set Offset
-func (options *GetResourceUsageReportOptions) SetOffset(offset string) *GetResourceUsageReportOptions {
-	options.Offset = core.StringPtr(offset)
-	return options
+func (_options *GetResourceUsageReportOptions) SetOffset(offset string) *GetResourceUsageReportOptions {
+	_options.Offset = core.StringPtr(offset)
+	return _options
 }
 
 // SetHeaders : Allow user to set Headers
@@ -369,7 +371,7 @@ type MetricUsage struct {
 	RatedCost *float64 `json:"rated_cost" validate:"required"`
 
 	// The price with which cost was calculated.
-	Price []interface{} `json:"price,omitempty"`
+	Price []map[string]interface{} `json:"price,omitempty"`
 }
 
 // UnmarshalMetricUsage unmarshals an instance of MetricUsage from the specified map of raw messages.
@@ -502,6 +504,18 @@ func UnmarshalReports(m map[string]json.RawMessage, result interface{}) (err err
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
+}
+
+// Retrieve the value to be passed to a request to access the next page of results
+func (resp *Reports) GetNextOffset() (*string, error) {
+	if core.IsNil(resp.Next) {
+		return nil, nil
+	}
+	offset, err := core.GetQueryParam(resp.Next.Href, "offset")
+	if err != nil || offset == nil {
+		return nil, err
+	}
+	return offset, nil
 }
 
 // ResourceUsage : A container for all the plans in the resource.
@@ -677,4 +691,91 @@ func UnmarshalResourceUsageReport(m map[string]json.RawMessage, result interface
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
 	return
+}
+
+//
+// GetResourceUsageReportPager can be used to simplify the use of the "GetResourceUsageReport" method.
+//
+type GetResourceUsageReportPager struct {
+	hasNext     bool
+	options     *GetResourceUsageReportOptions
+	client      *EnterpriseUsageReportsV1
+	pageContext struct {
+		next *string
+	}
+}
+
+// NewGetResourceUsageReportPager returns a new GetResourceUsageReportPager instance.
+func (enterpriseUsageReports *EnterpriseUsageReportsV1) NewGetResourceUsageReportPager(options *GetResourceUsageReportOptions) (pager *GetResourceUsageReportPager, err error) {
+	if options.Offset != nil && *options.Offset != "" {
+		err = fmt.Errorf("the 'options.Offset' field should not be set")
+		return
+	}
+
+	var optionsCopy GetResourceUsageReportOptions = *options
+	pager = &GetResourceUsageReportPager{
+		hasNext: true,
+		options: &optionsCopy,
+		client:  enterpriseUsageReports,
+	}
+	return
+}
+
+// HasNext returns true if there are potentially more results to be retrieved.
+func (pager *GetResourceUsageReportPager) HasNext() bool {
+	return pager.hasNext
+}
+
+// GetNextWithContext returns the next page of results using the specified Context.
+func (pager *GetResourceUsageReportPager) GetNextWithContext(ctx context.Context) (page []ResourceUsageReport, err error) {
+	if !pager.HasNext() {
+		return nil, fmt.Errorf("no more results available")
+	}
+
+	pager.options.Offset = pager.pageContext.next
+
+	result, _, err := pager.client.GetResourceUsageReportWithContext(ctx, pager.options)
+	if err != nil {
+		return
+	}
+
+	var next *string
+	if result.Next != nil {
+		var offset *string
+		offset, err = core.GetQueryParam(result.Next.Href, "offset")
+		if err != nil {
+			err = fmt.Errorf("error retrieving 'offset' query parameter from URL '%s': %s", *result.Next.Href, err.Error())
+			return
+		}
+		next = offset
+	}
+	pager.pageContext.next = next
+	pager.hasNext = (pager.pageContext.next != nil)
+	page = result.Reports
+
+	return
+}
+
+// GetAllWithContext returns all results by invoking GetNextWithContext() repeatedly
+// until all pages of results have been retrieved.
+func (pager *GetResourceUsageReportPager) GetAllWithContext(ctx context.Context) (allItems []ResourceUsageReport, err error) {
+	for pager.HasNext() {
+		var nextPage []ResourceUsageReport
+		nextPage, err = pager.GetNextWithContext(ctx)
+		if err != nil {
+			return
+		}
+		allItems = append(allItems, nextPage...)
+	}
+	return
+}
+
+// GetNext invokes GetNextWithContext() using context.Background() as the Context parameter.
+func (pager *GetResourceUsageReportPager) GetNext() (page []ResourceUsageReport, err error) {
+	return pager.GetNextWithContext(context.Background())
+}
+
+// GetAll invokes GetAllWithContext() using context.Background() as the Context parameter.
+func (pager *GetResourceUsageReportPager) GetAll() (allItems []ResourceUsageReport, err error) {
+	return pager.GetAllWithContext(context.Background())
 }

--- a/enterpriseusagereportsv1/enterprise_usage_reports_v1_examples_test.go
+++ b/enterpriseusagereportsv1/enterprise_usage_reports_v1_examples_test.go
@@ -1,7 +1,8 @@
+//go:build examples
 // +build examples
 
 /**
- * (C) Copyright IBM Corp. 2020, 2021.
+ * (C) Copyright IBM Corp. 2020, 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -125,24 +126,27 @@ var _ = Describe(`EnterpriseUsageReportsV1 Examples Tests`, func() {
 		It(`GetResourceUsageReport request example`, func() {
 			fmt.Println("\nGetResourceUsageReport() result:")
 			// begin-get_resource_usage_report
+			getResourceUsageReportOptions := &enterpriseusagereportsv1.GetResourceUsageReportOptions{
+				EnterpriseID: &enterpriseID,
+				Month:        &billingMonth,
+			}
 
-			getResourceUsageReportOptions := enterpriseUsageReportsService.NewGetResourceUsageReportOptions()
-			getResourceUsageReportOptions.SetEnterpriseID(enterpriseID)
-			getResourceUsageReportOptions.SetMonth(billingMonth)
-
-			reports, response, err := enterpriseUsageReportsService.GetResourceUsageReport(getResourceUsageReportOptions)
+			pager, err := enterpriseUsageReportsService.NewGetResourceUsageReportPager(getResourceUsageReportOptions)
 			if err != nil {
 				panic(err)
 			}
-			b, _ := json.MarshalIndent(reports, "", "  ")
+
+			var allResults []enterpriseusagereportsv1.ResourceUsageReport
+			for pager.HasNext() {
+				nextPage, err := pager.GetNext()
+				if err != nil {
+					panic(err)
+				}
+				allResults = append(allResults, nextPage...)
+			}
+			b, _ := json.MarshalIndent(allResults, "", "  ")
 			fmt.Println(string(b))
-
 			// end-get_resource_usage_report
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
-			Expect(reports).ToNot(BeNil())
-
 		})
 	})
 })

--- a/enterpriseusagereportsv1/enterprise_usage_reports_v1_suite_test.go
+++ b/enterpriseusagereportsv1/enterprise_usage_reports_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,10 @@
 package enterpriseusagereportsv1_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"testing"
 )
 
 func TestEnterpriseUsageReportsV1(t *testing.T) {

--- a/enterpriseusagereportsv1/enterprise_usage_reports_v1_test.go
+++ b/enterpriseusagereportsv1/enterprise_usage_reports_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2020.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,13 +66,14 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ENTERPRISE_USAGE_REPORTS_URL":       "https://enterpriseusagereportsv1/api",
+				"ENTERPRISE_USAGE_REPORTS_URL": "https://enterpriseusagereportsv1/api",
 				"ENTERPRISE_USAGE_REPORTS_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{})
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+				})
 				Expect(enterpriseUsageReportsService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -101,7 +102,8 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{})
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+				})
 				err := enterpriseUsageReportsService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(enterpriseUsageReportsService).ToNot(BeNil())
@@ -119,12 +121,13 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ENTERPRISE_USAGE_REPORTS_URL":       "https://enterpriseusagereportsv1/api",
+				"ENTERPRISE_USAGE_REPORTS_URL": "https://enterpriseusagereportsv1/api",
 				"ENTERPRISE_USAGE_REPORTS_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{})
+			enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1UsingExternalConfig(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+			})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(enterpriseUsageReportsService).To(BeNil())
@@ -135,7 +138,7 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ENTERPRISE_USAGE_REPORTS_AUTH_TYPE": "NOAuth",
+				"ENTERPRISE_USAGE_REPORTS_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -162,7 +165,7 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 	})
 	Describe(`GetResourceUsageReport(getResourceUsageReportOptions *GetResourceUsageReportOptions) - Operation response error`, func() {
 		getResourceUsageReportPath := "/v1/resource-usage-reports"
-		Context(`Using mock server endpoint`, func() {
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
 			BeforeEach(func() {
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 					defer GinkgoRecover()
@@ -171,24 +174,16 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 					Expect(req.URL.EscapedPath()).To(Equal(getResourceUsageReportPath))
 					Expect(req.Method).To(Equal("GET"))
 					Expect(req.URL.Query()["enterprise_id"]).To(Equal([]string{"abc12340d4bf4e36b0423d209b286f24"}))
-
 					Expect(req.URL.Query()["account_group_id"]).To(Equal([]string{"def456a237b94b9a9238ef024e204c9f"}))
-
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"987abcba31834216b8c726a7dd9eb8d6"}))
-
 					// TODO: Add check for children query parameter
-
 					Expect(req.URL.Query()["month"]).To(Equal([]string{"2019-06"}))
-
 					Expect(req.URL.Query()["billing_unit_id"]).To(Equal([]string{"testString"}))
-
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-
 					Expect(req.URL.Query()["offset"]).To(Equal([]string{"testString"}))
-
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetResourceUsageReport with error: Operation response processing error`, func() {
@@ -228,13 +223,10 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 			})
 		})
 	})
-
 	Describe(`GetResourceUsageReport(getResourceUsageReportOptions *GetResourceUsageReportOptions)`, func() {
 		getResourceUsageReportPath := "/v1/resource-usage-reports"
-		var serverSleepTime time.Duration
-		Context(`Using mock server endpoint`, func() {
+		Context(`Using mock server endpoint with timeout`, func() {
 			BeforeEach(func() {
-				serverSleepTime = 0
 				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 					defer GinkgoRecover()
 
@@ -243,24 +235,85 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 
 					Expect(req.URL.Query()["enterprise_id"]).To(Equal([]string{"abc12340d4bf4e36b0423d209b286f24"}))
-
 					Expect(req.URL.Query()["account_group_id"]).To(Equal([]string{"def456a237b94b9a9238ef024e204c9f"}))
-
 					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"987abcba31834216b8c726a7dd9eb8d6"}))
-
 					// TODO: Add check for children query parameter
-
 					Expect(req.URL.Query()["month"]).To(Equal([]string{"2019-06"}))
-
 					Expect(req.URL.Query()["billing_unit_id"]).To(Equal([]string{"testString"}))
-
 					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
-
 					Expect(req.URL.Query()["offset"]).To(Equal([]string{"testString"}))
-
 					// Sleep a short time to support a timeout test
-					time.Sleep(serverSleepTime)
+					time.Sleep(100 * time.Millisecond)
 
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"limit": 5, "first": {"href": "Href"}, "next": {"href": "Href"}, "reports": [{"entity_id": "de129b787b86403db7d3a14be2ae5f76", "entity_type": "enterprise", "entity_crn": "crn:v1:bluemix:public:enterprise::a/e9a57260546c4b4aa9ebfa316a82e56e::enterprise:de129b787b86403db7d3a14be2ae5f76", "entity_name": "Platform-Services", "billing_unit_id": "65719a07280a4022a9efa2f6ff4c3369", "billing_unit_crn": "crn:v1:bluemix:public:billing::a/3f99f8accbc848ea96f3c61a0ae22c44::billing-unit:65719a07280a4022a9efa2f6ff4c3369", "billing_unit_name": "Operations", "country_code": "USA", "currency_code": "USD", "month": "2017-08", "billable_cost": 12, "non_billable_cost": 15, "billable_rated_cost": 17, "non_billable_rated_cost": 20, "resources": [{"resource_id": "ResourceID", "billable_cost": 12, "billable_rated_cost": 17, "non_billable_cost": 15, "non_billable_rated_cost": 20, "plans": [{"plan_id": "PlanID", "pricing_region": "PricingRegion", "pricing_plan_id": "PricingPlanID", "billable": true, "cost": 4, "rated_cost": 9, "usage": [{"metric": "UP-TIME", "unit": "HOURS", "quantity": 711.11, "rateable_quantity": 700, "cost": 123.45, "rated_cost": 130, "price": [{"anyKey": "anyValue"}]}]}]}]}]}`)
+				}))
+			})
+			It(`Invoke GetResourceUsageReport successfully with retries`, func() {
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(enterpriseUsageReportsService).ToNot(BeNil())
+				enterpriseUsageReportsService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetResourceUsageReportOptions model
+				getResourceUsageReportOptionsModel := new(enterpriseusagereportsv1.GetResourceUsageReportOptions)
+				getResourceUsageReportOptionsModel.EnterpriseID = core.StringPtr("abc12340d4bf4e36b0423d209b286f24")
+				getResourceUsageReportOptionsModel.AccountGroupID = core.StringPtr("def456a237b94b9a9238ef024e204c9f")
+				getResourceUsageReportOptionsModel.AccountID = core.StringPtr("987abcba31834216b8c726a7dd9eb8d6")
+				getResourceUsageReportOptionsModel.Children = core.BoolPtr(true)
+				getResourceUsageReportOptionsModel.Month = core.StringPtr("2019-06")
+				getResourceUsageReportOptionsModel.BillingUnitID = core.StringPtr("testString")
+				getResourceUsageReportOptionsModel.Limit = core.Int64Ptr(int64(10))
+				getResourceUsageReportOptionsModel.Offset = core.StringPtr("testString")
+				getResourceUsageReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := enterpriseUsageReportsService.GetResourceUsageReportWithContext(ctx, getResourceUsageReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				enterpriseUsageReportsService.DisableRetries()
+				result, response, operationErr := enterpriseUsageReportsService.GetResourceUsageReport(getResourceUsageReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = enterpriseUsageReportsService.GetResourceUsageReportWithContext(ctx, getResourceUsageReportOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getResourceUsageReportPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["enterprise_id"]).To(Equal([]string{"abc12340d4bf4e36b0423d209b286f24"}))
+					Expect(req.URL.Query()["account_group_id"]).To(Equal([]string{"def456a237b94b9a9238ef024e204c9f"}))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"987abcba31834216b8c726a7dd9eb8d6"}))
+					// TODO: Add check for children query parameter
+					Expect(req.URL.Query()["month"]).To(Equal([]string{"2019-06"}))
+					Expect(req.URL.Query()["billing_unit_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(10))}))
+					Expect(req.URL.Query()["offset"]).To(Equal([]string{"testString"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -274,7 +327,6 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 				})
 				Expect(serviceErr).To(BeNil())
 				Expect(enterpriseUsageReportsService).ToNot(BeNil())
-				enterpriseUsageReportsService.EnableRetries(0, 0)
 
 				// Invoke operation with nil options model (negative test)
 				result, response, operationErr := enterpriseUsageReportsService.GetResourceUsageReport(nil)
@@ -300,30 +352,6 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 				Expect(response).ToNot(BeNil())
 				Expect(result).ToNot(BeNil())
 
-				// Invoke operation with a Context to test a timeout error
-				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc()
-				serverSleepTime = 100 * time.Millisecond
-				_, _, operationErr = enterpriseUsageReportsService.GetResourceUsageReportWithContext(ctx, getResourceUsageReportOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-				serverSleepTime = time.Duration(0)
-
-				// Disable retries and test again
-				enterpriseUsageReportsService.DisableRetries()
-				result, response, operationErr = enterpriseUsageReportsService.GetResourceUsageReport(getResourceUsageReportOptionsModel)
-				Expect(operationErr).To(BeNil())
-				Expect(response).ToNot(BeNil())
-				Expect(result).ToNot(BeNil())
-
-				// Re-test the timeout error with retries disabled
-				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
-				defer cancelFunc2()
-				serverSleepTime = 100 * time.Millisecond
-				_, _, operationErr = enterpriseUsageReportsService.GetResourceUsageReportWithContext(ctx, getResourceUsageReportOptionsModel)
-				Expect(operationErr).ToNot(BeNil())
-				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
-				serverSleepTime = time.Duration(0)
 			})
 			It(`Invoke GetResourceUsageReport with error: Operation request error`, func() {
 				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
@@ -355,6 +383,158 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 			})
 			AfterEach(func() {
 				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetResourceUsageReport successfully`, func() {
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(enterpriseUsageReportsService).ToNot(BeNil())
+
+				// Construct an instance of the GetResourceUsageReportOptions model
+				getResourceUsageReportOptionsModel := new(enterpriseusagereportsv1.GetResourceUsageReportOptions)
+				getResourceUsageReportOptionsModel.EnterpriseID = core.StringPtr("abc12340d4bf4e36b0423d209b286f24")
+				getResourceUsageReportOptionsModel.AccountGroupID = core.StringPtr("def456a237b94b9a9238ef024e204c9f")
+				getResourceUsageReportOptionsModel.AccountID = core.StringPtr("987abcba31834216b8c726a7dd9eb8d6")
+				getResourceUsageReportOptionsModel.Children = core.BoolPtr(true)
+				getResourceUsageReportOptionsModel.Month = core.StringPtr("2019-06")
+				getResourceUsageReportOptionsModel.BillingUnitID = core.StringPtr("testString")
+				getResourceUsageReportOptionsModel.Limit = core.Int64Ptr(int64(10))
+				getResourceUsageReportOptionsModel.Offset = core.StringPtr("testString")
+				getResourceUsageReportOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := enterpriseUsageReportsService.GetResourceUsageReport(getResourceUsageReportOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Test pagination helper method on response`, func() {
+			It(`Invoke GetNextOffset successfully`, func() {
+				responseObject := new(enterpriseusagereportsv1.Reports)
+				nextObject := new(enterpriseusagereportsv1.Link)
+				nextObject.Href = core.StringPtr("ibm.com?offset=abc-123")
+				responseObject.Next = nextObject
+	
+				value, err := responseObject.GetNextOffset()
+				Expect(err).To(BeNil())
+				Expect(value).To(Equal(core.StringPtr("abc-123")))
+			})
+			It(`Invoke GetNextOffset without a "Next" property in the response`, func() {
+				responseObject := new(enterpriseusagereportsv1.Reports)
+	
+				value, err := responseObject.GetNextOffset()
+				Expect(err).To(BeNil())
+				Expect(value).To(BeNil())
+			})
+			It(`Invoke GetNextOffset without any query params in the "Next" URL`, func() {
+				responseObject := new(enterpriseusagereportsv1.Reports)
+				nextObject := new(enterpriseusagereportsv1.Link)
+				nextObject.Href = core.StringPtr("ibm.com")
+				responseObject.Next = nextObject
+	
+				value, err := responseObject.GetNextOffset()
+				Expect(err).To(BeNil())
+				Expect(value).To(BeNil())
+			})
+		})
+		Context(`Using mock server endpoint - paginated response`, func() {
+			BeforeEach(func() {
+				var requestNumber int = 0
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getResourceUsageReportPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					requestNumber++
+					if requestNumber == 1 {
+						fmt.Fprintf(res, "%s", `{"next":{"href":"https://myhost.com/somePath?offset=1"},"reports":[{"entity_id":"de129b787b86403db7d3a14be2ae5f76","entity_type":"enterprise","entity_crn":"crn:v1:bluemix:public:enterprise::a/e9a57260546c4b4aa9ebfa316a82e56e::enterprise:de129b787b86403db7d3a14be2ae5f76","entity_name":"Platform-Services","billing_unit_id":"65719a07280a4022a9efa2f6ff4c3369","billing_unit_crn":"crn:v1:bluemix:public:billing::a/3f99f8accbc848ea96f3c61a0ae22c44::billing-unit:65719a07280a4022a9efa2f6ff4c3369","billing_unit_name":"Operations","country_code":"USA","currency_code":"USD","month":"2017-08","billable_cost":12,"non_billable_cost":15,"billable_rated_cost":17,"non_billable_rated_cost":20,"resources":[{"resource_id":"ResourceID","billable_cost":12,"billable_rated_cost":17,"non_billable_cost":15,"non_billable_rated_cost":20,"plans":[{"plan_id":"PlanID","pricing_region":"PricingRegion","pricing_plan_id":"PricingPlanID","billable":true,"cost":4,"rated_cost":9,"usage":[{"metric":"UP-TIME","unit":"HOURS","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130,"price":[{"anyKey":"anyValue"}]}]}]}]}],"total_count":2,"limit":1}`)
+					} else if requestNumber == 2 {
+						fmt.Fprintf(res, "%s", `{"reports":[{"entity_id":"de129b787b86403db7d3a14be2ae5f76","entity_type":"enterprise","entity_crn":"crn:v1:bluemix:public:enterprise::a/e9a57260546c4b4aa9ebfa316a82e56e::enterprise:de129b787b86403db7d3a14be2ae5f76","entity_name":"Platform-Services","billing_unit_id":"65719a07280a4022a9efa2f6ff4c3369","billing_unit_crn":"crn:v1:bluemix:public:billing::a/3f99f8accbc848ea96f3c61a0ae22c44::billing-unit:65719a07280a4022a9efa2f6ff4c3369","billing_unit_name":"Operations","country_code":"USA","currency_code":"USD","month":"2017-08","billable_cost":12,"non_billable_cost":15,"billable_rated_cost":17,"non_billable_rated_cost":20,"resources":[{"resource_id":"ResourceID","billable_cost":12,"billable_rated_cost":17,"non_billable_cost":15,"non_billable_rated_cost":20,"plans":[{"plan_id":"PlanID","pricing_region":"PricingRegion","pricing_plan_id":"PricingPlanID","billable":true,"cost":4,"rated_cost":9,"usage":[{"metric":"UP-TIME","unit":"HOURS","quantity":711.11,"rateable_quantity":700,"cost":123.45,"rated_cost":130,"price":[{"anyKey":"anyValue"}]}]}]}]}],"total_count":2,"limit":1}`)
+					} else {
+						res.WriteHeader(400)
+					}
+				}))
+			})
+			It(`Use GetResourceUsageReportPager.GetNext successfully`, func() {
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(enterpriseUsageReportsService).ToNot(BeNil())
+
+				getResourceUsageReportOptionsModel := &enterpriseusagereportsv1.GetResourceUsageReportOptions{
+					EnterpriseID: core.StringPtr("abc12340d4bf4e36b0423d209b286f24"),
+					AccountGroupID: core.StringPtr("def456a237b94b9a9238ef024e204c9f"),
+					AccountID: core.StringPtr("987abcba31834216b8c726a7dd9eb8d6"),
+					Children: core.BoolPtr(true),
+					Month: core.StringPtr("2019-06"),
+					BillingUnitID: core.StringPtr("testString"),
+					Limit: core.Int64Ptr(int64(10)),
+				}
+
+				pager, err := enterpriseUsageReportsService.NewGetResourceUsageReportPager(getResourceUsageReportOptionsModel)
+				Expect(err).To(BeNil())
+				Expect(pager).ToNot(BeNil())
+
+				var allResults []enterpriseusagereportsv1.ResourceUsageReport
+				for pager.HasNext() {
+					nextPage, err := pager.GetNext()
+					Expect(err).To(BeNil())
+					Expect(nextPage).ToNot(BeNil())
+					allResults = append(allResults, nextPage...)
+				}
+				Expect(len(allResults)).To(Equal(2))
+			})
+			It(`Use GetResourceUsageReportPager.GetAll successfully`, func() {
+				enterpriseUsageReportsService, serviceErr := enterpriseusagereportsv1.NewEnterpriseUsageReportsV1(&enterpriseusagereportsv1.EnterpriseUsageReportsV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(enterpriseUsageReportsService).ToNot(BeNil())
+
+				getResourceUsageReportOptionsModel := &enterpriseusagereportsv1.GetResourceUsageReportOptions{
+					EnterpriseID: core.StringPtr("abc12340d4bf4e36b0423d209b286f24"),
+					AccountGroupID: core.StringPtr("def456a237b94b9a9238ef024e204c9f"),
+					AccountID: core.StringPtr("987abcba31834216b8c726a7dd9eb8d6"),
+					Children: core.BoolPtr(true),
+					Month: core.StringPtr("2019-06"),
+					BillingUnitID: core.StringPtr("testString"),
+					Limit: core.Int64Ptr(int64(10)),
+				}
+
+				pager, err := enterpriseUsageReportsService.NewGetResourceUsageReportPager(getResourceUsageReportOptionsModel)
+				Expect(err).To(BeNil())
+				Expect(pager).ToNot(BeNil())
+
+				allResults, err := pager.GetAll()
+				Expect(err).To(BeNil())
+				Expect(allResults).ToNot(BeNil())
+				Expect(len(allResults)).To(Equal(2))
 			})
 		})
 	})
@@ -403,11 +583,11 @@ var _ = Describe(`EnterpriseUsageReportsV1`, func() {
 			Expect(mockReader).ToNot(BeNil())
 		})
 		It(`Invoke CreateMockDate() successfully`, func() {
-			mockDate := CreateMockDate()
+			mockDate := CreateMockDate("2019-01-01")
 			Expect(mockDate).ToNot(BeNil())
 		})
 		It(`Invoke CreateMockDateTime() successfully`, func() {
-			mockDateTime := CreateMockDateTime()
+			mockDateTime := CreateMockDateTime("2019-01-01T12:00:00.000Z")
 			Expect(mockDateTime).ToNot(BeNil())
 		})
 	})
@@ -432,13 +612,19 @@ func CreateMockReader(mockData string) io.ReadCloser {
 	return io.NopCloser(bytes.NewReader([]byte(mockData)))
 }
 
-func CreateMockDate() *strfmt.Date {
-	d := strfmt.Date(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
+func CreateMockDate(mockData string) *strfmt.Date {
+	d, err := core.ParseDate(mockData)
+	if err != nil {
+		return nil
+	}
 	return &d
 }
 
-func CreateMockDateTime() *strfmt.DateTime {
-	d := strfmt.DateTime(time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC))
+func CreateMockDateTime(mockData string) *strfmt.DateTime {
+	d, err := core.ParseDateTime(mockData)
+	if err != nil {
+		return nil
+	}
 	return &d
 }
 


### PR DESCRIPTION
## PR summary
This commit contains a re-gen of the service to
leverage the new Pagers emitted by the SDK generator.

Signed-off-by: Phil Adams <phil_adams@us.ibm.com>

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->