### PR TITLE
feat(IAM Policy Management): add support for v2/policies API from IAM

### DIFF
--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -1124,9 +1124,38 @@ func (iamPolicyManagement *IamPolicyManagementV1) V2ListPoliciesWithContext(ctx 
 // **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.` The rule field can
 // either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
 // **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
-// levels of nested **`conditions`**. The IAM Services group (`IAM`) is a subset of account management services that
-// includes the IAM platform services IAM Identity, IAM Access Management, IAM Users Management, IAM Groups, and future
-// IAM services. If the subject is a locked service-id, the request will fail.
+// levels of nested **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g.,
+// access only during business hours, during the Monday-Friday work week). For example, a policy can grant access
+// Monday-Friday, 9:00am-5:00pm using the following rule:
+// ```json
+//   "rule": {
+//     "operator": "and",
+//     "conditions": [{
+//       "key": "{{environment.attributes.day_of_week}}",
+//       "operator": "dayOfWeekAnyOf",
+//       "value": [1, 2, 3, 4, 5]
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeGreaterThanOrEquals",
+//       "value": "09:00:00+00:00"
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeLessThanOrEquals",
+//       "value": "17:00:00+00:00"
+//     }]
+//   }
+// ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+// ```
+//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//   'monthEquals', 'monthAnyOf',
+//   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+// ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example above,
+// the **`pattern`** is **`"time-based-restrictions:weekly"`**. The IAM Services group (`IAM`) is a subset of account
+// management services that includes the IAM platform services IAM Identity, IAM Access Management, IAM Users
+// Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the request will fail.
 //
 // ### Attribute Operators
 //
@@ -1237,7 +1266,37 @@ func (iamPolicyManagement *IamPolicyManagementV1) V2CreatePolicyWithContext(ctx 
 // or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can either specify single
 // **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination **`operator`**.  The
 // possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2 levels of nested
-// **`conditions`**. If the subject is a locked service-id, the request will fail.
+// **`conditions`**. The operator for a rule can be used to specify a time based restriction (e.g., access only during
+// business hours, during the Monday-Friday work week). For example, a policy can grant access Monday-Friday,
+// 9:00am-5:00pm using the following rule:
+// ```json
+//   "rule": {
+//     "operator": "and",
+//     "conditions": [{
+//       "key": "{{environment.attributes.day_of_week}}",
+//       "operator": "dayOfWeekAnyOf",
+//       "value": [1, 2, 3, 4, 5]
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeGreaterThanOrEquals",
+//       "value": "09:00:00+00:00"
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeLessThanOrEquals",
+//       "value": "17:00:00+00:00"
+//     }]
+//   }
+// ``` Rules and conditions allow the following operators with **`key`**, **`value`** :
+// ```
+//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
+//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//   'monthEquals', 'monthAnyOf',
+//   'dayOfMonthEquals', 'dayOfMonthAnyOf'
+// ``` The pattern field can be coupled with a rule that matches the pattern. For the business hour rule example above,
+// the **`pattern`** is **`"time-based-restrictions:weekly"`**. If the subject is a locked service-id, the request will
+// fail.
 //
 // ### Attribute Operators
 //

--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.39.0-748eb4ca-20210917-165907
+ * IBM OpenAPI SDK Code Generator Version: 3.61.0-1667892a-20221109-194550
  */
 
 // Package iampolicymanagementv1 : Operations and models for the IamPolicyManagementV1 service
@@ -265,7 +265,9 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListPoliciesWithContext(ctx co
 // the **`access_group_id`** subject attribute for assigning access for an access group. The roles must be a subset of a
 // service's or the platform's supported roles. The resource attributes must be a subset of a service's or the
 // platform's supported attributes. The policy resource must include either the **`serviceType`**, **`serviceName`**,
-// or **`resourceGroupId`** attribute and the **`accountId`** attribute.` If the subject is a locked service-id, the
+// **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.` The IAM Services group
+// (`IAM`) is a subset of account management services that includes the IAM platform services IAM Identity, IAM Access
+// Management, IAM Users Management, IAM Groups, and future IAM services. If the subject is a locked service-id, the
 // request will fail.
 //
 // ### Authorization
@@ -283,7 +285,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListPoliciesWithContext(ctx co
 // ### Attribute Operators
 //
 // Currently, only the `stringEquals` and the `stringMatch` operators are available. Resource attributes may support one
-// or both operators.  For more information, see [how to assign access by using wildcards
+// or both operators. For more information, see [how to assign access by using wildcards
 // policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
 //
 // ### Attribute Validations
@@ -398,7 +400,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyWithContext(ctx co
 // ### Attribute Operators
 //
 // Currently, only the `stringEquals` and the `stringMatch` operators are available. Resource attributes might support
-// one or both operators.  For more information, see [how to assign access by using wildcards
+// one or both operators. For more information, see [how to assign access by using wildcards
 // policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
 //
 // ### Attribute Validations
@@ -1004,6 +1006,433 @@ func (iamPolicyManagement *IamPolicyManagementV1) DeleteRoleWithContext(ctx cont
 	}
 
 	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "DeleteRole")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamPolicyManagement.Service.Request(request, nil)
+
+	return
+}
+
+// V2ListPolicies : Get policies by attributes
+// Get policies and filter by attributes. While managing policies, you may want to retrieve policies in the account and
+// filter by attribute values. This can be done through query parameters. Currently, only the following attributes are
+// supported: account_id, iam_id, access_group_id, type, service_type, sort, format and state. account_id is a required
+// query parameter. Only policies that have the specified attributes and that the caller has read access to are
+// returned. If the caller does not have read access to any policies an empty array is returned.
+func (iamPolicyManagement *IamPolicyManagementV1) V2ListPolicies(v2ListPoliciesOptions *V2ListPoliciesOptions) (result *V2PolicyList, response *core.DetailedResponse, err error) {
+	return iamPolicyManagement.V2ListPoliciesWithContext(context.Background(), v2ListPoliciesOptions)
+}
+
+// V2ListPoliciesWithContext is an alternate form of the V2ListPolicies method which supports a Context parameter
+func (iamPolicyManagement *IamPolicyManagementV1) V2ListPoliciesWithContext(ctx context.Context, v2ListPoliciesOptions *V2ListPoliciesOptions) (result *V2PolicyList, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(v2ListPoliciesOptions, "v2ListPoliciesOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(v2ListPoliciesOptions, "v2ListPoliciesOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamPolicyManagement.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamPolicyManagement.Service.Options.URL, `/v2/policies`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range v2ListPoliciesOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "V2ListPolicies")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	if v2ListPoliciesOptions.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*v2ListPoliciesOptions.AcceptLanguage))
+	}
+
+	builder.AddQuery("account_id", fmt.Sprint(*v2ListPoliciesOptions.AccountID))
+	if v2ListPoliciesOptions.IamID != nil {
+		builder.AddQuery("iam_id", fmt.Sprint(*v2ListPoliciesOptions.IamID))
+	}
+	if v2ListPoliciesOptions.AccessGroupID != nil {
+		builder.AddQuery("access_group_id", fmt.Sprint(*v2ListPoliciesOptions.AccessGroupID))
+	}
+	if v2ListPoliciesOptions.Type != nil {
+		builder.AddQuery("type", fmt.Sprint(*v2ListPoliciesOptions.Type))
+	}
+	if v2ListPoliciesOptions.ServiceType != nil {
+		builder.AddQuery("service_type", fmt.Sprint(*v2ListPoliciesOptions.ServiceType))
+	}
+	if v2ListPoliciesOptions.ServiceName != nil {
+		builder.AddQuery("service_name", fmt.Sprint(*v2ListPoliciesOptions.ServiceName))
+	}
+	if v2ListPoliciesOptions.ServiceGroupID != nil {
+		builder.AddQuery("service_group_id", fmt.Sprint(*v2ListPoliciesOptions.ServiceGroupID))
+	}
+	if v2ListPoliciesOptions.Format != nil {
+		builder.AddQuery("format", fmt.Sprint(*v2ListPoliciesOptions.Format))
+	}
+	if v2ListPoliciesOptions.State != nil {
+		builder.AddQuery("state", fmt.Sprint(*v2ListPoliciesOptions.State))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamPolicyManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalV2PolicyList)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// V2CreatePolicy : Create a policy
+// Creates a policy to grant access between a subject and a resource. Currently, there is one type of a v2/policy:
+// **access**. A policy administrator might want to create an access policy which grants access to a user, service-id,
+// or an access group.
+//
+// ### Access
+//
+// To create an access policy, use **`"type": "access"`** in the body. The possible subject attributes are **`iam_id`**
+// and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+// the **`access_group_id`** subject attribute for assigning access for an access group. The roles must be a subset of a
+// service's or the platform's supported roles. The resource attributes must be a subset of a service's or the
+// platform's supported attributes. The policy resource must include either the **`serviceType`**, **`serviceName`**,
+// **`resourceGroupId`** or **`service_group_id`** attribute and the **`accountId`** attribute.` The rule field can
+// either specify single **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination
+// **`operator`**.  The possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2
+// levels of nested **`conditions`**. The IAM Services group (`IAM`) is a subset of account management services that
+// includes the IAM platform services IAM Identity, IAM Access Management, IAM Users Management, IAM Groups, and future
+// IAM services. If the subject is a locked service-id, the request will fail.
+//
+// ### Attribute Operators
+//
+// Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more information,
+// see [how to assign access by using wildcards policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+//
+// ### Attribute Validations
+//
+// Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+// geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+// against Global Catalog locations.
+func (iamPolicyManagement *IamPolicyManagementV1) V2CreatePolicy(v2CreatePolicyOptions *V2CreatePolicyOptions) (result *V2Policy, response *core.DetailedResponse, err error) {
+	return iamPolicyManagement.V2CreatePolicyWithContext(context.Background(), v2CreatePolicyOptions)
+}
+
+// V2CreatePolicyWithContext is an alternate form of the V2CreatePolicy method which supports a Context parameter
+func (iamPolicyManagement *IamPolicyManagementV1) V2CreatePolicyWithContext(ctx context.Context, v2CreatePolicyOptions *V2CreatePolicyOptions) (result *V2Policy, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(v2CreatePolicyOptions, "v2CreatePolicyOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(v2CreatePolicyOptions, "v2CreatePolicyOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamPolicyManagement.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamPolicyManagement.Service.Options.URL, `/v2/policies`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range v2CreatePolicyOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "V2CreatePolicy")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if v2CreatePolicyOptions.AcceptLanguage != nil {
+		builder.AddHeader("Accept-Language", fmt.Sprint(*v2CreatePolicyOptions.AcceptLanguage))
+	}
+
+	body := make(map[string]interface{})
+	if v2CreatePolicyOptions.Type != nil {
+		body["type"] = v2CreatePolicyOptions.Type
+	}
+	if v2CreatePolicyOptions.Control != nil {
+		body["control"] = v2CreatePolicyOptions.Control
+	}
+	if v2CreatePolicyOptions.Description != nil {
+		body["description"] = v2CreatePolicyOptions.Description
+	}
+	if v2CreatePolicyOptions.Subject != nil {
+		body["subject"] = v2CreatePolicyOptions.Subject
+	}
+	if v2CreatePolicyOptions.Resource != nil {
+		body["resource"] = v2CreatePolicyOptions.Resource
+	}
+	if v2CreatePolicyOptions.Pattern != nil {
+		body["pattern"] = v2CreatePolicyOptions.Pattern
+	}
+	if v2CreatePolicyOptions.Rule != nil {
+		body["rule"] = v2CreatePolicyOptions.Rule
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamPolicyManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalV2Policy)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// V2UpdatePolicy : Update a policy
+// Update a policy to grant access between a subject and a resource. A policy administrator might want to update an
+// existing policy.
+//
+// ### Access
+//
+// To update an access policy, use **`"type": "access"`** in the body. The possible subject attributes are **`iam_id`**
+// and **`access_group_id`**. Use the **`iam_id`** subject attribute for assigning access for a user or service-id. Use
+// the **`access_group_id`** subject attribute for assigning access for an access group. The roles must be a subset of a
+// service's or the platform's supported roles. The resource attributes must be a subset of a service's or the
+// platform's supported attributes. The policy resource must include either the **`serviceType`**, **`serviceName`**,
+// or **`resourceGroupId`** attribute and the **`accountId`** attribute.` The rule field can either specify single
+// **`key`**, **`value`**, and **`operator`** or be set of **`conditions`** with a combination **`operator`**.  The
+// possible combination operator are **`and`** and **`or`**. The rule field has a maximum of 2 levels of nested
+// **`conditions`**. If the subject is a locked service-id, the request will fail.
+//
+// ### Attribute Operators
+//
+// Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more information,
+// see [how to assign access by using wildcards policies](https://cloud.ibm.com/docs/account?topic=account-wildcard).
+//
+// ### Attribute Validations
+//
+// Policy attribute values must be between 1 and 1,000 characters in length. If location related attributes like
+// geography, country, metro, region, satellite, and locationvalues are supported by the service, they are validated
+// against Global Catalog locations.
+func (iamPolicyManagement *IamPolicyManagementV1) V2UpdatePolicy(v2UpdatePolicyOptions *V2UpdatePolicyOptions) (result *V2Policy, response *core.DetailedResponse, err error) {
+	return iamPolicyManagement.V2UpdatePolicyWithContext(context.Background(), v2UpdatePolicyOptions)
+}
+
+// V2UpdatePolicyWithContext is an alternate form of the V2UpdatePolicy method which supports a Context parameter
+func (iamPolicyManagement *IamPolicyManagementV1) V2UpdatePolicyWithContext(ctx context.Context, v2UpdatePolicyOptions *V2UpdatePolicyOptions) (result *V2Policy, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(v2UpdatePolicyOptions, "v2UpdatePolicyOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(v2UpdatePolicyOptions, "v2UpdatePolicyOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"policy_id": *v2UpdatePolicyOptions.PolicyID,
+	}
+
+	builder := core.NewRequestBuilder(core.PUT)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamPolicyManagement.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamPolicyManagement.Service.Options.URL, `/v2/policies/{policy_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range v2UpdatePolicyOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "V2UpdatePolicy")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if v2UpdatePolicyOptions.IfMatch != nil {
+		builder.AddHeader("If-Match", fmt.Sprint(*v2UpdatePolicyOptions.IfMatch))
+	}
+
+	body := make(map[string]interface{})
+	if v2UpdatePolicyOptions.Type != nil {
+		body["type"] = v2UpdatePolicyOptions.Type
+	}
+	if v2UpdatePolicyOptions.Control != nil {
+		body["control"] = v2UpdatePolicyOptions.Control
+	}
+	if v2UpdatePolicyOptions.Description != nil {
+		body["description"] = v2UpdatePolicyOptions.Description
+	}
+	if v2UpdatePolicyOptions.Subject != nil {
+		body["subject"] = v2UpdatePolicyOptions.Subject
+	}
+	if v2UpdatePolicyOptions.Resource != nil {
+		body["resource"] = v2UpdatePolicyOptions.Resource
+	}
+	if v2UpdatePolicyOptions.Pattern != nil {
+		body["pattern"] = v2UpdatePolicyOptions.Pattern
+	}
+	if v2UpdatePolicyOptions.Rule != nil {
+		body["rule"] = v2UpdatePolicyOptions.Rule
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamPolicyManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalV2Policy)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// V2GetPolicy : Retrieve a policy by ID
+// Retrieve a policy by providing a policy ID.
+func (iamPolicyManagement *IamPolicyManagementV1) V2GetPolicy(v2GetPolicyOptions *V2GetPolicyOptions) (result *Policy, response *core.DetailedResponse, err error) {
+	return iamPolicyManagement.V2GetPolicyWithContext(context.Background(), v2GetPolicyOptions)
+}
+
+// V2GetPolicyWithContext is an alternate form of the V2GetPolicy method which supports a Context parameter
+func (iamPolicyManagement *IamPolicyManagementV1) V2GetPolicyWithContext(ctx context.Context, v2GetPolicyOptions *V2GetPolicyOptions) (result *Policy, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(v2GetPolicyOptions, "v2GetPolicyOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(v2GetPolicyOptions, "v2GetPolicyOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"policy_id": *v2GetPolicyOptions.PolicyID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamPolicyManagement.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamPolicyManagement.Service.Options.URL, `/v2/policies/{policy_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range v2GetPolicyOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "V2GetPolicy")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamPolicyManagement.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPolicy)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// V2DeletePolicy : Delete a policy by ID
+// Delete a policy by providing a policy ID. A policy cannot be deleted if the subject ID contains a locked service ID.
+// If the subject of the policy is a locked service-id, the request will fail.
+func (iamPolicyManagement *IamPolicyManagementV1) V2DeletePolicy(v2DeletePolicyOptions *V2DeletePolicyOptions) (response *core.DetailedResponse, err error) {
+	return iamPolicyManagement.V2DeletePolicyWithContext(context.Background(), v2DeletePolicyOptions)
+}
+
+// V2DeletePolicyWithContext is an alternate form of the V2DeletePolicy method which supports a Context parameter
+func (iamPolicyManagement *IamPolicyManagementV1) V2DeletePolicyWithContext(ctx context.Context, v2DeletePolicyOptions *V2DeletePolicyOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(v2DeletePolicyOptions, "v2DeletePolicyOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(v2DeletePolicyOptions, "v2DeletePolicyOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"policy_id": *v2DeletePolicyOptions.PolicyID,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamPolicyManagement.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamPolicyManagement.Service.Options.URL, `/v2/policies/{policy_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range v2DeletePolicyOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_policy_management", "V1", "V2DeletePolicy")
 	for headerName, headerValue := range sdkHeaders {
 		builder.AddHeader(headerName, headerValue)
 	}
@@ -1780,6 +2209,563 @@ func (options *UpdateRoleOptions) SetHeaders(param map[string]string) *UpdateRol
 	return options
 }
 
+// V2CreatePolicyOptions : The V2CreatePolicy options.
+type V2CreatePolicyOptions struct {
+	// The policy type; either 'access' or 'authorization'.
+	Type *string `json:"type" validate:"required"`
+
+	// Specifies the type of access granted by the policy.
+	Control *V2PolicyBaseControl `json:"control" validate:"required"`
+
+	// Customer-defined description.
+	Description *string `json:"description,omitempty"`
+
+	// The subject attributes associated with a policy.
+	Subject *V2PolicyBaseSubject `json:"subject,omitempty"`
+
+	// The resource attributes associated with a policy.
+	Resource *V2PolicyBaseResource `json:"resource,omitempty"`
+
+	// Indicates pattern of rule.
+	Pattern *string `json:"pattern,omitempty"`
+
+	// Additional access conditions associated with a policy.
+	Rule V2PolicyBaseRuleIntf `json:"rule,omitempty"`
+
+	// Language code for translations
+	// * `default` - English
+	// * `de` -  German (Standard)
+	// * `en` - English
+	// * `es` - Spanish (Spain)
+	// * `fr` - French (Standard)
+	// * `it` - Italian (Standard)
+	// * `ja` - Japanese
+	// * `ko` - Korean
+	// * `pt-br` - Portuguese (Brazil)
+	// * `zh-cn` - Chinese (Simplified, PRC)
+	// * `zh-tw` - (Chinese, Taiwan).
+	AcceptLanguage *string `json:"Accept-Language,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewV2CreatePolicyOptions : Instantiate V2CreatePolicyOptions
+func (*IamPolicyManagementV1) NewV2CreatePolicyOptions(typeVar string, control *V2PolicyBaseControl) *V2CreatePolicyOptions {
+	return &V2CreatePolicyOptions{
+		Type: core.StringPtr(typeVar),
+		Control: control,
+	}
+}
+
+// SetType : Allow user to set Type
+func (_options *V2CreatePolicyOptions) SetType(typeVar string) *V2CreatePolicyOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetControl : Allow user to set Control
+func (_options *V2CreatePolicyOptions) SetControl(control *V2PolicyBaseControl) *V2CreatePolicyOptions {
+	_options.Control = control
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *V2CreatePolicyOptions) SetDescription(description string) *V2CreatePolicyOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetSubject : Allow user to set Subject
+func (_options *V2CreatePolicyOptions) SetSubject(subject *V2PolicyBaseSubject) *V2CreatePolicyOptions {
+	_options.Subject = subject
+	return _options
+}
+
+// SetResource : Allow user to set Resource
+func (_options *V2CreatePolicyOptions) SetResource(resource *V2PolicyBaseResource) *V2CreatePolicyOptions {
+	_options.Resource = resource
+	return _options
+}
+
+// SetPattern : Allow user to set Pattern
+func (_options *V2CreatePolicyOptions) SetPattern(pattern string) *V2CreatePolicyOptions {
+	_options.Pattern = core.StringPtr(pattern)
+	return _options
+}
+
+// SetRule : Allow user to set Rule
+func (_options *V2CreatePolicyOptions) SetRule(rule V2PolicyBaseRuleIntf) *V2CreatePolicyOptions {
+	_options.Rule = rule
+	return _options
+}
+
+// SetAcceptLanguage : Allow user to set AcceptLanguage
+func (_options *V2CreatePolicyOptions) SetAcceptLanguage(acceptLanguage string) *V2CreatePolicyOptions {
+	_options.AcceptLanguage = core.StringPtr(acceptLanguage)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *V2CreatePolicyOptions) SetHeaders(param map[string]string) *V2CreatePolicyOptions {
+	options.Headers = param
+	return options
+}
+
+// V2DeletePolicyOptions : The V2DeletePolicy options.
+type V2DeletePolicyOptions struct {
+	// The policy ID.
+	PolicyID *string `json:"policy_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewV2DeletePolicyOptions : Instantiate V2DeletePolicyOptions
+func (*IamPolicyManagementV1) NewV2DeletePolicyOptions(policyID string) *V2DeletePolicyOptions {
+	return &V2DeletePolicyOptions{
+		PolicyID: core.StringPtr(policyID),
+	}
+}
+
+// SetPolicyID : Allow user to set PolicyID
+func (_options *V2DeletePolicyOptions) SetPolicyID(policyID string) *V2DeletePolicyOptions {
+	_options.PolicyID = core.StringPtr(policyID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *V2DeletePolicyOptions) SetHeaders(param map[string]string) *V2DeletePolicyOptions {
+	options.Headers = param
+	return options
+}
+
+// V2GetPolicyOptions : The V2GetPolicy options.
+type V2GetPolicyOptions struct {
+	// The policy ID.
+	PolicyID *string `json:"policy_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewV2GetPolicyOptions : Instantiate V2GetPolicyOptions
+func (*IamPolicyManagementV1) NewV2GetPolicyOptions(policyID string) *V2GetPolicyOptions {
+	return &V2GetPolicyOptions{
+		PolicyID: core.StringPtr(policyID),
+	}
+}
+
+// SetPolicyID : Allow user to set PolicyID
+func (_options *V2GetPolicyOptions) SetPolicyID(policyID string) *V2GetPolicyOptions {
+	_options.PolicyID = core.StringPtr(policyID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *V2GetPolicyOptions) SetHeaders(param map[string]string) *V2GetPolicyOptions {
+	options.Headers = param
+	return options
+}
+
+// V2ListPoliciesOptions : The V2ListPolicies options.
+type V2ListPoliciesOptions struct {
+	// The account GUID in which the policies belong to.
+	AccountID *string `json:"account_id" validate:"required"`
+
+	// Language code for translations
+	// * `default` - English
+	// * `de` -  German (Standard)
+	// * `en` - English
+	// * `es` - Spanish (Spain)
+	// * `fr` - French (Standard)
+	// * `it` - Italian (Standard)
+	// * `ja` - Japanese
+	// * `ko` - Korean
+	// * `pt-br` - Portuguese (Brazil)
+	// * `zh-cn` - Chinese (Simplified, PRC)
+	// * `zh-tw` - (Chinese, Taiwan).
+	AcceptLanguage *string `json:"Accept-Language,omitempty"`
+
+	// Optional IAM ID used to identify the subject.
+	IamID *string `json:"iam_id,omitempty"`
+
+	// Optional access group id.
+	AccessGroupID *string `json:"access_group_id,omitempty"`
+
+	// Optional type of policy.
+	Type *string `json:"type,omitempty"`
+
+	// Optional type of service.
+	ServiceType *string `json:"service_type,omitempty"`
+
+	// Optional name of service.
+	ServiceName *string `json:"service_name,omitempty"`
+
+	// Optional ID of service group.
+	ServiceGroupID *string `json:"service_group_id,omitempty"`
+
+	// Include additional data per policy returned
+	// * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times
+	// it has done so
+	// * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
+	// fields.
+	Format *string `json:"format,omitempty"`
+
+	// The state of the policy.
+	// * `active` - returns active policies
+	// * `deleted` - returns non-active policies.
+	State *string `json:"state,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the V2ListPoliciesOptions.Type property.
+// Optional type of policy.
+const (
+	V2ListPoliciesOptionsTypeAccessConst = "access"
+	V2ListPoliciesOptionsTypeAuthorizationConst = "authorization"
+)
+
+// Constants associated with the V2ListPoliciesOptions.ServiceType property.
+// Optional type of service.
+const (
+	V2ListPoliciesOptionsServiceTypePlatformServiceConst = "platform_service"
+	V2ListPoliciesOptionsServiceTypeServiceConst = "service"
+)
+
+// Constants associated with the V2ListPoliciesOptions.Format property.
+// Include additional data per policy returned
+// * `include_last_permit` - returns details of when the policy last granted a permit decision and the number of times
+// it has done so
+// * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
+// fields.
+const (
+	V2ListPoliciesOptionsFormatDisplayConst = "display"
+	V2ListPoliciesOptionsFormatIncludeLastPermitConst = "include_last_permit"
+)
+
+// Constants associated with the V2ListPoliciesOptions.State property.
+// The state of the policy.
+// * `active` - returns active policies
+// * `deleted` - returns non-active policies.
+const (
+	V2ListPoliciesOptionsStateActiveConst = "active"
+	V2ListPoliciesOptionsStateDeletedConst = "deleted"
+)
+
+// NewV2ListPoliciesOptions : Instantiate V2ListPoliciesOptions
+func (*IamPolicyManagementV1) NewV2ListPoliciesOptions(accountID string) *V2ListPoliciesOptions {
+	return &V2ListPoliciesOptions{
+		AccountID: core.StringPtr(accountID),
+	}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *V2ListPoliciesOptions) SetAccountID(accountID string) *V2ListPoliciesOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetAcceptLanguage : Allow user to set AcceptLanguage
+func (_options *V2ListPoliciesOptions) SetAcceptLanguage(acceptLanguage string) *V2ListPoliciesOptions {
+	_options.AcceptLanguage = core.StringPtr(acceptLanguage)
+	return _options
+}
+
+// SetIamID : Allow user to set IamID
+func (_options *V2ListPoliciesOptions) SetIamID(iamID string) *V2ListPoliciesOptions {
+	_options.IamID = core.StringPtr(iamID)
+	return _options
+}
+
+// SetAccessGroupID : Allow user to set AccessGroupID
+func (_options *V2ListPoliciesOptions) SetAccessGroupID(accessGroupID string) *V2ListPoliciesOptions {
+	_options.AccessGroupID = core.StringPtr(accessGroupID)
+	return _options
+}
+
+// SetType : Allow user to set Type
+func (_options *V2ListPoliciesOptions) SetType(typeVar string) *V2ListPoliciesOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetServiceType : Allow user to set ServiceType
+func (_options *V2ListPoliciesOptions) SetServiceType(serviceType string) *V2ListPoliciesOptions {
+	_options.ServiceType = core.StringPtr(serviceType)
+	return _options
+}
+
+// SetServiceName : Allow user to set ServiceName
+func (_options *V2ListPoliciesOptions) SetServiceName(serviceName string) *V2ListPoliciesOptions {
+	_options.ServiceName = core.StringPtr(serviceName)
+	return _options
+}
+
+// SetServiceGroupID : Allow user to set ServiceGroupID
+func (_options *V2ListPoliciesOptions) SetServiceGroupID(serviceGroupID string) *V2ListPoliciesOptions {
+	_options.ServiceGroupID = core.StringPtr(serviceGroupID)
+	return _options
+}
+
+// SetFormat : Allow user to set Format
+func (_options *V2ListPoliciesOptions) SetFormat(format string) *V2ListPoliciesOptions {
+	_options.Format = core.StringPtr(format)
+	return _options
+}
+
+// SetState : Allow user to set State
+func (_options *V2ListPoliciesOptions) SetState(state string) *V2ListPoliciesOptions {
+	_options.State = core.StringPtr(state)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *V2ListPoliciesOptions) SetHeaders(param map[string]string) *V2ListPoliciesOptions {
+	options.Headers = param
+	return options
+}
+
+// V2PolicyBaseControl : Specifies the type of access granted by the policy.
+type V2PolicyBaseControl struct {
+	// Permission granted by the policy.
+	Grant *V2PolicyBaseControlGrant `json:"grant" validate:"required"`
+}
+
+// NewV2PolicyBaseControl : Instantiate V2PolicyBaseControl (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewV2PolicyBaseControl(grant *V2PolicyBaseControlGrant) (_model *V2PolicyBaseControl, err error) {
+	_model = &V2PolicyBaseControl{
+		Grant: grant,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalV2PolicyBaseControl unmarshals an instance of V2PolicyBaseControl from the specified map of raw messages.
+func UnmarshalV2PolicyBaseControl(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseControl)
+	err = core.UnmarshalModel(m, "grant", &obj.Grant, UnmarshalV2PolicyBaseControlGrant)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseControlGrant : Permission granted by the policy.
+type V2PolicyBaseControlGrant struct {
+	// A set of role cloud resource names (CRNs) granted by the policy.
+	Roles []PolicyRole `json:"roles" validate:"required"`
+}
+
+// NewV2PolicyBaseControlGrant : Instantiate V2PolicyBaseControlGrant (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewV2PolicyBaseControlGrant(roles []PolicyRole) (_model *V2PolicyBaseControlGrant, err error) {
+	_model = &V2PolicyBaseControlGrant{
+		Roles: roles,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalV2PolicyBaseControlGrant unmarshals an instance of V2PolicyBaseControlGrant from the specified map of raw messages.
+func UnmarshalV2PolicyBaseControlGrant(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseControlGrant)
+	err = core.UnmarshalModel(m, "roles", &obj.Roles, UnmarshalPolicyRole)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseResource : The resource attributes associated with a policy.
+type V2PolicyBaseResource struct {
+	// List of resource attributes associated with policy/.
+	Attributes []V2PolicyAttribute `json:"attributes,omitempty"`
+}
+
+// UnmarshalV2PolicyBaseResource unmarshals an instance of V2PolicyBaseResource from the specified map of raw messages.
+func UnmarshalV2PolicyBaseResource(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseResource)
+	err = core.UnmarshalModel(m, "attributes", &obj.Attributes, UnmarshalV2PolicyAttribute)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseRule : Additional access conditions associated with a policy.
+// Models which "extend" this model:
+// - V2PolicyBaseRuleV2PolicyAttribute
+// - V2PolicyBaseRuleV2RuleWithConditions
+type V2PolicyBaseRule struct {
+	// The name of an attribute.
+	Key *string `json:"key,omitempty"`
+
+	// The operator of an attribute.
+	Operator *string `json:"operator,omitempty"`
+
+	// The value of an attribute; can be array, boolean, string, or integer.
+	Value interface{} `json:"value,omitempty"`
+
+	// List of conditions to associated with a policy. Note that conditions can be nested up to 2 levels.
+	Conditions []V2PolicyAttribute `json:"conditions,omitempty"`
+}
+func (*V2PolicyBaseRule) isaV2PolicyBaseRule() bool {
+	return true
+}
+
+type V2PolicyBaseRuleIntf interface {
+	isaV2PolicyBaseRule() bool
+}
+
+// UnmarshalV2PolicyBaseRule unmarshals an instance of V2PolicyBaseRule from the specified map of raw messages.
+func UnmarshalV2PolicyBaseRule(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseRule)
+	err = core.UnmarshalPrimitive(m, "key", &obj.Key)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "operator", &obj.Operator)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalV2PolicyAttribute)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseSubject : The subject attributes associated with a policy.
+type V2PolicyBaseSubject struct {
+	// List of subject attributes associated with policy/.
+	Attributes []V2PolicyAttribute `json:"attributes,omitempty"`
+}
+
+// UnmarshalV2PolicyBaseSubject unmarshals an instance of V2PolicyBaseSubject from the specified map of raw messages.
+func UnmarshalV2PolicyBaseSubject(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseSubject)
+	err = core.UnmarshalModel(m, "attributes", &obj.Attributes, UnmarshalV2PolicyAttribute)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2UpdatePolicyOptions : The V2UpdatePolicy options.
+type V2UpdatePolicyOptions struct {
+	// The policy ID.
+	PolicyID *string `json:"policy_id" validate:"required,ne="`
+
+	// The revision number for updating a policy and must match the ETag value of the existing policy. The Etag can be
+	// retrieved using the GET /v1/policies/{policy_id} API and looking at the ETag response header.
+	IfMatch *string `json:"If-Match" validate:"required"`
+
+	// The policy type; either 'access' or 'authorization'.
+	Type *string `json:"type" validate:"required"`
+
+	// Specifies the type of access granted by the policy.
+	Control *V2PolicyBaseControl `json:"control" validate:"required"`
+
+	// Customer-defined description.
+	Description *string `json:"description,omitempty"`
+
+	// The subject attributes associated with a policy.
+	Subject *V2PolicyBaseSubject `json:"subject,omitempty"`
+
+	// The resource attributes associated with a policy.
+	Resource *V2PolicyBaseResource `json:"resource,omitempty"`
+
+	// Indicates pattern of rule.
+	Pattern *string `json:"pattern,omitempty"`
+
+	// Additional access conditions associated with a policy.
+	Rule V2PolicyBaseRuleIntf `json:"rule,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewV2UpdatePolicyOptions : Instantiate V2UpdatePolicyOptions
+func (*IamPolicyManagementV1) NewV2UpdatePolicyOptions(policyID string, ifMatch string, typeVar string, control *V2PolicyBaseControl) *V2UpdatePolicyOptions {
+	return &V2UpdatePolicyOptions{
+		PolicyID: core.StringPtr(policyID),
+		IfMatch: core.StringPtr(ifMatch),
+		Type: core.StringPtr(typeVar),
+		Control: control,
+	}
+}
+
+// SetPolicyID : Allow user to set PolicyID
+func (_options *V2UpdatePolicyOptions) SetPolicyID(policyID string) *V2UpdatePolicyOptions {
+	_options.PolicyID = core.StringPtr(policyID)
+	return _options
+}
+
+// SetIfMatch : Allow user to set IfMatch
+func (_options *V2UpdatePolicyOptions) SetIfMatch(ifMatch string) *V2UpdatePolicyOptions {
+	_options.IfMatch = core.StringPtr(ifMatch)
+	return _options
+}
+
+// SetType : Allow user to set Type
+func (_options *V2UpdatePolicyOptions) SetType(typeVar string) *V2UpdatePolicyOptions {
+	_options.Type = core.StringPtr(typeVar)
+	return _options
+}
+
+// SetControl : Allow user to set Control
+func (_options *V2UpdatePolicyOptions) SetControl(control *V2PolicyBaseControl) *V2UpdatePolicyOptions {
+	_options.Control = control
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *V2UpdatePolicyOptions) SetDescription(description string) *V2UpdatePolicyOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetSubject : Allow user to set Subject
+func (_options *V2UpdatePolicyOptions) SetSubject(subject *V2PolicyBaseSubject) *V2UpdatePolicyOptions {
+	_options.Subject = subject
+	return _options
+}
+
+// SetResource : Allow user to set Resource
+func (_options *V2UpdatePolicyOptions) SetResource(resource *V2PolicyBaseResource) *V2UpdatePolicyOptions {
+	_options.Resource = resource
+	return _options
+}
+
+// SetPattern : Allow user to set Pattern
+func (_options *V2UpdatePolicyOptions) SetPattern(pattern string) *V2UpdatePolicyOptions {
+	_options.Pattern = core.StringPtr(pattern)
+	return _options
+}
+
+// SetRule : Allow user to set Rule
+func (_options *V2UpdatePolicyOptions) SetRule(rule V2PolicyBaseRuleIntf) *V2UpdatePolicyOptions {
+	_options.Rule = rule
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *V2UpdatePolicyOptions) SetHeaders(param map[string]string) *V2UpdatePolicyOptions {
+	options.Headers = param
+	return options
+}
+
 // CustomRole : An additional set of properties associated with a role.
 type CustomRole struct {
 	// The role ID. Composed of hexadecimal characters.
@@ -2262,6 +3248,273 @@ func UnmarshalSubjectAttribute(m map[string]json.RawMessage, result interface{})
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2Policy : The core set of properties associated with a policy.
+type V2Policy struct {
+	// The policy ID.
+	ID *string `json:"id,omitempty"`
+
+	// The policy type; either 'access' or 'authorization'.
+	Type *string `json:"type" validate:"required"`
+
+	// Customer-defined description.
+	Description *string `json:"description,omitempty"`
+
+	// The subject attributes associated with a policy.
+	Subject *V2PolicyBaseSubject `json:"subject,omitempty"`
+
+	// Specifies the type of access granted by the policy.
+	Control *V2PolicyBaseControl `json:"control" validate:"required"`
+
+	// The resource attributes associated with a policy.
+	Resource *V2PolicyBaseResource `json:"resource,omitempty"`
+
+	// Indicates pattern of rule.
+	Pattern *string `json:"pattern,omitempty"`
+
+	// Additional access conditions associated with a policy.
+	Rule V2PolicyBaseRuleIntf `json:"rule,omitempty"`
+
+	// The href link back to the policy.
+	Href *string `json:"href,omitempty"`
+
+	// The UTC timestamp when the policy was created.
+	CreatedAt *strfmt.DateTime `json:"created_at,omitempty"`
+
+	// The iam ID of the entity that created the policy.
+	CreatedByID *string `json:"created_by_id,omitempty"`
+
+	// The UTC timestamp when the policy was last modified.
+	LastModifiedAt *strfmt.DateTime `json:"last_modified_at,omitempty"`
+
+	// The iam ID of the entity that last modified the policy.
+	LastModifiedByID *string `json:"last_modified_by_id,omitempty"`
+
+	// The policy state.
+	State *string `json:"state,omitempty"`
+}
+
+// Constants associated with the V2Policy.State property.
+// The policy state.
+const (
+	V2PolicyStateActiveConst = "active"
+	V2PolicyStateDeletedConst = "deleted"
+)
+
+// UnmarshalV2Policy unmarshals an instance of V2Policy from the specified map of raw messages.
+func UnmarshalV2Policy(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2Policy)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "subject", &obj.Subject, UnmarshalV2PolicyBaseSubject)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "control", &obj.Control, UnmarshalV2PolicyBaseControl)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "resource", &obj.Resource, UnmarshalV2PolicyBaseResource)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "pattern", &obj.Pattern)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "rule", &obj.Rule, UnmarshalV2PolicyBaseRule)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_by_id", &obj.CreatedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_at", &obj.LastModifiedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_by_id", &obj.LastModifiedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "state", &obj.State)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyAttribute : Resource/subject attribute associated with policy attributes.
+type V2PolicyAttribute struct {
+	// The name of an attribute.
+	Key *string `json:"key" validate:"required"`
+
+	// The operator of an attribute.
+	Operator *string `json:"operator" validate:"required"`
+
+	// The value of an attribute; can be array, boolean, string, or integer.
+	Value interface{} `json:"value" validate:"required"`
+}
+
+// NewV2PolicyAttribute : Instantiate V2PolicyAttribute (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewV2PolicyAttribute(key string, operator string, value interface{}) (_model *V2PolicyAttribute, err error) {
+	_model = &V2PolicyAttribute{
+		Key: core.StringPtr(key),
+		Operator: core.StringPtr(operator),
+		Value: value,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalV2PolicyAttribute unmarshals an instance of V2PolicyAttribute from the specified map of raw messages.
+func UnmarshalV2PolicyAttribute(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyAttribute)
+	err = core.UnmarshalPrimitive(m, "key", &obj.Key)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "operator", &obj.Operator)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyList : A collection of policies.
+type V2PolicyList struct {
+	// List of policies.
+	Policies []V2Policy `json:"policies,omitempty"`
+}
+
+// UnmarshalV2PolicyList unmarshals an instance of V2PolicyList from the specified map of raw messages.
+func UnmarshalV2PolicyList(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyList)
+	err = core.UnmarshalModel(m, "policies", &obj.Policies, UnmarshalV2Policy)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseRuleV2PolicyAttribute : Resource/subject attribute associated with policy attributes.
+// This model "extends" V2PolicyBaseRule
+type V2PolicyBaseRuleV2PolicyAttribute struct {
+	// The name of an attribute.
+	Key *string `json:"key" validate:"required"`
+
+	// The operator of an attribute.
+	Operator *string `json:"operator" validate:"required"`
+
+	// The value of an attribute; can be array, boolean, string, or integer.
+	Value interface{} `json:"value" validate:"required"`
+}
+
+// NewV2PolicyBaseRuleV2PolicyAttribute : Instantiate V2PolicyBaseRuleV2PolicyAttribute (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewV2PolicyBaseRuleV2PolicyAttribute(key string, operator string, value interface{}) (_model *V2PolicyBaseRuleV2PolicyAttribute, err error) {
+	_model = &V2PolicyBaseRuleV2PolicyAttribute{
+		Key: core.StringPtr(key),
+		Operator: core.StringPtr(operator),
+		Value: value,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+func (*V2PolicyBaseRuleV2PolicyAttribute) isaV2PolicyBaseRule() bool {
+	return true
+}
+
+// UnmarshalV2PolicyBaseRuleV2PolicyAttribute unmarshals an instance of V2PolicyBaseRuleV2PolicyAttribute from the specified map of raw messages.
+func UnmarshalV2PolicyBaseRuleV2PolicyAttribute(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseRuleV2PolicyAttribute)
+	err = core.UnmarshalPrimitive(m, "key", &obj.Key)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "operator", &obj.Operator)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// V2PolicyBaseRuleV2RuleWithConditions : Policy rule that has 2 to 10 conditions.
+// This model "extends" V2PolicyBaseRule
+type V2PolicyBaseRuleV2RuleWithConditions struct {
+	// Operator to evalute conditions.
+	Operator *string `json:"operator" validate:"required"`
+
+	// List of conditions to associated with a policy. Note that conditions can be nested up to 2 levels.
+	Conditions []V2PolicyAttribute `json:"conditions" validate:"required"`
+}
+
+// Constants associated with the V2PolicyBaseRuleV2RuleWithConditions.Operator property.
+// Operator to evalute conditions.
+const (
+	V2PolicyBaseRuleV2RuleWithConditionsOperatorAndConst = "and"
+	V2PolicyBaseRuleV2RuleWithConditionsOperatorOrConst = "or"
+)
+
+// NewV2PolicyBaseRuleV2RuleWithConditions : Instantiate V2PolicyBaseRuleV2RuleWithConditions (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewV2PolicyBaseRuleV2RuleWithConditions(operator string, conditions []V2PolicyAttribute) (_model *V2PolicyBaseRuleV2RuleWithConditions, err error) {
+	_model = &V2PolicyBaseRuleV2RuleWithConditions{
+		Operator: core.StringPtr(operator),
+		Conditions: conditions,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+func (*V2PolicyBaseRuleV2RuleWithConditions) isaV2PolicyBaseRule() bool {
+	return true
+}
+
+// UnmarshalV2PolicyBaseRuleV2RuleWithConditions unmarshals an instance of V2PolicyBaseRuleV2RuleWithConditions from the specified map of raw messages.
+func UnmarshalV2PolicyBaseRuleV2RuleWithConditions(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(V2PolicyBaseRuleV2RuleWithConditions)
+	err = core.UnmarshalPrimitive(m, "operator", &obj.Operator)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalV2PolicyAttribute)
 	if err != nil {
 		return
 	}

--- a/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
@@ -324,6 +324,190 @@ var _ = Describe(`IamPolicyManagementV1 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(204))
 
 		})
+		It(`V2CreatePolicy request example`, func() {
+			fmt.Println("\nCreatePolicy() result:")
+			// begin-v2_create_policy
+
+			subjectAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:  core.StringPtr("iam_id"),
+				Operator: core.StringPtr("stringEquals"),
+				Value: &exampleUserID,
+			}
+			policySubject := &iampolicymanagementv1.V2PolicyBaseSubject{
+				Attributes: []iampolicymanagementv1.V2PolicyAttribute{*subjectAttribute},
+			}
+			policyRole := &iampolicymanagementv1.PolicyRole{
+				RoleID: core.StringPtr("crn:v1:bluemix:public:iam::::role:Viewer"),
+			}
+			v2PolicyGrant := &iampolicymanagementv1.V2PolicyBaseControlGrant{
+				Roles: []iampolicymanagementv1.PolicyRole{*policyRole},
+			}
+			v2PolicyControl := &iampolicymanagementv1.V2PolicyBaseControl{
+				Grant: v2PolicyGrant,
+			}
+			accountIDResourceAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:     core.StringPtr("accountId"),
+				Operator: core.StringPtr("stringEquals"),
+				Value:    core.StringPtr(exampleAccountID),
+			}
+			serviceNameResourceAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:     core.StringPtr("serviceType"),
+				Operator: core.StringPtr("stringEquals"),
+				Value:    core.StringPtr("service"),
+			}
+			policyResource := &iampolicymanagementv1.V2PolicyBaseResource{
+				Attributes: []iampolicymanagementv1.V2PolicyAttribute{
+					*accountIDResourceAttribute, *serviceNameResourceAttribute},
+			}
+
+			options := iamPolicyManagementService.NewV2CreatePolicyOptions(
+				"access",
+				v2PolicyControl,
+			)
+			options.SetSubject(policySubject)
+			options.SetResource(policyResource)
+
+			policy, response, err := iamPolicyManagementService.V2CreatePolicy(options)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(policy, "", "  ")
+			fmt.Println(string(b))
+
+			// end-create_policy
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(201))
+			Expect(policy).ToNot(BeNil())
+
+			examplePolicyID = *policy.ID
+		})
+		It(`V2GetPolicy request example`, func() {
+			fmt.Println("\nGetPolicy() result:")
+			// begin-get_policy
+
+			options := iamPolicyManagementService.NewV2GetPolicyOptions(
+				examplePolicyID,
+			)
+
+			policy, response, err := iamPolicyManagementService.V2GetPolicy(options)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(policy, "", "  ")
+			fmt.Println(string(b))
+
+			// end-get_policy
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(policy).ToNot(BeNil())
+
+			examplePolicyETag = response.GetHeaders().Get("ETag")
+		})
+		It(`V2UpdatePolicy request example`, func() {
+			fmt.Println("\nUpdatePolicy() result:")
+			// begin-update_policy
+
+			subjectAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:  core.StringPtr("iam_id"),
+				Operator: core.StringPtr("stringEquals"),
+				Value: &exampleUserID,
+			}
+			policySubject := &iampolicymanagementv1.V2PolicyBaseSubject{
+				Attributes: []iampolicymanagementv1.V2PolicyAttribute{*subjectAttribute},
+			}
+			updatedPolicyRole := &iampolicymanagementv1.PolicyRole{
+				RoleID: core.StringPtr("crn:v1:bluemix:public:iam::::role:Editor"),
+			}
+			v2PolicyGrant := &iampolicymanagementv1.V2PolicyBaseControlGrant{
+				Roles: []iampolicymanagementv1.PolicyRole{*updatedPolicyRole},
+			}
+			v2PolicyControl := &iampolicymanagementv1.V2PolicyBaseControl{
+				Grant: v2PolicyGrant,
+			}
+			accountIDResourceAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:     core.StringPtr("accountId"),
+				Operator: core.StringPtr("stringEquals"),
+				Value:    core.StringPtr(exampleAccountID),
+			}
+			serviceNameResourceAttribute := &iampolicymanagementv1.V2PolicyAttribute{
+				Key:     core.StringPtr("serviceType"),
+				Operator: core.StringPtr("stringEquals"),
+				Value:    core.StringPtr("service"),
+			}
+			policyResource := &iampolicymanagementv1.V2PolicyBaseResource{
+				Attributes: []iampolicymanagementv1.V2PolicyAttribute{
+					*accountIDResourceAttribute, *serviceNameResourceAttribute},
+			}
+
+			options := iamPolicyManagementService.NewV2UpdatePolicyOptions(
+				examplePolicyID,
+				examplePolicyETag,
+				"access",
+				v2PolicyControl,
+			)
+			options.SetSubject(policySubject)
+			options.SetResource(policyResource)
+
+
+			policy, response, err := iamPolicyManagementService.V2UpdatePolicy(options)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(policy, "", "  ")
+			fmt.Println(string(b))
+
+			// end-update_policy
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(policy).ToNot(BeNil())
+
+			examplePolicyETag = response.GetHeaders().Get("ETag")
+		})
+		It(`V2ListPolicies request example`, func() {
+			fmt.Println("\nListPolicies() result:")
+			// begin-list_policies
+
+			options := iamPolicyManagementService.NewV2ListPoliciesOptions(
+				exampleAccountID,
+			)
+			options.SetIamID(exampleUserID)
+			options.SetFormat("include_last_permit")
+
+			policyList, response, err := iamPolicyManagementService.V2ListPolicies(options)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(policyList, "", "  ")
+			fmt.Println(string(b))
+
+			// end-list_policies
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(policyList).ToNot(BeNil())
+
+		})
+		It(`V2DeletePolicy request example`, func() {
+			// begin-delete_policy
+
+			options := iamPolicyManagementService.NewV2DeletePolicyOptions(
+				examplePolicyID,
+			)
+
+			response, err := iamPolicyManagementService.V2DeletePolicy(options)
+			if err != nil {
+				panic(err)
+			}
+
+			// end-delete_policy
+			fmt.Printf("\nDeletePolicy() response status code: %d\n", response.StatusCode)
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
+
+		})
 		It(`CreateRole request example`, func() {
 			fmt.Println("\nCreateRole() result:")
 			// begin-create_role

--- a/iampolicymanagementv1/iam_policy_management_v1_suite_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2021.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,7 +187,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.URL.Query()["state"]).To(Equal([]string{"active"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListPolicies with error: Operation response processing error`, func() {
@@ -475,7 +475,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreatePolicy with error: Operation response processing error`, func() {
@@ -900,7 +900,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdatePolicy with error: Operation response processing error`, func() {
@@ -1328,7 +1328,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetPolicy with error: Operation response processing error`, func() {
@@ -1610,7 +1610,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke PatchPolicy with error: Operation response processing error`, func() {
@@ -1874,7 +1874,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.URL.Query()["policy_type"]).To(Equal([]string{"authorization"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke ListRoles with error: Operation response processing error`, func() {
@@ -2113,7 +2113,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke CreateRole with error: Operation response processing error`, func() {
@@ -2393,7 +2393,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke UpdateRole with error: Operation response processing error`, func() {
@@ -2661,7 +2661,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.Method).To(Equal("GET"))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, `} this is not valid json {`)
+					fmt.Fprint(res, `} this is not valid json {`)
 				}))
 			})
 			It(`Invoke GetRole with error: Operation response processing error`, func() {
@@ -2921,6 +2921,1471 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				deleteRoleOptionsModelNew := new(iampolicymanagementv1.DeleteRoleOptions)
 				// Invoke operation with invalid model (negative test)
 				response, operationErr = iamPolicyManagementService.DeleteRole(deleteRoleOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2ListPolicies(v2ListPoliciesOptions *V2ListPoliciesOptions) - Operation response error`, func() {
+		v2ListPoliciesPath := "/v2/policies"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2ListPoliciesPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["iam_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["access_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"access"}))
+					Expect(req.URL.Query()["service_type"]).To(Equal([]string{"service"}))
+					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["format"]).To(Equal([]string{"include_last_permit"}))
+					Expect(req.URL.Query()["state"]).To(Equal([]string{"active"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke V2ListPolicies with error: Operation response processing error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2ListPoliciesOptions model
+				v2ListPoliciesOptionsModel := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				v2ListPoliciesOptionsModel.AccountID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2ListPoliciesOptionsModel.IamID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AccessGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Type = core.StringPtr("access")
+				v2ListPoliciesOptionsModel.ServiceType = core.StringPtr("service")
+				v2ListPoliciesOptionsModel.ServiceName = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.ServiceGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Format = core.StringPtr("include_last_permit")
+				v2ListPoliciesOptionsModel.State = core.StringPtr("active")
+				v2ListPoliciesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamPolicyManagementService.EnableRetries(0, 0)
+				result, response, operationErr = iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2ListPolicies(v2ListPoliciesOptions *V2ListPoliciesOptions)`, func() {
+		v2ListPoliciesPath := "/v2/policies"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2ListPoliciesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["iam_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["access_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"access"}))
+					Expect(req.URL.Query()["service_type"]).To(Equal([]string{"service"}))
+					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["format"]).To(Equal([]string{"include_last_permit"}))
+					Expect(req.URL.Query()["state"]).To(Equal([]string{"active"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"policies": [{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}]}`)
+				}))
+			})
+			It(`Invoke V2ListPolicies successfully with retries`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+				iamPolicyManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the V2ListPoliciesOptions model
+				v2ListPoliciesOptionsModel := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				v2ListPoliciesOptionsModel.AccountID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2ListPoliciesOptionsModel.IamID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AccessGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Type = core.StringPtr("access")
+				v2ListPoliciesOptionsModel.ServiceType = core.StringPtr("service")
+				v2ListPoliciesOptionsModel.ServiceName = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.ServiceGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Format = core.StringPtr("include_last_permit")
+				v2ListPoliciesOptionsModel.State = core.StringPtr("active")
+				v2ListPoliciesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamPolicyManagementService.V2ListPoliciesWithContext(ctx, v2ListPoliciesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamPolicyManagementService.DisableRetries()
+				result, response, operationErr := iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamPolicyManagementService.V2ListPoliciesWithContext(ctx, v2ListPoliciesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2ListPoliciesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["iam_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["access_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["type"]).To(Equal([]string{"access"}))
+					Expect(req.URL.Query()["service_type"]).To(Equal([]string{"service"}))
+					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["format"]).To(Equal([]string{"include_last_permit"}))
+					Expect(req.URL.Query()["state"]).To(Equal([]string{"active"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"policies": [{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}]}`)
+				}))
+			})
+			It(`Invoke V2ListPolicies successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamPolicyManagementService.V2ListPolicies(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the V2ListPoliciesOptions model
+				v2ListPoliciesOptionsModel := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				v2ListPoliciesOptionsModel.AccountID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2ListPoliciesOptionsModel.IamID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AccessGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Type = core.StringPtr("access")
+				v2ListPoliciesOptionsModel.ServiceType = core.StringPtr("service")
+				v2ListPoliciesOptionsModel.ServiceName = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.ServiceGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Format = core.StringPtr("include_last_permit")
+				v2ListPoliciesOptionsModel.State = core.StringPtr("active")
+				v2ListPoliciesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke V2ListPolicies with error: Operation validation and request error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2ListPoliciesOptions model
+				v2ListPoliciesOptionsModel := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				v2ListPoliciesOptionsModel.AccountID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2ListPoliciesOptionsModel.IamID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AccessGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Type = core.StringPtr("access")
+				v2ListPoliciesOptionsModel.ServiceType = core.StringPtr("service")
+				v2ListPoliciesOptionsModel.ServiceName = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.ServiceGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Format = core.StringPtr("include_last_permit")
+				v2ListPoliciesOptionsModel.State = core.StringPtr("active")
+				v2ListPoliciesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamPolicyManagementService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the V2ListPoliciesOptions model with no property values
+				v2ListPoliciesOptionsModelNew := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke V2ListPolicies successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2ListPoliciesOptions model
+				v2ListPoliciesOptionsModel := new(iampolicymanagementv1.V2ListPoliciesOptions)
+				v2ListPoliciesOptionsModel.AccountID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2ListPoliciesOptionsModel.IamID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.AccessGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Type = core.StringPtr("access")
+				v2ListPoliciesOptionsModel.ServiceType = core.StringPtr("service")
+				v2ListPoliciesOptionsModel.ServiceName = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.ServiceGroupID = core.StringPtr("testString")
+				v2ListPoliciesOptionsModel.Format = core.StringPtr("include_last_permit")
+				v2ListPoliciesOptionsModel.State = core.StringPtr("active")
+				v2ListPoliciesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamPolicyManagementService.V2ListPolicies(v2ListPoliciesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2CreatePolicy(v2CreatePolicyOptions *V2CreatePolicyOptions) - Operation response error`, func() {
+		v2CreatePolicyPath := "/v2/policies"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2CreatePolicyPath))
+					Expect(req.Method).To(Equal("POST"))
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke V2CreatePolicy with error: Operation response processing error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsModel := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				v2CreatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2CreatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2CreatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2CreatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2CreatePolicyOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2CreatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamPolicyManagementService.EnableRetries(0, 0)
+				result, response, operationErr = iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2CreatePolicy(v2CreatePolicyOptions *V2CreatePolicyOptions)`, func() {
+		v2CreatePolicyPath := "/v2/policies"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2CreatePolicyPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2CreatePolicy successfully with retries`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+				iamPolicyManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsModel := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				v2CreatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2CreatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2CreatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2CreatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2CreatePolicyOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2CreatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamPolicyManagementService.V2CreatePolicyWithContext(ctx, v2CreatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamPolicyManagementService.DisableRetries()
+				result, response, operationErr := iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamPolicyManagementService.V2CreatePolicyWithContext(ctx, v2CreatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2CreatePolicyPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["Accept-Language"]).ToNot(BeNil())
+					Expect(req.Header["Accept-Language"][0]).To(Equal(fmt.Sprintf("%v", "default")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2CreatePolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamPolicyManagementService.V2CreatePolicy(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsModel := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				v2CreatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2CreatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2CreatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2CreatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2CreatePolicyOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2CreatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke V2CreatePolicy with error: Operation validation and request error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsModel := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				v2CreatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2CreatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2CreatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2CreatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2CreatePolicyOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2CreatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamPolicyManagementService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the V2CreatePolicyOptions model with no property values
+				v2CreatePolicyOptionsModelNew := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke V2CreatePolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsModel := new(iampolicymanagementv1.V2CreatePolicyOptions)
+				v2CreatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2CreatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2CreatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2CreatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2CreatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2CreatePolicyOptionsModel.AcceptLanguage = core.StringPtr("default")
+				v2CreatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamPolicyManagementService.V2CreatePolicy(v2CreatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2UpdatePolicy(v2UpdatePolicyOptions *V2UpdatePolicyOptions) - Operation response error`, func() {
+		v2UpdatePolicyPath := "/v2/policies/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2UpdatePolicyPath))
+					Expect(req.Method).To(Equal("PUT"))
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke V2UpdatePolicy with error: Operation response processing error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				v2UpdatePolicyOptionsModel := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				v2UpdatePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.IfMatch = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2UpdatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2UpdatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2UpdatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2UpdatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamPolicyManagementService.EnableRetries(0, 0)
+				result, response, operationErr = iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2UpdatePolicy(v2UpdatePolicyOptions *V2UpdatePolicyOptions)`, func() {
+		v2UpdatePolicyPath := "/v2/policies/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2UpdatePolicyPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2UpdatePolicy successfully with retries`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+				iamPolicyManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				v2UpdatePolicyOptionsModel := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				v2UpdatePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.IfMatch = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2UpdatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2UpdatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2UpdatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2UpdatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamPolicyManagementService.V2UpdatePolicyWithContext(ctx, v2UpdatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamPolicyManagementService.DisableRetries()
+				result, response, operationErr := iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamPolicyManagementService.V2UpdatePolicyWithContext(ctx, v2UpdatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2UpdatePolicyPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "control": {"grant": {"roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}]}}, "resource": {"attributes": [{"key": "Key", "operator": "Operator", "value": "anyValue"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "Operator", "value": "anyValue"}, "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2UpdatePolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamPolicyManagementService.V2UpdatePolicy(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				v2UpdatePolicyOptionsModel := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				v2UpdatePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.IfMatch = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2UpdatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2UpdatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2UpdatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2UpdatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke V2UpdatePolicy with error: Operation validation and request error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				v2UpdatePolicyOptionsModel := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				v2UpdatePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.IfMatch = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2UpdatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2UpdatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2UpdatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2UpdatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamPolicyManagementService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the V2UpdatePolicyOptions model with no property values
+				v2UpdatePolicyOptionsModelNew := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke V2UpdatePolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				policyRoleModel.RoleID = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				v2UpdatePolicyOptionsModel := new(iampolicymanagementv1.V2UpdatePolicyOptions)
+				v2UpdatePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.IfMatch = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Type = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Control = v2PolicyBaseControlModel
+				v2UpdatePolicyOptionsModel.Description = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Subject = v2PolicyBaseSubjectModel
+				v2UpdatePolicyOptionsModel.Resource = v2PolicyBaseResourceModel
+				v2UpdatePolicyOptionsModel.Pattern = core.StringPtr("testString")
+				v2UpdatePolicyOptionsModel.Rule = v2PolicyBaseRuleModel
+				v2UpdatePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamPolicyManagementService.V2UpdatePolicy(v2UpdatePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2GetPolicy(v2GetPolicyOptions *V2GetPolicyOptions) - Operation response error`, func() {
+		v2GetPolicyPath := "/v2/policies/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2GetPolicyPath))
+					Expect(req.Method).To(Equal("GET"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke V2GetPolicy with error: Operation response processing error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2GetPolicyOptions model
+				v2GetPolicyOptionsModel := new(iampolicymanagementv1.V2GetPolicyOptions)
+				v2GetPolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2GetPolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamPolicyManagementService.EnableRetries(0, 0)
+				result, response, operationErr = iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2GetPolicy(v2GetPolicyOptions *V2GetPolicyOptions)`, func() {
+		v2GetPolicyPath := "/v2/policies/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2GetPolicyPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subjects": [{"attributes": [{"name": "Name", "value": "Value"}]}], "roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}], "resources": [{"attributes": [{"name": "Name", "value": "Value", "operator": "Operator"}], "tags": [{"name": "Name", "value": "Value", "operator": "Operator"}]}], "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2GetPolicy successfully with retries`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+				iamPolicyManagementService.EnableRetries(0, 0)
+
+				// Construct an instance of the V2GetPolicyOptions model
+				v2GetPolicyOptionsModel := new(iampolicymanagementv1.V2GetPolicyOptions)
+				v2GetPolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2GetPolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamPolicyManagementService.V2GetPolicyWithContext(ctx, v2GetPolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamPolicyManagementService.DisableRetries()
+				result, response, operationErr := iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamPolicyManagementService.V2GetPolicyWithContext(ctx, v2GetPolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2GetPolicyPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "type": "Type", "description": "Description", "subjects": [{"attributes": [{"name": "Name", "value": "Value"}]}], "roles": [{"role_id": "RoleID", "display_name": "DisplayName", "description": "Description"}], "resources": [{"attributes": [{"name": "Name", "value": "Value", "operator": "Operator"}], "tags": [{"name": "Name", "value": "Value", "operator": "Operator"}]}], "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active"}`)
+				}))
+			})
+			It(`Invoke V2GetPolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamPolicyManagementService.V2GetPolicy(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the V2GetPolicyOptions model
+				v2GetPolicyOptionsModel := new(iampolicymanagementv1.V2GetPolicyOptions)
+				v2GetPolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2GetPolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke V2GetPolicy with error: Operation validation and request error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2GetPolicyOptions model
+				v2GetPolicyOptionsModel := new(iampolicymanagementv1.V2GetPolicyOptions)
+				v2GetPolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2GetPolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamPolicyManagementService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the V2GetPolicyOptions model with no property values
+				v2GetPolicyOptionsModelNew := new(iampolicymanagementv1.V2GetPolicyOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke V2GetPolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2GetPolicyOptions model
+				v2GetPolicyOptionsModel := new(iampolicymanagementv1.V2GetPolicyOptions)
+				v2GetPolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2GetPolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamPolicyManagementService.V2GetPolicy(v2GetPolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`V2DeletePolicy(v2DeletePolicyOptions *V2DeletePolicyOptions)`, func() {
+		v2DeletePolicyPath := "/v2/policies/testString"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(v2DeletePolicyPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke V2DeletePolicy successfully`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamPolicyManagementService.V2DeletePolicy(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the V2DeletePolicyOptions model
+				v2DeletePolicyOptionsModel := new(iampolicymanagementv1.V2DeletePolicyOptions)
+				v2DeletePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2DeletePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamPolicyManagementService.V2DeletePolicy(v2DeletePolicyOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke V2DeletePolicy with error: Operation validation and request error`, func() {
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1(&iampolicymanagementv1.IamPolicyManagementV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamPolicyManagementService).ToNot(BeNil())
+
+				// Construct an instance of the V2DeletePolicyOptions model
+				v2DeletePolicyOptionsModel := new(iampolicymanagementv1.V2DeletePolicyOptions)
+				v2DeletePolicyOptionsModel.PolicyID = core.StringPtr("testString")
+				v2DeletePolicyOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamPolicyManagementService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamPolicyManagementService.V2DeletePolicy(v2DeletePolicyOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the V2DeletePolicyOptions model with no property values
+				v2DeletePolicyOptionsModelNew := new(iampolicymanagementv1.V2DeletePolicyOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamPolicyManagementService.V2DeletePolicy(v2DeletePolicyOptionsModelNew)
 				Expect(operationErr).ToNot(BeNil())
 				Expect(response).To(BeNil())
 			})
@@ -3228,6 +4693,219 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				Expect(updateRoleOptionsModel.Actions).To(Equal([]string{"testString"}))
 				Expect(updateRoleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewV2CreatePolicyOptions successfully`, func() {
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				Expect(policyRoleModel).ToNot(BeNil())
+				policyRoleModel.RoleID = core.StringPtr("testString")
+				Expect(policyRoleModel.RoleID).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				Expect(v2PolicyBaseControlGrantModel).ToNot(BeNil())
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+				Expect(v2PolicyBaseControlGrantModel.Roles).To(Equal([]iampolicymanagementv1.PolicyRole{*policyRoleModel}))
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				Expect(v2PolicyBaseControlModel).ToNot(BeNil())
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+				Expect(v2PolicyBaseControlModel.Grant).To(Equal(v2PolicyBaseControlGrantModel))
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				Expect(v2PolicyAttributeModel).ToNot(BeNil())
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+				Expect(v2PolicyAttributeModel.Key).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyAttributeModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyAttributeModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				Expect(v2PolicyBaseSubjectModel).ToNot(BeNil())
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+				Expect(v2PolicyBaseSubjectModel.Attributes).To(Equal([]iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}))
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				Expect(v2PolicyBaseResourceModel).ToNot(BeNil())
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+				Expect(v2PolicyBaseResourceModel.Attributes).To(Equal([]iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}))
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				Expect(v2PolicyBaseRuleModel).ToNot(BeNil())
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+				Expect(v2PolicyBaseRuleModel.Key).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyBaseRuleModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyBaseRuleModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2CreatePolicyOptions model
+				v2CreatePolicyOptionsType := "testString"
+				var v2CreatePolicyOptionsControl *iampolicymanagementv1.V2PolicyBaseControl = nil
+				v2CreatePolicyOptionsModel := iamPolicyManagementService.NewV2CreatePolicyOptions(v2CreatePolicyOptionsType, v2CreatePolicyOptionsControl)
+				v2CreatePolicyOptionsModel.SetType("testString")
+				v2CreatePolicyOptionsModel.SetControl(v2PolicyBaseControlModel)
+				v2CreatePolicyOptionsModel.SetDescription("testString")
+				v2CreatePolicyOptionsModel.SetSubject(v2PolicyBaseSubjectModel)
+				v2CreatePolicyOptionsModel.SetResource(v2PolicyBaseResourceModel)
+				v2CreatePolicyOptionsModel.SetPattern("testString")
+				v2CreatePolicyOptionsModel.SetRule(v2PolicyBaseRuleModel)
+				v2CreatePolicyOptionsModel.SetAcceptLanguage("default")
+				v2CreatePolicyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(v2CreatePolicyOptionsModel).ToNot(BeNil())
+				Expect(v2CreatePolicyOptionsModel.Type).To(Equal(core.StringPtr("testString")))
+				Expect(v2CreatePolicyOptionsModel.Control).To(Equal(v2PolicyBaseControlModel))
+				Expect(v2CreatePolicyOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(v2CreatePolicyOptionsModel.Subject).To(Equal(v2PolicyBaseSubjectModel))
+				Expect(v2CreatePolicyOptionsModel.Resource).To(Equal(v2PolicyBaseResourceModel))
+				Expect(v2CreatePolicyOptionsModel.Pattern).To(Equal(core.StringPtr("testString")))
+				Expect(v2CreatePolicyOptionsModel.Rule).To(Equal(v2PolicyBaseRuleModel))
+				Expect(v2CreatePolicyOptionsModel.AcceptLanguage).To(Equal(core.StringPtr("default")))
+				Expect(v2CreatePolicyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewV2DeletePolicyOptions successfully`, func() {
+				// Construct an instance of the V2DeletePolicyOptions model
+				policyID := "testString"
+				v2DeletePolicyOptionsModel := iamPolicyManagementService.NewV2DeletePolicyOptions(policyID)
+				v2DeletePolicyOptionsModel.SetPolicyID("testString")
+				v2DeletePolicyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(v2DeletePolicyOptionsModel).ToNot(BeNil())
+				Expect(v2DeletePolicyOptionsModel.PolicyID).To(Equal(core.StringPtr("testString")))
+				Expect(v2DeletePolicyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewV2GetPolicyOptions successfully`, func() {
+				// Construct an instance of the V2GetPolicyOptions model
+				policyID := "testString"
+				v2GetPolicyOptionsModel := iamPolicyManagementService.NewV2GetPolicyOptions(policyID)
+				v2GetPolicyOptionsModel.SetPolicyID("testString")
+				v2GetPolicyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(v2GetPolicyOptionsModel).ToNot(BeNil())
+				Expect(v2GetPolicyOptionsModel.PolicyID).To(Equal(core.StringPtr("testString")))
+				Expect(v2GetPolicyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewV2ListPoliciesOptions successfully`, func() {
+				// Construct an instance of the V2ListPoliciesOptions model
+				accountID := "testString"
+				v2ListPoliciesOptionsModel := iamPolicyManagementService.NewV2ListPoliciesOptions(accountID)
+				v2ListPoliciesOptionsModel.SetAccountID("testString")
+				v2ListPoliciesOptionsModel.SetAcceptLanguage("default")
+				v2ListPoliciesOptionsModel.SetIamID("testString")
+				v2ListPoliciesOptionsModel.SetAccessGroupID("testString")
+				v2ListPoliciesOptionsModel.SetType("access")
+				v2ListPoliciesOptionsModel.SetServiceType("service")
+				v2ListPoliciesOptionsModel.SetServiceName("testString")
+				v2ListPoliciesOptionsModel.SetServiceGroupID("testString")
+				v2ListPoliciesOptionsModel.SetFormat("include_last_permit")
+				v2ListPoliciesOptionsModel.SetState("active")
+				v2ListPoliciesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(v2ListPoliciesOptionsModel).ToNot(BeNil())
+				Expect(v2ListPoliciesOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(v2ListPoliciesOptionsModel.AcceptLanguage).To(Equal(core.StringPtr("default")))
+				Expect(v2ListPoliciesOptionsModel.IamID).To(Equal(core.StringPtr("testString")))
+				Expect(v2ListPoliciesOptionsModel.AccessGroupID).To(Equal(core.StringPtr("testString")))
+				Expect(v2ListPoliciesOptionsModel.Type).To(Equal(core.StringPtr("access")))
+				Expect(v2ListPoliciesOptionsModel.ServiceType).To(Equal(core.StringPtr("service")))
+				Expect(v2ListPoliciesOptionsModel.ServiceName).To(Equal(core.StringPtr("testString")))
+				Expect(v2ListPoliciesOptionsModel.ServiceGroupID).To(Equal(core.StringPtr("testString")))
+				Expect(v2ListPoliciesOptionsModel.Format).To(Equal(core.StringPtr("include_last_permit")))
+				Expect(v2ListPoliciesOptionsModel.State).To(Equal(core.StringPtr("active")))
+				Expect(v2ListPoliciesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewV2PolicyBaseControl successfully`, func() {
+				var grant *iampolicymanagementv1.V2PolicyBaseControlGrant = nil
+				_, err := iamPolicyManagementService.NewV2PolicyBaseControl(grant)
+				Expect(err).ToNot(BeNil())
+			})
+			It(`Invoke NewV2PolicyBaseControlGrant successfully`, func() {
+				roles := []iampolicymanagementv1.PolicyRole{}
+				_model, err := iamPolicyManagementService.NewV2PolicyBaseControlGrant(roles)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewV2UpdatePolicyOptions successfully`, func() {
+				// Construct an instance of the PolicyRole model
+				policyRoleModel := new(iampolicymanagementv1.PolicyRole)
+				Expect(policyRoleModel).ToNot(BeNil())
+				policyRoleModel.RoleID = core.StringPtr("testString")
+				Expect(policyRoleModel.RoleID).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2PolicyBaseControlGrant model
+				v2PolicyBaseControlGrantModel := new(iampolicymanagementv1.V2PolicyBaseControlGrant)
+				Expect(v2PolicyBaseControlGrantModel).ToNot(BeNil())
+				v2PolicyBaseControlGrantModel.Roles = []iampolicymanagementv1.PolicyRole{*policyRoleModel}
+				Expect(v2PolicyBaseControlGrantModel.Roles).To(Equal([]iampolicymanagementv1.PolicyRole{*policyRoleModel}))
+
+				// Construct an instance of the V2PolicyBaseControl model
+				v2PolicyBaseControlModel := new(iampolicymanagementv1.V2PolicyBaseControl)
+				Expect(v2PolicyBaseControlModel).ToNot(BeNil())
+				v2PolicyBaseControlModel.Grant = v2PolicyBaseControlGrantModel
+				Expect(v2PolicyBaseControlModel.Grant).To(Equal(v2PolicyBaseControlGrantModel))
+
+				// Construct an instance of the V2PolicyAttribute model
+				v2PolicyAttributeModel := new(iampolicymanagementv1.V2PolicyAttribute)
+				Expect(v2PolicyAttributeModel).ToNot(BeNil())
+				v2PolicyAttributeModel.Key = core.StringPtr("testString")
+				v2PolicyAttributeModel.Operator = core.StringPtr("testString")
+				v2PolicyAttributeModel.Value = core.StringPtr("testString")
+				Expect(v2PolicyAttributeModel.Key).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyAttributeModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyAttributeModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2PolicyBaseSubject model
+				v2PolicyBaseSubjectModel := new(iampolicymanagementv1.V2PolicyBaseSubject)
+				Expect(v2PolicyBaseSubjectModel).ToNot(BeNil())
+				v2PolicyBaseSubjectModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+				Expect(v2PolicyBaseSubjectModel.Attributes).To(Equal([]iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}))
+
+				// Construct an instance of the V2PolicyBaseResource model
+				v2PolicyBaseResourceModel := new(iampolicymanagementv1.V2PolicyBaseResource)
+				Expect(v2PolicyBaseResourceModel).ToNot(BeNil())
+				v2PolicyBaseResourceModel.Attributes = []iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}
+				Expect(v2PolicyBaseResourceModel.Attributes).To(Equal([]iampolicymanagementv1.V2PolicyAttribute{*v2PolicyAttributeModel}))
+
+				// Construct an instance of the V2PolicyBaseRuleV2PolicyAttribute model
+				v2PolicyBaseRuleModel := new(iampolicymanagementv1.V2PolicyBaseRuleV2PolicyAttribute)
+				Expect(v2PolicyBaseRuleModel).ToNot(BeNil())
+				v2PolicyBaseRuleModel.Key = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Operator = core.StringPtr("testString")
+				v2PolicyBaseRuleModel.Value = core.StringPtr("testString")
+				Expect(v2PolicyBaseRuleModel.Key).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyBaseRuleModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(v2PolicyBaseRuleModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the V2UpdatePolicyOptions model
+				policyID := "testString"
+				ifMatch := "testString"
+				v2UpdatePolicyOptionsType := "testString"
+				var v2UpdatePolicyOptionsControl *iampolicymanagementv1.V2PolicyBaseControl = nil
+				v2UpdatePolicyOptionsModel := iamPolicyManagementService.NewV2UpdatePolicyOptions(policyID, ifMatch, v2UpdatePolicyOptionsType, v2UpdatePolicyOptionsControl)
+				v2UpdatePolicyOptionsModel.SetPolicyID("testString")
+				v2UpdatePolicyOptionsModel.SetIfMatch("testString")
+				v2UpdatePolicyOptionsModel.SetType("testString")
+				v2UpdatePolicyOptionsModel.SetControl(v2PolicyBaseControlModel)
+				v2UpdatePolicyOptionsModel.SetDescription("testString")
+				v2UpdatePolicyOptionsModel.SetSubject(v2PolicyBaseSubjectModel)
+				v2UpdatePolicyOptionsModel.SetResource(v2PolicyBaseResourceModel)
+				v2UpdatePolicyOptionsModel.SetPattern("testString")
+				v2UpdatePolicyOptionsModel.SetRule(v2PolicyBaseRuleModel)
+				v2UpdatePolicyOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(v2UpdatePolicyOptionsModel).ToNot(BeNil())
+				Expect(v2UpdatePolicyOptionsModel.PolicyID).To(Equal(core.StringPtr("testString")))
+				Expect(v2UpdatePolicyOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
+				Expect(v2UpdatePolicyOptionsModel.Type).To(Equal(core.StringPtr("testString")))
+				Expect(v2UpdatePolicyOptionsModel.Control).To(Equal(v2PolicyBaseControlModel))
+				Expect(v2UpdatePolicyOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(v2UpdatePolicyOptionsModel.Subject).To(Equal(v2PolicyBaseSubjectModel))
+				Expect(v2UpdatePolicyOptionsModel.Resource).To(Equal(v2PolicyBaseResourceModel))
+				Expect(v2UpdatePolicyOptionsModel.Pattern).To(Equal(core.StringPtr("testString")))
+				Expect(v2UpdatePolicyOptionsModel.Rule).To(Equal(v2PolicyBaseRuleModel))
+				Expect(v2UpdatePolicyOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewPolicyRole successfully`, func() {
 				roleID := "testString"
 				_model, err := iamPolicyManagementService.NewPolicyRole(roleID)
@@ -3252,6 +4930,29 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				name := "testString"
 				value := "testString"
 				_model, err := iamPolicyManagementService.NewSubjectAttribute(name, value)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewV2PolicyAttribute successfully`, func() {
+				key := "testString"
+				operator := "testString"
+				value := core.StringPtr("testString")
+				_model, err := iamPolicyManagementService.NewV2PolicyAttribute(key, operator, value)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewV2PolicyBaseRuleV2PolicyAttribute successfully`, func() {
+				key := "testString"
+				operator := "testString"
+				value := core.StringPtr("testString")
+				_model, err := iamPolicyManagementService.NewV2PolicyBaseRuleV2PolicyAttribute(key, operator, value)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewV2PolicyBaseRuleV2RuleWithConditions successfully`, func() {
+				operator := "and"
+				conditions := []iampolicymanagementv1.V2PolicyAttribute{}
+				_model, err := iamPolicyManagementService.NewV2PolicyBaseRuleV2RuleWithConditions(operator, conditions)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
## PR summary
Code to support new v2/policies API has been introduced. The new v2/policies API will have new JSON fields and existing v1/fields have been changed.

v1/policies API will continue to be supported.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) 

PR's are currently open for staging and production docs. They are not currently merged:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/139
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/140

## Current vs new behavior  
Current behavior will remain same (v1 will continue to be supported). New behavior is v2/policies support which allows for time based restriction policies using new rule field (an integration test has been added of this example).

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
See:
Issue: https://github.ibm.com/IAM/AM-issues/issues/925
TRI: https://github.ibm.com/IAM/architecture/blob/master/TRIDocs/Access-Management/Smart-Policies/smart_policies.md