### PR TITLE
feat(IAM Policy Management): support of new query param source_group_id for v2/roles

### DIFF
--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.65.0-79fc0b8f-20230209-215651
+ * IBM OpenAPI SDK Code Generator Version: 3.68.2-ac7def68-20230310-195410
  */
 
 // Package iampolicymanagementv1 : Operations and models for the IamPolicyManagementV1 service
@@ -681,8 +681,9 @@ func (iamPolicyManagement *IamPolicyManagementV1) UpdatePolicyStateWithContext(c
 // ListRoles : Get roles by filters
 // Get roles based on the filters. While managing roles, you may want to retrieve roles and filter by usages. This can
 // be done through query parameters. Currently, we only support the following attributes: account_id, service_name,
-// source_service_name and policy_type. Only roles that match the filter and that the caller has read access to are
-// returned. If the caller does not have read access to any roles an empty array is returned.
+// service_group_id, source_service_name and policy_type. Both service_name and service_group_id attributes are mutually
+// exclusive. Only roles that match the filter and that the caller has read access to are returned. If the caller does
+// not have read access to any roles an empty array is returned.
 func (iamPolicyManagement *IamPolicyManagementV1) ListRoles(listRolesOptions *ListRolesOptions) (result *RoleList, response *core.DetailedResponse, err error) {
 	return iamPolicyManagement.ListRolesWithContext(context.Background(), listRolesOptions)
 }
@@ -726,6 +727,9 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListRolesWithContext(ctx conte
 	}
 	if listRolesOptions.PolicyType != nil {
 		builder.AddQuery("policy_type", fmt.Sprint(*listRolesOptions.PolicyType))
+	}
+	if listRolesOptions.ServiceGroupID != nil {
+		builder.AddQuery("service_group_id", fmt.Sprint(*listRolesOptions.ServiceGroupID))
 	}
 
 	request, err := builder.Build()
@@ -2354,6 +2358,9 @@ type ListRolesOptions struct {
 	// Optional Policy Type.
 	PolicyType *string `json:"policy_type,omitempty"`
 
+	// Optional id of service group.
+	ServiceGroupID *string `json:"service_group_id,omitempty"`
+
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
@@ -2390,6 +2397,12 @@ func (_options *ListRolesOptions) SetSourceServiceName(sourceServiceName string)
 // SetPolicyType : Allow user to set PolicyType
 func (_options *ListRolesOptions) SetPolicyType(policyType string) *ListRolesOptions {
 	_options.PolicyType = core.StringPtr(policyType)
+	return _options
+}
+
+// SetServiceGroupID : Allow user to set ServiceGroupID
+func (_options *ListRolesOptions) SetServiceGroupID(serviceGroupID string) *ListRolesOptions {
+	_options.ServiceGroupID = core.StringPtr(serviceGroupID)
 	return _options
 }
 

--- a/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
@@ -475,6 +475,28 @@ var _ = Describe(`IamPolicyManagementV1 Examples Tests`, func() {
 				v2PolicyControl,
 				"access",
 			)
+			weeklyConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+				Key:      core.StringPtr("{{environment.attributes.day_of_week}}"),
+				Operator: core.StringPtr("dayOfWeekAnyOf"),
+				Value:    []string{"1+00:00", "2+00:00", "3+00:00", "4+00:00"},
+			}
+			startConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
+				Operator: core.StringPtr("timeGreaterThanOrEquals"),
+				Value:    core.StringPtr("09:00:00+00:00"),
+			}
+			endConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
+				Operator: core.StringPtr("timeLessThanOrEquals"),
+				Value:    core.StringPtr("17:00:00+00:00"),
+			}
+			policyRule := &iampolicymanagementv1.V2PolicyRule{
+				Operator: core.StringPtr("and"),
+				Conditions: []iampolicymanagementv1.RuleAttribute{
+					*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute},
+			}
+			options.SetRule(policyRule)
+			options.SetPattern(*core.StringPtr("time-based-conditions:weekly:custom-hours"))
 			options.SetSubject(policySubject)
 			options.SetResource(policyResource)
 

--- a/iampolicymanagementv1/iam_policy_management_v1_integration_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_integration_test.go
@@ -59,6 +59,7 @@ var _ = Describe("IAM Policy Management - Integration Tests", func() {
 		testCustomRoleId   string = ""
 		testCustomRoleETag string = ""
 		testCustomRoleName string = "TestGoRole" + strconv.Itoa(rand.Intn(100000))
+		testServiceRoleCrn string = "crn:v1:bluemix:public:iam-identity::::serviceRole:ServiceIdCreator"
 	)
 
 	var shouldSkipTest = func() {
@@ -606,6 +607,39 @@ var _ = Describe("IAM Policy Management - Integration Tests", func() {
 				}
 			}
 			Expect(testRolePresent).To(BeTrue())
+		})
+	})
+
+	Describe("List V2 roles", func() {
+		It("Successfully listed the roles when account_id and service_group_id present", func() {
+			shouldSkipTest()
+
+			options := service.NewListRolesOptions()
+			options.SetAccountID(testAccountID)
+			options.SetServiceGroupID("IAM")
+			result, detailedResponse, err := service.ListRoles(options)
+			Expect(err).To(BeNil())
+			Expect(detailedResponse.StatusCode).To(Equal(200))
+			Expect(result).ToNot(BeNil())
+			fmt.Fprintf(GinkgoWriter, "ListRoles() result:\n%s\n", common.ToJSON(result))
+
+			// confirm the system's viewer and service roles are present
+			testSystemRolePresent := false
+			testServiceRolePresent := false
+			for _, role := range result.SystemRoles {
+				if *role.CRN == testViewerRoleCrn {
+					testSystemRolePresent = true
+				}
+			}
+
+			for _, role := range result.ServiceRoles {
+				if *role.CRN == testServiceRoleCrn {
+					testServiceRolePresent = true
+				}
+			}
+
+			Expect(testSystemRolePresent).To(BeTrue())
+			Expect(testServiceRolePresent).To(BeTrue())
 		})
 	})
 

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -1872,6 +1872,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["source_service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["policy_type"]).To(Equal([]string{"authorization"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"IAM"}))
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
 					fmt.Fprint(res, `} this is not valid json {`)
@@ -1892,6 +1893,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.ServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.SourceServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.PolicyType = core.StringPtr("authorization")
+				listRolesOptionsModel.ServiceGroupID = core.StringPtr("IAM")
 				listRolesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := iamPolicyManagementService.ListRoles(listRolesOptionsModel)
@@ -1928,6 +1930,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["source_service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["policy_type"]).To(Equal([]string{"authorization"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"IAM"}))
 					// Sleep a short time to support a timeout test
 					time.Sleep(100 * time.Millisecond)
 
@@ -1953,6 +1956,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.ServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.SourceServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.PolicyType = core.StringPtr("authorization")
+				listRolesOptionsModel.ServiceGroupID = core.StringPtr("IAM")
 				listRolesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -1995,6 +1999,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					Expect(req.URL.Query()["service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["source_service_name"]).To(Equal([]string{"iam-groups"}))
 					Expect(req.URL.Query()["policy_type"]).To(Equal([]string{"authorization"}))
+					Expect(req.URL.Query()["service_group_id"]).To(Equal([]string{"IAM"}))
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
@@ -2022,6 +2027,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.ServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.SourceServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.PolicyType = core.StringPtr("authorization")
+				listRolesOptionsModel.ServiceGroupID = core.StringPtr("IAM")
 				listRolesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -2046,6 +2052,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.ServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.SourceServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.PolicyType = core.StringPtr("authorization")
+				listRolesOptionsModel.ServiceGroupID = core.StringPtr("IAM")
 				listRolesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := iamPolicyManagementService.SetServiceURL("")
@@ -2084,6 +2091,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.ServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.SourceServiceName = core.StringPtr("iam-groups")
 				listRolesOptionsModel.PolicyType = core.StringPtr("authorization")
+				listRolesOptionsModel.ServiceGroupID = core.StringPtr("IAM")
 				listRolesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -4851,6 +4859,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				listRolesOptionsModel.SetServiceName("iam-groups")
 				listRolesOptionsModel.SetSourceServiceName("iam-groups")
 				listRolesOptionsModel.SetPolicyType("authorization")
+				listRolesOptionsModel.SetServiceGroupID("IAM")
 				listRolesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(listRolesOptionsModel).ToNot(BeNil())
 				Expect(listRolesOptionsModel.AcceptLanguage).To(Equal(core.StringPtr("default")))
@@ -4858,6 +4867,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				Expect(listRolesOptionsModel.ServiceName).To(Equal(core.StringPtr("iam-groups")))
 				Expect(listRolesOptionsModel.SourceServiceName).To(Equal(core.StringPtr("iam-groups")))
 				Expect(listRolesOptionsModel.PolicyType).To(Equal(core.StringPtr("authorization")))
+				Expect(listRolesOptionsModel.ServiceGroupID).To(Equal(core.StringPtr("IAM")))
 				Expect(listRolesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewListV2PoliciesOptions successfully`, func() {


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
V2Roles to support optional query parameter service_group_id
Fixed replacePolicy example


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

PR's are merged:
Staging: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/162
Production: https://github.ibm.com/cloud-api-docs/iam-access-management/pull/163

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
https://github.ibm.com/IAM/AM-issues/issues/645