### PR TITLE
feat(IAM Identity): Add support for IAM enterprise

### DIFF
--- a/iamidentityv1/iam_identity_v1.go
+++ b/iamidentityv1/iam_identity_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.72.0-5d70f2bb-20230511-203609
+ * IBM OpenAPI SDK Code Generator Version: 3.74.0-89f1dbab-20230630-160213
  */
 
 // Package iamidentityv1 : Operations and models for the IamIdentityV1 service
@@ -689,7 +689,7 @@ func (iamIdentity *IamIdentityV1) UnlockAPIKeyWithContext(ctx context.Context, u
 // ListServiceIds : List service IDs
 // Returns a list of service IDs. Users can manage user API keys for themself, or service ID API keys for service IDs
 // that are bound to an entity they have access to. Note: apikey details are only included in the response when creating
-// a Service ID with an api key.
+// a Service ID with an apikey.
 func (iamIdentity *IamIdentityV1) ListServiceIds(listServiceIdsOptions *ListServiceIdsOptions) (result *ServiceIDList, response *core.DetailedResponse, err error) {
 	return iamIdentity.ListServiceIdsWithContext(context.Background(), listServiceIdsOptions)
 }
@@ -847,7 +847,7 @@ func (iamIdentity *IamIdentityV1) CreateServiceIDWithContext(ctx context.Context
 // GetServiceID : Get details of a service ID
 // Returns the details of a service ID. Users can manage user API keys for themself, or service ID API keys for service
 // IDs that are bound to an entity they have access to. Note: apikey details are only included in the response when
-// creating a Service ID with an api key.
+// creating a Service ID with an apikey.
 func (iamIdentity *IamIdentityV1) GetServiceID(getServiceIDOptions *GetServiceIDOptions) (result *ServiceID, response *core.DetailedResponse, err error) {
 	return iamIdentity.GetServiceIDWithContext(context.Background(), getServiceIDOptions)
 }
@@ -1654,7 +1654,7 @@ func (iamIdentity *IamIdentityV1) GetClaimRuleWithContext(ctx context.Context, g
 
 	pathParamsMap := map[string]string{
 		"profile-id": *getClaimRuleOptions.ProfileID,
-		"rule-id":    *getClaimRuleOptions.RuleID,
+		"rule-id": *getClaimRuleOptions.RuleID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -1715,7 +1715,7 @@ func (iamIdentity *IamIdentityV1) UpdateClaimRuleWithContext(ctx context.Context
 
 	pathParamsMap := map[string]string{
 		"profile-id": *updateClaimRuleOptions.ProfileID,
-		"rule-id":    *updateClaimRuleOptions.RuleID,
+		"rule-id": *updateClaimRuleOptions.RuleID,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
@@ -1808,7 +1808,7 @@ func (iamIdentity *IamIdentityV1) DeleteClaimRuleWithContext(ctx context.Context
 
 	pathParamsMap := map[string]string{
 		"profile-id": *deleteClaimRuleOptions.ProfileID,
-		"rule-id":    *deleteClaimRuleOptions.RuleID,
+		"rule-id": *deleteClaimRuleOptions.RuleID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -1994,7 +1994,7 @@ func (iamIdentity *IamIdentityV1) GetLinkWithContext(ctx context.Context, getLin
 
 	pathParamsMap := map[string]string{
 		"profile-id": *getLinkOptions.ProfileID,
-		"link-id":    *getLinkOptions.LinkID,
+		"link-id": *getLinkOptions.LinkID,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2055,7 +2055,7 @@ func (iamIdentity *IamIdentityV1) DeleteLinkWithContext(ctx context.Context, del
 
 	pathParamsMap := map[string]string{
 		"profile-id": *deleteLinkOptions.ProfileID,
-		"link-id":    *deleteLinkOptions.LinkID,
+		"link-id": *deleteLinkOptions.LinkID,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -2220,12 +2220,12 @@ func (iamIdentity *IamIdentityV1) SetProfileIdentitiesWithContext(ctx context.Co
 
 // SetProfileIdentity : Add a specific identity that can assume the trusted profile
 // Add a specific identity that can assume the trusted profile.
-func (iamIdentity *IamIdentityV1) SetProfileIdentity(setProfileIdentityOptions *SetProfileIdentityOptions) (result *ProfileIdentity, response *core.DetailedResponse, err error) {
+func (iamIdentity *IamIdentityV1) SetProfileIdentity(setProfileIdentityOptions *SetProfileIdentityOptions) (result *ProfileIdentityResponse, response *core.DetailedResponse, err error) {
 	return iamIdentity.SetProfileIdentityWithContext(context.Background(), setProfileIdentityOptions)
 }
 
 // SetProfileIdentityWithContext is an alternate form of the SetProfileIdentity method which supports a Context parameter
-func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Context, setProfileIdentityOptions *SetProfileIdentityOptions) (result *ProfileIdentity, response *core.DetailedResponse, err error) {
+func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Context, setProfileIdentityOptions *SetProfileIdentityOptions) (result *ProfileIdentityResponse, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(setProfileIdentityOptions, "setProfileIdentityOptions cannot be nil")
 	if err != nil {
 		return
@@ -2236,7 +2236,7 @@ func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Cont
 	}
 
 	pathParamsMap := map[string]string{
-		"profile-id":    *setProfileIdentityOptions.ProfileID,
+		"profile-id": *setProfileIdentityOptions.ProfileID,
 		"identity-type": *setProfileIdentityOptions.IdentityType,
 	}
 
@@ -2266,9 +2266,6 @@ func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Cont
 	if setProfileIdentityOptions.Type != nil {
 		body["type"] = setProfileIdentityOptions.Type
 	}
-	if setProfileIdentityOptions.IamID != nil {
-		body["iam_id"] = setProfileIdentityOptions.IamID
-	}
 	if setProfileIdentityOptions.Accounts != nil {
 		body["accounts"] = setProfileIdentityOptions.Accounts
 	}
@@ -2291,7 +2288,7 @@ func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Cont
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalProfileIdentity)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalProfileIdentityResponse)
 		if err != nil {
 			return
 		}
@@ -2303,12 +2300,12 @@ func (iamIdentity *IamIdentityV1) SetProfileIdentityWithContext(ctx context.Cont
 
 // GetProfileIdentity : Get the identity that can assume the trusted profile
 // Get the identity that can assume the trusted profile.
-func (iamIdentity *IamIdentityV1) GetProfileIdentity(getProfileIdentityOptions *GetProfileIdentityOptions) (result *ProfileIdentity, response *core.DetailedResponse, err error) {
+func (iamIdentity *IamIdentityV1) GetProfileIdentity(getProfileIdentityOptions *GetProfileIdentityOptions) (result *ProfileIdentityResponse, response *core.DetailedResponse, err error) {
 	return iamIdentity.GetProfileIdentityWithContext(context.Background(), getProfileIdentityOptions)
 }
 
 // GetProfileIdentityWithContext is an alternate form of the GetProfileIdentity method which supports a Context parameter
-func (iamIdentity *IamIdentityV1) GetProfileIdentityWithContext(ctx context.Context, getProfileIdentityOptions *GetProfileIdentityOptions) (result *ProfileIdentity, response *core.DetailedResponse, err error) {
+func (iamIdentity *IamIdentityV1) GetProfileIdentityWithContext(ctx context.Context, getProfileIdentityOptions *GetProfileIdentityOptions) (result *ProfileIdentityResponse, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(getProfileIdentityOptions, "getProfileIdentityOptions cannot be nil")
 	if err != nil {
 		return
@@ -2319,7 +2316,7 @@ func (iamIdentity *IamIdentityV1) GetProfileIdentityWithContext(ctx context.Cont
 	}
 
 	pathParamsMap := map[string]string{
-		"profile-id":    *getProfileIdentityOptions.ProfileID,
+		"profile-id": *getProfileIdentityOptions.ProfileID,
 		"identity-type": *getProfileIdentityOptions.IdentityType,
 		"identifier-id": *getProfileIdentityOptions.IdentifierID,
 	}
@@ -2353,7 +2350,7 @@ func (iamIdentity *IamIdentityV1) GetProfileIdentityWithContext(ctx context.Cont
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalProfileIdentity)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalProfileIdentityResponse)
 		if err != nil {
 			return
 		}
@@ -2381,7 +2378,7 @@ func (iamIdentity *IamIdentityV1) DeleteProfileIdentityWithContext(ctx context.C
 	}
 
 	pathParamsMap := map[string]string{
-		"profile-id":    *deleteProfileIdentityOptions.ProfileID,
+		"profile-id": *deleteProfileIdentityOptions.ProfileID,
 		"identity-type": *deleteProfileIdentityOptions.IdentityType,
 		"identifier-id": *deleteProfileIdentityOptions.IdentifierID,
 	}
@@ -2725,7 +2722,7 @@ func (iamIdentity *IamIdentityV1) GetMfaReportWithContext(ctx context.Context, g
 
 	pathParamsMap := map[string]string{
 		"account_id": *getMfaReportOptions.AccountID,
-		"reference":  *getMfaReportOptions.Reference,
+		"reference": *getMfaReportOptions.Reference,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2763,6 +2760,1021 @@ func (iamIdentity *IamIdentityV1) GetMfaReportWithContext(ctx context.Context, g
 		}
 		response.Result = result
 	}
+
+	return
+}
+
+// ListAccountSettingsAssignments : List Assignments
+// List Account Settings Template Assignments.
+func (iamIdentity *IamIdentityV1) ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptions *ListAccountSettingsAssignmentsOptions) (result *TemplateAssignmentListResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListAccountSettingsAssignmentsWithContext(context.Background(), listAccountSettingsAssignmentsOptions)
+}
+
+// ListAccountSettingsAssignmentsWithContext is an alternate form of the ListAccountSettingsAssignments method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListAccountSettingsAssignmentsWithContext(ctx context.Context, listAccountSettingsAssignmentsOptions *ListAccountSettingsAssignmentsOptions) (result *TemplateAssignmentListResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(listAccountSettingsAssignmentsOptions, "listAccountSettingsAssignmentsOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_assignments/`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listAccountSettingsAssignmentsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListAccountSettingsAssignments")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listAccountSettingsAssignmentsOptions.AccountID != nil {
+		builder.AddQuery("account_id", fmt.Sprint(*listAccountSettingsAssignmentsOptions.AccountID))
+	}
+	if listAccountSettingsAssignmentsOptions.TemplateID != nil {
+		builder.AddQuery("template_id", fmt.Sprint(*listAccountSettingsAssignmentsOptions.TemplateID))
+	}
+	if listAccountSettingsAssignmentsOptions.TemplateVersion != nil {
+		builder.AddQuery("template_version", fmt.Sprint(*listAccountSettingsAssignmentsOptions.TemplateVersion))
+	}
+	if listAccountSettingsAssignmentsOptions.Target != nil {
+		builder.AddQuery("target", fmt.Sprint(*listAccountSettingsAssignmentsOptions.Target))
+	}
+	if listAccountSettingsAssignmentsOptions.TargetType != nil {
+		builder.AddQuery("target_type", fmt.Sprint(*listAccountSettingsAssignmentsOptions.TargetType))
+	}
+	if listAccountSettingsAssignmentsOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listAccountSettingsAssignmentsOptions.Limit))
+	}
+	if listAccountSettingsAssignmentsOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listAccountSettingsAssignmentsOptions.Pagetoken))
+	}
+	if listAccountSettingsAssignmentsOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listAccountSettingsAssignmentsOptions.Sort))
+	}
+	if listAccountSettingsAssignmentsOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listAccountSettingsAssignmentsOptions.Order))
+	}
+	if listAccountSettingsAssignmentsOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listAccountSettingsAssignmentsOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentListResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateAccountSettingsAssignment : Create Assignment
+// Create an assigment for an Account Settings Template.
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptions *CreateAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateAccountSettingsAssignmentWithContext(context.Background(), createAccountSettingsAssignmentOptions)
+}
+
+// CreateAccountSettingsAssignmentWithContext is an alternate form of the CreateAccountSettingsAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsAssignmentWithContext(ctx context.Context, createAccountSettingsAssignmentOptions *CreateAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createAccountSettingsAssignmentOptions, "createAccountSettingsAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createAccountSettingsAssignmentOptions, "createAccountSettingsAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_assignments/`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createAccountSettingsAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateAccountSettingsAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createAccountSettingsAssignmentOptions.TemplateID != nil {
+		body["template_id"] = createAccountSettingsAssignmentOptions.TemplateID
+	}
+	if createAccountSettingsAssignmentOptions.TemplateVersion != nil {
+		body["template_version"] = createAccountSettingsAssignmentOptions.TemplateVersion
+	}
+	if createAccountSettingsAssignmentOptions.TargetType != nil {
+		body["target_type"] = createAccountSettingsAssignmentOptions.TargetType
+	}
+	if createAccountSettingsAssignmentOptions.Target != nil {
+		body["target"] = createAccountSettingsAssignmentOptions.Target
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetAccountSettingsAssignment : Get Assignment
+// Get an assigment for an Account Settings Template.
+func (iamIdentity *IamIdentityV1) GetAccountSettingsAssignment(getAccountSettingsAssignmentOptions *GetAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetAccountSettingsAssignmentWithContext(context.Background(), getAccountSettingsAssignmentOptions)
+}
+
+// GetAccountSettingsAssignmentWithContext is an alternate form of the GetAccountSettingsAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetAccountSettingsAssignmentWithContext(ctx context.Context, getAccountSettingsAssignmentOptions *GetAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getAccountSettingsAssignmentOptions, "getAccountSettingsAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getAccountSettingsAssignmentOptions, "getAccountSettingsAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *getAccountSettingsAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getAccountSettingsAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetAccountSettingsAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getAccountSettingsAssignmentOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getAccountSettingsAssignmentOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteAccountSettingsAssignment : Delete Assignment
+// Delete an Account Settings assignment. This will remove any resources created by this assignment.
+func (iamIdentity *IamIdentityV1) DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptions *DeleteAccountSettingsAssignmentOptions) (result *ExceptionResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteAccountSettingsAssignmentWithContext(context.Background(), deleteAccountSettingsAssignmentOptions)
+}
+
+// DeleteAccountSettingsAssignmentWithContext is an alternate form of the DeleteAccountSettingsAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteAccountSettingsAssignmentWithContext(ctx context.Context, deleteAccountSettingsAssignmentOptions *DeleteAccountSettingsAssignmentOptions) (result *ExceptionResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteAccountSettingsAssignmentOptions, "deleteAccountSettingsAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteAccountSettingsAssignmentOptions, "deleteAccountSettingsAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *deleteAccountSettingsAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteAccountSettingsAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteAccountSettingsAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalExceptionResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// UpdateAccountSettingsAssignment : Update Assignment
+// Update an Account Settings assignment in order to retry failed assignments or migrate resources to a new version.
+func (iamIdentity *IamIdentityV1) UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptions *UpdateAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.UpdateAccountSettingsAssignmentWithContext(context.Background(), updateAccountSettingsAssignmentOptions)
+}
+
+// UpdateAccountSettingsAssignmentWithContext is an alternate form of the UpdateAccountSettingsAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) UpdateAccountSettingsAssignmentWithContext(ctx context.Context, updateAccountSettingsAssignmentOptions *UpdateAccountSettingsAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateAccountSettingsAssignmentOptions, "updateAccountSettingsAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(updateAccountSettingsAssignmentOptions, "updateAccountSettingsAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *updateAccountSettingsAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.PATCH)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range updateAccountSettingsAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "UpdateAccountSettingsAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if updateAccountSettingsAssignmentOptions.IfMatch != nil {
+		builder.AddHeader("If-Match", fmt.Sprint(*updateAccountSettingsAssignmentOptions.IfMatch))
+	}
+
+	body := make(map[string]interface{})
+	if updateAccountSettingsAssignmentOptions.TemplateVersion != nil {
+		body["template_version"] = updateAccountSettingsAssignmentOptions.TemplateVersion
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// ListAccountSettingsTemplates : List Account Settings Templates
+// List Account Settings Templates for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) ListAccountSettingsTemplates(listAccountSettingsTemplatesOptions *ListAccountSettingsTemplatesOptions) (result *AccountSettingsTemplateList, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListAccountSettingsTemplatesWithContext(context.Background(), listAccountSettingsTemplatesOptions)
+}
+
+// ListAccountSettingsTemplatesWithContext is an alternate form of the ListAccountSettingsTemplates method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListAccountSettingsTemplatesWithContext(ctx context.Context, listAccountSettingsTemplatesOptions *ListAccountSettingsTemplatesOptions) (result *AccountSettingsTemplateList, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(listAccountSettingsTemplatesOptions, "listAccountSettingsTemplatesOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listAccountSettingsTemplatesOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListAccountSettingsTemplates")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listAccountSettingsTemplatesOptions.AccountID != nil {
+		builder.AddQuery("account_id", fmt.Sprint(*listAccountSettingsTemplatesOptions.AccountID))
+	}
+	if listAccountSettingsTemplatesOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listAccountSettingsTemplatesOptions.Limit))
+	}
+	if listAccountSettingsTemplatesOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listAccountSettingsTemplatesOptions.Pagetoken))
+	}
+	if listAccountSettingsTemplatesOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listAccountSettingsTemplatesOptions.Sort))
+	}
+	if listAccountSettingsTemplatesOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listAccountSettingsTemplatesOptions.Order))
+	}
+	if listAccountSettingsTemplatesOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listAccountSettingsTemplatesOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateList)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateAccountSettingsTemplate : Create an Account Settings Template
+// Create a new Account Settings Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsTemplate(createAccountSettingsTemplateOptions *CreateAccountSettingsTemplateOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateAccountSettingsTemplateWithContext(context.Background(), createAccountSettingsTemplateOptions)
+}
+
+// CreateAccountSettingsTemplateWithContext is an alternate form of the CreateAccountSettingsTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsTemplateWithContext(ctx context.Context, createAccountSettingsTemplateOptions *CreateAccountSettingsTemplateOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createAccountSettingsTemplateOptions, "createAccountSettingsTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createAccountSettingsTemplateOptions, "createAccountSettingsTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createAccountSettingsTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateAccountSettingsTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createAccountSettingsTemplateOptions.AccountID != nil {
+		body["account_id"] = createAccountSettingsTemplateOptions.AccountID
+	}
+	if createAccountSettingsTemplateOptions.Name != nil {
+		body["name"] = createAccountSettingsTemplateOptions.Name
+	}
+	if createAccountSettingsTemplateOptions.Description != nil {
+		body["description"] = createAccountSettingsTemplateOptions.Description
+	}
+	if createAccountSettingsTemplateOptions.AccountSettings != nil {
+		body["account_settings"] = createAccountSettingsTemplateOptions.AccountSettings
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetLatestAccountSettingsTemplateVersion : Get latest version of an Account Settings Template
+// Get latest version of an Account Settings Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptions *GetLatestAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetLatestAccountSettingsTemplateVersionWithContext(context.Background(), getLatestAccountSettingsTemplateVersionOptions)
+}
+
+// GetLatestAccountSettingsTemplateVersionWithContext is an alternate form of the GetLatestAccountSettingsTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetLatestAccountSettingsTemplateVersionWithContext(ctx context.Context, getLatestAccountSettingsTemplateVersionOptions *GetLatestAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getLatestAccountSettingsTemplateVersionOptions, "getLatestAccountSettingsTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getLatestAccountSettingsTemplateVersionOptions, "getLatestAccountSettingsTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *getLatestAccountSettingsTemplateVersionOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getLatestAccountSettingsTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetLatestAccountSettingsTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getLatestAccountSettingsTemplateVersionOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getLatestAccountSettingsTemplateVersionOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteAllVersionsOfAccountSettingsTemplate : Delete all versions of an Account Settings Template
+// Delete all versions of an Account Settings Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) DeleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptions *DeleteAllVersionsOfAccountSettingsTemplateOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteAllVersionsOfAccountSettingsTemplateWithContext(context.Background(), deleteAllVersionsOfAccountSettingsTemplateOptions)
+}
+
+// DeleteAllVersionsOfAccountSettingsTemplateWithContext is an alternate form of the DeleteAllVersionsOfAccountSettingsTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteAllVersionsOfAccountSettingsTemplateWithContext(ctx context.Context, deleteAllVersionsOfAccountSettingsTemplateOptions *DeleteAllVersionsOfAccountSettingsTemplateOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteAllVersionsOfAccountSettingsTemplateOptions, "deleteAllVersionsOfAccountSettingsTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteAllVersionsOfAccountSettingsTemplateOptions, "deleteAllVersionsOfAccountSettingsTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *deleteAllVersionsOfAccountSettingsTemplateOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteAllVersionsOfAccountSettingsTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteAllVersionsOfAccountSettingsTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
+
+	return
+}
+
+// ListVersionsOfAccountSettingsTemplate : List Account Settings Template versions
+// List versions of an Account Settings Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptions *ListVersionsOfAccountSettingsTemplateOptions) (result *AccountSettingsTemplateList, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListVersionsOfAccountSettingsTemplateWithContext(context.Background(), listVersionsOfAccountSettingsTemplateOptions)
+}
+
+// ListVersionsOfAccountSettingsTemplateWithContext is an alternate form of the ListVersionsOfAccountSettingsTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListVersionsOfAccountSettingsTemplateWithContext(ctx context.Context, listVersionsOfAccountSettingsTemplateOptions *ListVersionsOfAccountSettingsTemplateOptions) (result *AccountSettingsTemplateList, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(listVersionsOfAccountSettingsTemplateOptions, "listVersionsOfAccountSettingsTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(listVersionsOfAccountSettingsTemplateOptions, "listVersionsOfAccountSettingsTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *listVersionsOfAccountSettingsTemplateOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listVersionsOfAccountSettingsTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListVersionsOfAccountSettingsTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listVersionsOfAccountSettingsTemplateOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listVersionsOfAccountSettingsTemplateOptions.Limit))
+	}
+	if listVersionsOfAccountSettingsTemplateOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listVersionsOfAccountSettingsTemplateOptions.Pagetoken))
+	}
+	if listVersionsOfAccountSettingsTemplateOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listVersionsOfAccountSettingsTemplateOptions.Sort))
+	}
+	if listVersionsOfAccountSettingsTemplateOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listVersionsOfAccountSettingsTemplateOptions.Order))
+	}
+	if listVersionsOfAccountSettingsTemplateOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listVersionsOfAccountSettingsTemplateOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateList)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateAccountSettingsTemplateVersion : Create a new version of an Account Settings Template
+// Create a new version of an Account Settings Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptions *CreateAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateAccountSettingsTemplateVersionWithContext(context.Background(), createAccountSettingsTemplateVersionOptions)
+}
+
+// CreateAccountSettingsTemplateVersionWithContext is an alternate form of the CreateAccountSettingsTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateAccountSettingsTemplateVersionWithContext(ctx context.Context, createAccountSettingsTemplateVersionOptions *CreateAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createAccountSettingsTemplateVersionOptions, "createAccountSettingsTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createAccountSettingsTemplateVersionOptions, "createAccountSettingsTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *createAccountSettingsTemplateVersionOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createAccountSettingsTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateAccountSettingsTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createAccountSettingsTemplateVersionOptions.AccountID != nil {
+		body["account_id"] = createAccountSettingsTemplateVersionOptions.AccountID
+	}
+	if createAccountSettingsTemplateVersionOptions.Name != nil {
+		body["name"] = createAccountSettingsTemplateVersionOptions.Name
+	}
+	if createAccountSettingsTemplateVersionOptions.Description != nil {
+		body["description"] = createAccountSettingsTemplateVersionOptions.Description
+	}
+	if createAccountSettingsTemplateVersionOptions.AccountSettings != nil {
+		body["account_settings"] = createAccountSettingsTemplateVersionOptions.AccountSettings
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetAccountSettingsTemplateVersion : Get version of an Account Settings Template
+// Get a specific version of an Account Settings Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptions *GetAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetAccountSettingsTemplateVersionWithContext(context.Background(), getAccountSettingsTemplateVersionOptions)
+}
+
+// GetAccountSettingsTemplateVersionWithContext is an alternate form of the GetAccountSettingsTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetAccountSettingsTemplateVersionWithContext(ctx context.Context, getAccountSettingsTemplateVersionOptions *GetAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getAccountSettingsTemplateVersionOptions, "getAccountSettingsTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getAccountSettingsTemplateVersionOptions, "getAccountSettingsTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *getAccountSettingsTemplateVersionOptions.TemplateID,
+		"version": *getAccountSettingsTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getAccountSettingsTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetAccountSettingsTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getAccountSettingsTemplateVersionOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getAccountSettingsTemplateVersionOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// UpdateAccountSettingsTemplateVersion : Update version of an Account Settings Template
+// Update a specific version of an Account Settings Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptions *UpdateAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.UpdateAccountSettingsTemplateVersionWithContext(context.Background(), updateAccountSettingsTemplateVersionOptions)
+}
+
+// UpdateAccountSettingsTemplateVersionWithContext is an alternate form of the UpdateAccountSettingsTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) UpdateAccountSettingsTemplateVersionWithContext(ctx context.Context, updateAccountSettingsTemplateVersionOptions *UpdateAccountSettingsTemplateVersionOptions) (result *AccountSettingsTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateAccountSettingsTemplateVersionOptions, "updateAccountSettingsTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(updateAccountSettingsTemplateVersionOptions, "updateAccountSettingsTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *updateAccountSettingsTemplateVersionOptions.TemplateID,
+		"version": *updateAccountSettingsTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.PUT)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range updateAccountSettingsTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "UpdateAccountSettingsTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if updateAccountSettingsTemplateVersionOptions.IfMatch != nil {
+		builder.AddHeader("If-Match", fmt.Sprint(*updateAccountSettingsTemplateVersionOptions.IfMatch))
+	}
+
+	body := make(map[string]interface{})
+	if updateAccountSettingsTemplateVersionOptions.AccountID != nil {
+		body["account_id"] = updateAccountSettingsTemplateVersionOptions.AccountID
+	}
+	if updateAccountSettingsTemplateVersionOptions.Name != nil {
+		body["name"] = updateAccountSettingsTemplateVersionOptions.Name
+	}
+	if updateAccountSettingsTemplateVersionOptions.Description != nil {
+		body["description"] = updateAccountSettingsTemplateVersionOptions.Description
+	}
+	if updateAccountSettingsTemplateVersionOptions.AccountSettings != nil {
+		body["account_settings"] = updateAccountSettingsTemplateVersionOptions.AccountSettings
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalAccountSettingsTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteAccountSettingsTemplateVersion : Delete version of an Account Settings Template
+// Delete a specific version of an Account Settings Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) DeleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptions *DeleteAccountSettingsTemplateVersionOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteAccountSettingsTemplateVersionWithContext(context.Background(), deleteAccountSettingsTemplateVersionOptions)
+}
+
+// DeleteAccountSettingsTemplateVersionWithContext is an alternate form of the DeleteAccountSettingsTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteAccountSettingsTemplateVersionWithContext(ctx context.Context, deleteAccountSettingsTemplateVersionOptions *DeleteAccountSettingsTemplateVersionOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteAccountSettingsTemplateVersionOptions, "deleteAccountSettingsTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteAccountSettingsTemplateVersionOptions, "deleteAccountSettingsTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *deleteAccountSettingsTemplateVersionOptions.TemplateID,
+		"version": *deleteAccountSettingsTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteAccountSettingsTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteAccountSettingsTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
+
+	return
+}
+
+// CommitAccountSettingsTemplate : Commit a template version
+// Commit a specific version of an Account Settings Template in an Enterprise Account. A Template must be committed
+// before being assigned, and once committed, can no longer be modified.
+func (iamIdentity *IamIdentityV1) CommitAccountSettingsTemplate(commitAccountSettingsTemplateOptions *CommitAccountSettingsTemplateOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.CommitAccountSettingsTemplateWithContext(context.Background(), commitAccountSettingsTemplateOptions)
+}
+
+// CommitAccountSettingsTemplateWithContext is an alternate form of the CommitAccountSettingsTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CommitAccountSettingsTemplateWithContext(ctx context.Context, commitAccountSettingsTemplateOptions *CommitAccountSettingsTemplateOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(commitAccountSettingsTemplateOptions, "commitAccountSettingsTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(commitAccountSettingsTemplateOptions, "commitAccountSettingsTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *commitAccountSettingsTemplateOptions.TemplateID,
+		"version": *commitAccountSettingsTemplateOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/account_settings_templates/{template_id}/versions/{version}/commit`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range commitAccountSettingsTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CommitAccountSettingsTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
 
 	return
 }
@@ -2835,7 +3847,7 @@ func (iamIdentity *IamIdentityV1) CreateReportWithContext(ctx context.Context, c
 	return
 }
 
-// GetReport : Get activity report for the account
+// GetReport : Get activity report across on account scope
 // Get activity report for the account by specifying the account ID and the reference that is generated by triggering
 // the report. Reports older than a day are deleted when generating a new report.
 func (iamIdentity *IamIdentityV1) GetReport(getReportOptions *GetReportOptions) (result *Report, response *core.DetailedResponse, err error) {
@@ -2855,7 +3867,7 @@ func (iamIdentity *IamIdentityV1) GetReportWithContext(ctx context.Context, getR
 
 	pathParamsMap := map[string]string{
 		"account_id": *getReportOptions.AccountID,
-		"reference":  *getReportOptions.Reference,
+		"reference": *getReportOptions.Reference,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2897,6 +3909,1030 @@ func (iamIdentity *IamIdentityV1) GetReportWithContext(ctx context.Context, getR
 	return
 }
 
+// ListTrustedProfileAssignments : List Assignments
+// List Trusted Profile Template Assignments.
+func (iamIdentity *IamIdentityV1) ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptions *ListTrustedProfileAssignmentsOptions) (result *TemplateAssignmentListResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListTrustedProfileAssignmentsWithContext(context.Background(), listTrustedProfileAssignmentsOptions)
+}
+
+// ListTrustedProfileAssignmentsWithContext is an alternate form of the ListTrustedProfileAssignments method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListTrustedProfileAssignmentsWithContext(ctx context.Context, listTrustedProfileAssignmentsOptions *ListTrustedProfileAssignmentsOptions) (result *TemplateAssignmentListResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(listTrustedProfileAssignmentsOptions, "listTrustedProfileAssignmentsOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_assignments/`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listTrustedProfileAssignmentsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListTrustedProfileAssignments")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listTrustedProfileAssignmentsOptions.AccountID != nil {
+		builder.AddQuery("account_id", fmt.Sprint(*listTrustedProfileAssignmentsOptions.AccountID))
+	}
+	if listTrustedProfileAssignmentsOptions.TemplateID != nil {
+		builder.AddQuery("template_id", fmt.Sprint(*listTrustedProfileAssignmentsOptions.TemplateID))
+	}
+	if listTrustedProfileAssignmentsOptions.TemplateVersion != nil {
+		builder.AddQuery("template_version", fmt.Sprint(*listTrustedProfileAssignmentsOptions.TemplateVersion))
+	}
+	if listTrustedProfileAssignmentsOptions.Target != nil {
+		builder.AddQuery("target", fmt.Sprint(*listTrustedProfileAssignmentsOptions.Target))
+	}
+	if listTrustedProfileAssignmentsOptions.TargetType != nil {
+		builder.AddQuery("target_type", fmt.Sprint(*listTrustedProfileAssignmentsOptions.TargetType))
+	}
+	if listTrustedProfileAssignmentsOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listTrustedProfileAssignmentsOptions.Limit))
+	}
+	if listTrustedProfileAssignmentsOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listTrustedProfileAssignmentsOptions.Pagetoken))
+	}
+	if listTrustedProfileAssignmentsOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listTrustedProfileAssignmentsOptions.Sort))
+	}
+	if listTrustedProfileAssignmentsOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listTrustedProfileAssignmentsOptions.Order))
+	}
+	if listTrustedProfileAssignmentsOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listTrustedProfileAssignmentsOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentListResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateTrustedProfileAssignment : Create Assignment
+// Create an assigment for a Trusted Profile Template.
+func (iamIdentity *IamIdentityV1) CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptions *CreateTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateTrustedProfileAssignmentWithContext(context.Background(), createTrustedProfileAssignmentOptions)
+}
+
+// CreateTrustedProfileAssignmentWithContext is an alternate form of the CreateTrustedProfileAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateTrustedProfileAssignmentWithContext(ctx context.Context, createTrustedProfileAssignmentOptions *CreateTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createTrustedProfileAssignmentOptions, "createTrustedProfileAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createTrustedProfileAssignmentOptions, "createTrustedProfileAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_assignments/`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createTrustedProfileAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateTrustedProfileAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createTrustedProfileAssignmentOptions.TemplateID != nil {
+		body["template_id"] = createTrustedProfileAssignmentOptions.TemplateID
+	}
+	if createTrustedProfileAssignmentOptions.TemplateVersion != nil {
+		body["template_version"] = createTrustedProfileAssignmentOptions.TemplateVersion
+	}
+	if createTrustedProfileAssignmentOptions.TargetType != nil {
+		body["target_type"] = createTrustedProfileAssignmentOptions.TargetType
+	}
+	if createTrustedProfileAssignmentOptions.Target != nil {
+		body["target"] = createTrustedProfileAssignmentOptions.Target
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetTrustedProfileAssignment : Get Assignment
+// Get an assigment for a Trusted Profile Template.
+func (iamIdentity *IamIdentityV1) GetTrustedProfileAssignment(getTrustedProfileAssignmentOptions *GetTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetTrustedProfileAssignmentWithContext(context.Background(), getTrustedProfileAssignmentOptions)
+}
+
+// GetTrustedProfileAssignmentWithContext is an alternate form of the GetTrustedProfileAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetTrustedProfileAssignmentWithContext(ctx context.Context, getTrustedProfileAssignmentOptions *GetTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getTrustedProfileAssignmentOptions, "getTrustedProfileAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getTrustedProfileAssignmentOptions, "getTrustedProfileAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *getTrustedProfileAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getTrustedProfileAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetTrustedProfileAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getTrustedProfileAssignmentOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getTrustedProfileAssignmentOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteTrustedProfileAssignment : Delete Assignment
+// Delete a Trusted Profile assignment. This will remove any resources created by this assignment.
+func (iamIdentity *IamIdentityV1) DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptions *DeleteTrustedProfileAssignmentOptions) (result *ExceptionResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteTrustedProfileAssignmentWithContext(context.Background(), deleteTrustedProfileAssignmentOptions)
+}
+
+// DeleteTrustedProfileAssignmentWithContext is an alternate form of the DeleteTrustedProfileAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteTrustedProfileAssignmentWithContext(ctx context.Context, deleteTrustedProfileAssignmentOptions *DeleteTrustedProfileAssignmentOptions) (result *ExceptionResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteTrustedProfileAssignmentOptions, "deleteTrustedProfileAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteTrustedProfileAssignmentOptions, "deleteTrustedProfileAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *deleteTrustedProfileAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteTrustedProfileAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteTrustedProfileAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalExceptionResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// UpdateTrustedProfileAssignment : Update Assignment
+// Update a Trusted Profile assignment in order to retry failed assignments or migrate resources to a new version.
+func (iamIdentity *IamIdentityV1) UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptions *UpdateTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.UpdateTrustedProfileAssignmentWithContext(context.Background(), updateTrustedProfileAssignmentOptions)
+}
+
+// UpdateTrustedProfileAssignmentWithContext is an alternate form of the UpdateTrustedProfileAssignment method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) UpdateTrustedProfileAssignmentWithContext(ctx context.Context, updateTrustedProfileAssignmentOptions *UpdateTrustedProfileAssignmentOptions) (result *TemplateAssignmentResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateTrustedProfileAssignmentOptions, "updateTrustedProfileAssignmentOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(updateTrustedProfileAssignmentOptions, "updateTrustedProfileAssignmentOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"assignment_id": *updateTrustedProfileAssignmentOptions.AssignmentID,
+	}
+
+	builder := core.NewRequestBuilder(core.PATCH)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_assignments/{assignment_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range updateTrustedProfileAssignmentOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "UpdateTrustedProfileAssignment")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if updateTrustedProfileAssignmentOptions.IfMatch != nil {
+		builder.AddHeader("If-Match", fmt.Sprint(*updateTrustedProfileAssignmentOptions.IfMatch))
+	}
+
+	body := make(map[string]interface{})
+	if updateTrustedProfileAssignmentOptions.TemplateVersion != nil {
+		body["template_version"] = updateTrustedProfileAssignmentOptions.TemplateVersion
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTemplateAssignmentResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// ListProfileTemplates : List Profile Templates
+// List Trusted Profile Templates for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) ListProfileTemplates(listProfileTemplatesOptions *ListProfileTemplatesOptions) (result *TrustedProfileTemplateList, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListProfileTemplatesWithContext(context.Background(), listProfileTemplatesOptions)
+}
+
+// ListProfileTemplatesWithContext is an alternate form of the ListProfileTemplates method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListProfileTemplatesWithContext(ctx context.Context, listProfileTemplatesOptions *ListProfileTemplatesOptions) (result *TrustedProfileTemplateList, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(listProfileTemplatesOptions, "listProfileTemplatesOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listProfileTemplatesOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListProfileTemplates")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listProfileTemplatesOptions.AccountID != nil {
+		builder.AddQuery("account_id", fmt.Sprint(*listProfileTemplatesOptions.AccountID))
+	}
+	if listProfileTemplatesOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listProfileTemplatesOptions.Limit))
+	}
+	if listProfileTemplatesOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listProfileTemplatesOptions.Pagetoken))
+	}
+	if listProfileTemplatesOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listProfileTemplatesOptions.Sort))
+	}
+	if listProfileTemplatesOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listProfileTemplatesOptions.Order))
+	}
+	if listProfileTemplatesOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listProfileTemplatesOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateList)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateProfileTemplate : Create a Profile Template
+// Create a new Trusted Profile Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) CreateProfileTemplate(createProfileTemplateOptions *CreateProfileTemplateOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateProfileTemplateWithContext(context.Background(), createProfileTemplateOptions)
+}
+
+// CreateProfileTemplateWithContext is an alternate form of the CreateProfileTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateProfileTemplateWithContext(ctx context.Context, createProfileTemplateOptions *CreateProfileTemplateOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createProfileTemplateOptions, "createProfileTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createProfileTemplateOptions, "createProfileTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates`, nil)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createProfileTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateProfileTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createProfileTemplateOptions.AccountID != nil {
+		body["account_id"] = createProfileTemplateOptions.AccountID
+	}
+	if createProfileTemplateOptions.Name != nil {
+		body["name"] = createProfileTemplateOptions.Name
+	}
+	if createProfileTemplateOptions.Description != nil {
+		body["description"] = createProfileTemplateOptions.Description
+	}
+	if createProfileTemplateOptions.Profile != nil {
+		body["profile"] = createProfileTemplateOptions.Profile
+	}
+	if createProfileTemplateOptions.PolicyTemplateReferences != nil {
+		body["policy_template_references"] = createProfileTemplateOptions.PolicyTemplateReferences
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetLatestProfileTemplateVersion : Get latest version of a Profile Template
+// Get latest version of a Trusted Profile Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptions *GetLatestProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetLatestProfileTemplateVersionWithContext(context.Background(), getLatestProfileTemplateVersionOptions)
+}
+
+// GetLatestProfileTemplateVersionWithContext is an alternate form of the GetLatestProfileTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetLatestProfileTemplateVersionWithContext(ctx context.Context, getLatestProfileTemplateVersionOptions *GetLatestProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getLatestProfileTemplateVersionOptions, "getLatestProfileTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getLatestProfileTemplateVersionOptions, "getLatestProfileTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *getLatestProfileTemplateVersionOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getLatestProfileTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetLatestProfileTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getLatestProfileTemplateVersionOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getLatestProfileTemplateVersionOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteAllVersionsOfProfileTemplate : Delete all versions of a Profile Template
+// Delete all versions of a Trusted Profile Template for an Enterprise Account.
+func (iamIdentity *IamIdentityV1) DeleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptions *DeleteAllVersionsOfProfileTemplateOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteAllVersionsOfProfileTemplateWithContext(context.Background(), deleteAllVersionsOfProfileTemplateOptions)
+}
+
+// DeleteAllVersionsOfProfileTemplateWithContext is an alternate form of the DeleteAllVersionsOfProfileTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteAllVersionsOfProfileTemplateWithContext(ctx context.Context, deleteAllVersionsOfProfileTemplateOptions *DeleteAllVersionsOfProfileTemplateOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteAllVersionsOfProfileTemplateOptions, "deleteAllVersionsOfProfileTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteAllVersionsOfProfileTemplateOptions, "deleteAllVersionsOfProfileTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *deleteAllVersionsOfProfileTemplateOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteAllVersionsOfProfileTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteAllVersionsOfProfileTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
+
+	return
+}
+
+// ListVersionsOfProfileTemplate : List Profile Template versions
+// List versions of a Trusted Profile Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptions *ListVersionsOfProfileTemplateOptions) (result *TrustedProfileTemplateList, response *core.DetailedResponse, err error) {
+	return iamIdentity.ListVersionsOfProfileTemplateWithContext(context.Background(), listVersionsOfProfileTemplateOptions)
+}
+
+// ListVersionsOfProfileTemplateWithContext is an alternate form of the ListVersionsOfProfileTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) ListVersionsOfProfileTemplateWithContext(ctx context.Context, listVersionsOfProfileTemplateOptions *ListVersionsOfProfileTemplateOptions) (result *TrustedProfileTemplateList, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(listVersionsOfProfileTemplateOptions, "listVersionsOfProfileTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(listVersionsOfProfileTemplateOptions, "listVersionsOfProfileTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *listVersionsOfProfileTemplateOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range listVersionsOfProfileTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "ListVersionsOfProfileTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if listVersionsOfProfileTemplateOptions.Limit != nil {
+		builder.AddQuery("limit", fmt.Sprint(*listVersionsOfProfileTemplateOptions.Limit))
+	}
+	if listVersionsOfProfileTemplateOptions.Pagetoken != nil {
+		builder.AddQuery("pagetoken", fmt.Sprint(*listVersionsOfProfileTemplateOptions.Pagetoken))
+	}
+	if listVersionsOfProfileTemplateOptions.Sort != nil {
+		builder.AddQuery("sort", fmt.Sprint(*listVersionsOfProfileTemplateOptions.Sort))
+	}
+	if listVersionsOfProfileTemplateOptions.Order != nil {
+		builder.AddQuery("order", fmt.Sprint(*listVersionsOfProfileTemplateOptions.Order))
+	}
+	if listVersionsOfProfileTemplateOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*listVersionsOfProfileTemplateOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateList)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// CreateProfileTemplateVersion : Create a new version of a Profile Template
+// Create a new version of a Trusted Profile Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) CreateProfileTemplateVersion(createProfileTemplateVersionOptions *CreateProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.CreateProfileTemplateVersionWithContext(context.Background(), createProfileTemplateVersionOptions)
+}
+
+// CreateProfileTemplateVersionWithContext is an alternate form of the CreateProfileTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CreateProfileTemplateVersionWithContext(ctx context.Context, createProfileTemplateVersionOptions *CreateProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(createProfileTemplateVersionOptions, "createProfileTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(createProfileTemplateVersionOptions, "createProfileTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *createProfileTemplateVersionOptions.TemplateID,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range createProfileTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CreateProfileTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if createProfileTemplateVersionOptions.AccountID != nil {
+		body["account_id"] = createProfileTemplateVersionOptions.AccountID
+	}
+	if createProfileTemplateVersionOptions.Name != nil {
+		body["name"] = createProfileTemplateVersionOptions.Name
+	}
+	if createProfileTemplateVersionOptions.Description != nil {
+		body["description"] = createProfileTemplateVersionOptions.Description
+	}
+	if createProfileTemplateVersionOptions.Profile != nil {
+		body["profile"] = createProfileTemplateVersionOptions.Profile
+	}
+	if createProfileTemplateVersionOptions.PolicyTemplateReferences != nil {
+		body["policy_template_references"] = createProfileTemplateVersionOptions.PolicyTemplateReferences
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// GetProfileTemplateVersion : Get version of a Profile Template
+// Get a specific version of a Trusted Profile Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) GetProfileTemplateVersion(getProfileTemplateVersionOptions *GetProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.GetProfileTemplateVersionWithContext(context.Background(), getProfileTemplateVersionOptions)
+}
+
+// GetProfileTemplateVersionWithContext is an alternate form of the GetProfileTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) GetProfileTemplateVersionWithContext(ctx context.Context, getProfileTemplateVersionOptions *GetProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(getProfileTemplateVersionOptions, "getProfileTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(getProfileTemplateVersionOptions, "getProfileTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *getProfileTemplateVersionOptions.TemplateID,
+		"version": *getProfileTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range getProfileTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "GetProfileTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	if getProfileTemplateVersionOptions.IncludeHistory != nil {
+		builder.AddQuery("include_history", fmt.Sprint(*getProfileTemplateVersionOptions.IncludeHistory))
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// UpdateProfileTemplateVersion : Update version of a Profile Template
+// Update a specific version of a Trusted Profile Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) UpdateProfileTemplateVersion(updateProfileTemplateVersionOptions *UpdateProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	return iamIdentity.UpdateProfileTemplateVersionWithContext(context.Background(), updateProfileTemplateVersionOptions)
+}
+
+// UpdateProfileTemplateVersionWithContext is an alternate form of the UpdateProfileTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) UpdateProfileTemplateVersionWithContext(ctx context.Context, updateProfileTemplateVersionOptions *UpdateProfileTemplateVersionOptions) (result *TrustedProfileTemplateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateProfileTemplateVersionOptions, "updateProfileTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(updateProfileTemplateVersionOptions, "updateProfileTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *updateProfileTemplateVersionOptions.TemplateID,
+		"version": *updateProfileTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.PUT)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range updateProfileTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "UpdateProfileTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+	if updateProfileTemplateVersionOptions.IfMatch != nil {
+		builder.AddHeader("If-Match", fmt.Sprint(*updateProfileTemplateVersionOptions.IfMatch))
+	}
+
+	body := make(map[string]interface{})
+	if updateProfileTemplateVersionOptions.AccountID != nil {
+		body["account_id"] = updateProfileTemplateVersionOptions.AccountID
+	}
+	if updateProfileTemplateVersionOptions.Name != nil {
+		body["name"] = updateProfileTemplateVersionOptions.Name
+	}
+	if updateProfileTemplateVersionOptions.Description != nil {
+		body["description"] = updateProfileTemplateVersionOptions.Description
+	}
+	if updateProfileTemplateVersionOptions.Profile != nil {
+		body["profile"] = updateProfileTemplateVersionOptions.Profile
+	}
+	if updateProfileTemplateVersionOptions.PolicyTemplateReferences != nil {
+		body["policy_template_references"] = updateProfileTemplateVersionOptions.PolicyTemplateReferences
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = iamIdentity.Service.Request(request, &rawResponse)
+	if err != nil {
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalTrustedProfileTemplateResponse)
+		if err != nil {
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// DeleteProfileTemplateVersion : Delete version of a Profile Template
+// Delete a specific version of a Trusted Profile Template in an Enterprise Account.
+func (iamIdentity *IamIdentityV1) DeleteProfileTemplateVersion(deleteProfileTemplateVersionOptions *DeleteProfileTemplateVersionOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.DeleteProfileTemplateVersionWithContext(context.Background(), deleteProfileTemplateVersionOptions)
+}
+
+// DeleteProfileTemplateVersionWithContext is an alternate form of the DeleteProfileTemplateVersion method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) DeleteProfileTemplateVersionWithContext(ctx context.Context, deleteProfileTemplateVersionOptions *DeleteProfileTemplateVersionOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(deleteProfileTemplateVersionOptions, "deleteProfileTemplateVersionOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(deleteProfileTemplateVersionOptions, "deleteProfileTemplateVersionOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *deleteProfileTemplateVersionOptions.TemplateID,
+		"version": *deleteProfileTemplateVersionOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.DELETE)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions/{version}`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range deleteProfileTemplateVersionOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "DeleteProfileTemplateVersion")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
+
+	return
+}
+
+// CommitProfileTemplate : Commit a template version
+// Commit a specific version of a Trusted Profile Template in an Enterprise Account. A Template must be committed before
+// being assigned, and once committed, can no longer be modified.
+func (iamIdentity *IamIdentityV1) CommitProfileTemplate(commitProfileTemplateOptions *CommitProfileTemplateOptions) (response *core.DetailedResponse, err error) {
+	return iamIdentity.CommitProfileTemplateWithContext(context.Background(), commitProfileTemplateOptions)
+}
+
+// CommitProfileTemplateWithContext is an alternate form of the CommitProfileTemplate method which supports a Context parameter
+func (iamIdentity *IamIdentityV1) CommitProfileTemplateWithContext(ctx context.Context, commitProfileTemplateOptions *CommitProfileTemplateOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(commitProfileTemplateOptions, "commitProfileTemplateOptions cannot be nil")
+	if err != nil {
+		return
+	}
+	err = core.ValidateStruct(commitProfileTemplateOptions, "commitProfileTemplateOptions")
+	if err != nil {
+		return
+	}
+
+	pathParamsMap := map[string]string{
+		"template_id": *commitProfileTemplateOptions.TemplateID,
+		"version": *commitProfileTemplateOptions.Version,
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = iamIdentity.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(iamIdentity.Service.Options.URL, `/v1/profile_templates/{template_id}/versions/{version}/commit`, pathParamsMap)
+	if err != nil {
+		return
+	}
+
+	for headerName, headerValue := range commitProfileTemplateOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("iam_identity", "V1", "CommitProfileTemplate")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		return
+	}
+
+	response, err = iamIdentity.Service.Request(request, nil)
+
+	return
+}
+
 // AccountBasedMfaEnrollment : AccountBasedMfaEnrollment struct
 type AccountBasedMfaEnrollment struct {
 	SecurityQuestions *MfaEnrollmentTypeStatus `json:"security_questions" validate:"required"`
@@ -2925,6 +4961,147 @@ func UnmarshalAccountBasedMfaEnrollment(m map[string]json.RawMessage, result int
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "complies", &obj.Complies)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// AccountSettingsComponent : AccountSettingsComponent struct
+type AccountSettingsComponent struct {
+	// Defines whether or not creating a Service Id is access controlled. Valid values:
+	//   * RESTRICTED - to apply access control
+	//   * NOT_RESTRICTED - to remove access control
+	//   * NOT_SET - to 'unset' a previous set value.
+	RestrictCreateServiceID *string `json:"restrict_create_service_id,omitempty"`
+
+	// Defines whether or not creating platform API keys is access controlled. Valid values:
+	//   * RESTRICTED - to apply access control
+	//   * NOT_RESTRICTED - to remove access control
+	//   * NOT_SET - to 'unset' a previous set value.
+	RestrictCreatePlatformApikey *string `json:"restrict_create_platform_apikey,omitempty"`
+
+	// Defines the IP addresses and subnets from which IAM tokens can be created for the account.
+	AllowedIPAddresses *string `json:"allowed_ip_addresses,omitempty"`
+
+	// Defines the MFA trait for the account. Valid values:
+	//   * NONE - No MFA trait set
+	//   * TOTP - For all non-federated IBMId users
+	//   * TOTP4ALL - For all users
+	//   * LEVEL1 - Email-based MFA for all users
+	//   * LEVEL2 - TOTP-based MFA for all users
+	//   * LEVEL3 - U2F MFA for all users.
+	Mfa *string `json:"mfa,omitempty"`
+
+	// List of users that are exempted from the MFA requirement of the account.
+	UserMfa []AccountSettingsUserMfa `json:"user_mfa,omitempty"`
+
+	// Defines the session expiration in seconds for the account. Valid values:
+	//   * Any whole number between between '900' and '86400'
+	//   * NOT_SET - To unset account setting and use service default.
+	SessionExpirationInSeconds *string `json:"session_expiration_in_seconds,omitempty"`
+
+	// Defines the period of time in seconds in which a session will be invalidated due to inactivity. Valid values:
+	//   * Any whole number between '900' and '7200'
+	//   * NOT_SET - To unset account setting and use service default.
+	SessionInvalidationInSeconds *string `json:"session_invalidation_in_seconds,omitempty"`
+
+	// Defines the max allowed sessions per identity required by the account. Valid values:
+	//   * Any whole number greater than 0
+	//   * NOT_SET - To unset account setting and use service default.
+	MaxSessionsPerIdentity *string `json:"max_sessions_per_identity,omitempty"`
+
+	// Defines the access token expiration in seconds. Valid values:
+	//   * Any whole number between '900' and '3600'
+	//   * NOT_SET - To unset account setting and use service default.
+	SystemAccessTokenExpirationInSeconds *string `json:"system_access_token_expiration_in_seconds,omitempty"`
+
+	// Defines the refresh token expiration in seconds. Valid values:
+	//   * Any whole number between '900' and '259200'
+	//   * NOT_SET - To unset account setting and use service default.
+	SystemRefreshTokenExpirationInSeconds *string `json:"system_refresh_token_expiration_in_seconds,omitempty"`
+}
+
+// Constants associated with the AccountSettingsComponent.RestrictCreateServiceID property.
+// Defines whether or not creating a Service Id is access controlled. Valid values:
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to 'unset' a previous set value.
+const (
+	AccountSettingsComponentRestrictCreateServiceIDNotRestrictedConst = "NOT_RESTRICTED"
+	AccountSettingsComponentRestrictCreateServiceIDNotSetConst = "NOT_SET"
+	AccountSettingsComponentRestrictCreateServiceIDRestrictedConst = "RESTRICTED"
+)
+
+// Constants associated with the AccountSettingsComponent.RestrictCreatePlatformApikey property.
+// Defines whether or not creating platform API keys is access controlled. Valid values:
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to 'unset' a previous set value.
+const (
+	AccountSettingsComponentRestrictCreatePlatformApikeyNotRestrictedConst = "NOT_RESTRICTED"
+	AccountSettingsComponentRestrictCreatePlatformApikeyNotSetConst = "NOT_SET"
+	AccountSettingsComponentRestrictCreatePlatformApikeyRestrictedConst = "RESTRICTED"
+)
+
+// Constants associated with the AccountSettingsComponent.Mfa property.
+// Defines the MFA trait for the account. Valid values:
+//   * NONE - No MFA trait set
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
+const (
+	AccountSettingsComponentMfaLevel1Const = "LEVEL1"
+	AccountSettingsComponentMfaLevel2Const = "LEVEL2"
+	AccountSettingsComponentMfaLevel3Const = "LEVEL3"
+	AccountSettingsComponentMfaNoneConst = "NONE"
+	AccountSettingsComponentMfaTotpConst = "TOTP"
+	AccountSettingsComponentMfaTotp4allConst = "TOTP4ALL"
+)
+
+// UnmarshalAccountSettingsComponent unmarshals an instance of AccountSettingsComponent from the specified map of raw messages.
+func UnmarshalAccountSettingsComponent(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(AccountSettingsComponent)
+	err = core.UnmarshalPrimitive(m, "restrict_create_service_id", &obj.RestrictCreateServiceID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "restrict_create_platform_apikey", &obj.RestrictCreatePlatformApikey)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "allowed_ip_addresses", &obj.AllowedIPAddresses)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "mfa", &obj.Mfa)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "user_mfa", &obj.UserMfa, UnmarshalAccountSettingsUserMfa)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "session_expiration_in_seconds", &obj.SessionExpirationInSeconds)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "session_invalidation_in_seconds", &obj.SessionInvalidationInSeconds)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "max_sessions_per_identity", &obj.MaxSessionsPerIdentity)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "system_access_token_expiration_in_seconds", &obj.SystemAccessTokenExpirationInSeconds)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "system_refresh_token_expiration_in_seconds", &obj.SystemRefreshTokenExpirationInSeconds)
 	if err != nil {
 		return
 	}
@@ -3002,43 +5179,43 @@ type AccountSettingsResponse struct {
 
 // Constants associated with the AccountSettingsResponse.RestrictCreateServiceID property.
 // Defines whether or not creating a Service Id is access controlled. Valid values:
-//   - RESTRICTED - to apply access control
-//   - NOT_RESTRICTED - to remove access control
-//   - NOT_SET - to 'unset' a previous set value.
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to 'unset' a previous set value.
 const (
 	AccountSettingsResponseRestrictCreateServiceIDNotRestrictedConst = "NOT_RESTRICTED"
-	AccountSettingsResponseRestrictCreateServiceIDNotSetConst        = "NOT_SET"
-	AccountSettingsResponseRestrictCreateServiceIDRestrictedConst    = "RESTRICTED"
+	AccountSettingsResponseRestrictCreateServiceIDNotSetConst = "NOT_SET"
+	AccountSettingsResponseRestrictCreateServiceIDRestrictedConst = "RESTRICTED"
 )
 
 // Constants associated with the AccountSettingsResponse.RestrictCreatePlatformApikey property.
 // Defines whether or not creating platform API keys is access controlled. Valid values:
-//   - RESTRICTED - to apply access control
-//   - NOT_RESTRICTED - to remove access control
-//   - NOT_SET - to 'unset' a previous set value.
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to 'unset' a previous set value.
 const (
 	AccountSettingsResponseRestrictCreatePlatformApikeyNotRestrictedConst = "NOT_RESTRICTED"
-	AccountSettingsResponseRestrictCreatePlatformApikeyNotSetConst        = "NOT_SET"
-	AccountSettingsResponseRestrictCreatePlatformApikeyRestrictedConst    = "RESTRICTED"
+	AccountSettingsResponseRestrictCreatePlatformApikeyNotSetConst = "NOT_SET"
+	AccountSettingsResponseRestrictCreatePlatformApikeyRestrictedConst = "RESTRICTED"
 )
 
 // Constants associated with the AccountSettingsResponse.Mfa property.
 // Defines the MFA trait for the account. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	AccountSettingsResponseMfaLevel1Const     = "LEVEL1"
-	AccountSettingsResponseMfaLevel2Const     = "LEVEL2"
-	AccountSettingsResponseMfaLevel3Const     = "LEVEL3"
-	AccountSettingsResponseMfaNoneConst       = "NONE"
+	AccountSettingsResponseMfaLevel1Const = "LEVEL1"
+	AccountSettingsResponseMfaLevel2Const = "LEVEL2"
+	AccountSettingsResponseMfaLevel3Const = "LEVEL3"
+	AccountSettingsResponseMfaNoneConst = "NONE"
 	AccountSettingsResponseMfaNoneNoRopcConst = "NONE_NO_ROPC"
-	AccountSettingsResponseMfaTotpConst       = "TOTP"
-	AccountSettingsResponseMfaTotp4allConst   = "TOTP4ALL"
+	AccountSettingsResponseMfaTotpConst = "TOTP"
+	AccountSettingsResponseMfaTotp4allConst = "TOTP4ALL"
 )
 
 // UnmarshalAccountSettingsResponse unmarshals an instance of AccountSettingsResponse from the specified map of raw messages.
@@ -3104,6 +5281,174 @@ func UnmarshalAccountSettingsResponse(m map[string]json.RawMessage, result inter
 	return
 }
 
+// AccountSettingsTemplateList : AccountSettingsTemplateList struct
+type AccountSettingsTemplateList struct {
+	// Context with key properties for problem determination.
+	Context *ResponseContext `json:"context,omitempty"`
+
+	// The offset of the current page.
+	Offset *int64 `json:"offset,omitempty"`
+
+	// Optional size of a single page.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Link to the first page.
+	First *string `json:"first,omitempty"`
+
+	// Link to the previous available page. If 'previous' property is not part of the response no previous page is
+	// available.
+	Previous *string `json:"previous,omitempty"`
+
+	// Link to the next available page. If 'next' property is not part of the response no next page is available.
+	Next *string `json:"next,omitempty"`
+
+	// List of Account Settings Templates based on the query paramters and the page size. The account_settings_templates
+	// array is always part of the response but might be empty depending on the query parameter values provided.
+	AccountSettingsTemplates []AccountSettingsTemplateResponse `json:"account_settings_templates" validate:"required"`
+}
+
+// UnmarshalAccountSettingsTemplateList unmarshals an instance of AccountSettingsTemplateList from the specified map of raw messages.
+func UnmarshalAccountSettingsTemplateList(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(AccountSettingsTemplateList)
+	err = core.UnmarshalModel(m, "context", &obj.Context, UnmarshalResponseContext)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "first", &obj.First)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "previous", &obj.Previous)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "next", &obj.Next)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "account_settings_templates", &obj.AccountSettingsTemplates, UnmarshalAccountSettingsTemplateResponse)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// AccountSettingsTemplateResponse : Response body format for Account Settings Template REST requests.
+type AccountSettingsTemplateResponse struct {
+	// ID of the the template.
+	ID *string `json:"id" validate:"required"`
+
+	// Version of the the template.
+	Version *int64 `json:"version" validate:"required"`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id" validate:"required"`
+
+	// Name of the Template.
+	Name *string `json:"name" validate:"required"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	// Committed flag determines if the template is ready for assignment.
+	Committed *bool `json:"committed" validate:"required"`
+
+	AccountSettings *AccountSettingsComponent `json:"account_settings" validate:"required"`
+
+	// History of the Template.
+	History []EnityHistoryRecord `json:"history,omitempty"`
+
+	// Entity tag for this templateId-version combination.
+	EntityTag *string `json:"entity_tag" validate:"required"`
+
+	// Cloud resource name.
+	CRN *string `json:"crn" validate:"required"`
+
+	// Template Created At.
+	CreatedAt *string `json:"created_at,omitempty"`
+
+	// IAMid of the creator.
+	CreatedByID *string `json:"created_by_id,omitempty"`
+
+	// Template last modified at.
+	LastModifiedAt *string `json:"last_modified_at,omitempty"`
+
+	// IAMid of the identity that made the latest modification.
+	LastModifiedByID *string `json:"last_modified_by_id,omitempty"`
+}
+
+// UnmarshalAccountSettingsTemplateResponse unmarshals an instance of AccountSettingsTemplateResponse from the specified map of raw messages.
+func UnmarshalAccountSettingsTemplateResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(AccountSettingsTemplateResponse)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version", &obj.Version)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "committed", &obj.Committed)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "account_settings", &obj.AccountSettings, UnmarshalAccountSettingsComponent)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "history", &obj.History, UnmarshalEnityHistoryRecord)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "entity_tag", &obj.EntityTag)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "crn", &obj.CRN)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_by_id", &obj.CreatedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_at", &obj.LastModifiedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_by_id", &obj.LastModifiedByID)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // AccountSettingsUserMfa : AccountSettingsUserMfa struct
 type AccountSettingsUserMfa struct {
 	// The iam_id of the user.
@@ -3122,28 +5467,28 @@ type AccountSettingsUserMfa struct {
 
 // Constants associated with the AccountSettingsUserMfa.Mfa property.
 // Defines the MFA requirement for the user. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	AccountSettingsUserMfaMfaLevel1Const     = "LEVEL1"
-	AccountSettingsUserMfaMfaLevel2Const     = "LEVEL2"
-	AccountSettingsUserMfaMfaLevel3Const     = "LEVEL3"
-	AccountSettingsUserMfaMfaNoneConst       = "NONE"
+	AccountSettingsUserMfaMfaLevel1Const = "LEVEL1"
+	AccountSettingsUserMfaMfaLevel2Const = "LEVEL2"
+	AccountSettingsUserMfaMfaLevel3Const = "LEVEL3"
+	AccountSettingsUserMfaMfaNoneConst = "NONE"
 	AccountSettingsUserMfaMfaNoneNoRopcConst = "NONE_NO_ROPC"
-	AccountSettingsUserMfaMfaTotpConst       = "TOTP"
-	AccountSettingsUserMfaMfaTotp4allConst   = "TOTP4ALL"
+	AccountSettingsUserMfaMfaTotpConst = "TOTP"
+	AccountSettingsUserMfaMfaTotp4allConst = "TOTP4ALL"
 )
 
 // NewAccountSettingsUserMfa : Instantiate AccountSettingsUserMfa (Generic Model Constructor)
 func (*IamIdentityV1) NewAccountSettingsUserMfa(iamID string, mfa string) (_model *AccountSettingsUserMfa, err error) {
 	_model = &AccountSettingsUserMfa{
 		IamID: core.StringPtr(iamID),
-		Mfa:   core.StringPtr(mfa),
+		Mfa: core.StringPtr(mfa),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -3538,6 +5883,262 @@ func UnmarshalApikeyActivityUser(m map[string]json.RawMessage, result interface{
 	return
 }
 
+// CommitAccountSettingsTemplateOptions : The CommitAccountSettingsTemplate options.
+type CommitAccountSettingsTemplateOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Account Settings Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCommitAccountSettingsTemplateOptions : Instantiate CommitAccountSettingsTemplateOptions
+func (*IamIdentityV1) NewCommitAccountSettingsTemplateOptions(templateID string, version string) *CommitAccountSettingsTemplateOptions {
+	return &CommitAccountSettingsTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CommitAccountSettingsTemplateOptions) SetTemplateID(templateID string) *CommitAccountSettingsTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *CommitAccountSettingsTemplateOptions) SetVersion(version string) *CommitAccountSettingsTemplateOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CommitAccountSettingsTemplateOptions) SetHeaders(param map[string]string) *CommitAccountSettingsTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// CommitProfileTemplateOptions : The CommitProfileTemplate options.
+type CommitProfileTemplateOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Profile Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCommitProfileTemplateOptions : Instantiate CommitProfileTemplateOptions
+func (*IamIdentityV1) NewCommitProfileTemplateOptions(templateID string, version string) *CommitProfileTemplateOptions {
+	return &CommitProfileTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CommitProfileTemplateOptions) SetTemplateID(templateID string) *CommitProfileTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *CommitProfileTemplateOptions) SetVersion(version string) *CommitProfileTemplateOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CommitProfileTemplateOptions) SetHeaders(param map[string]string) *CommitProfileTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateAccountSettingsAssignmentOptions : The CreateAccountSettingsAssignment options.
+type CreateAccountSettingsAssignmentOptions struct {
+	// ID of the template to assign.
+	TemplateID *string `json:"template_id" validate:"required"`
+
+	// Version of the template to assign.
+	TemplateVersion *int64 `json:"template_version" validate:"required"`
+
+	// Type of target to deploy to.
+	TargetType *string `json:"target_type" validate:"required"`
+
+	// Identifier of target to deploy to.
+	Target *string `json:"target" validate:"required"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the CreateAccountSettingsAssignmentOptions.TargetType property.
+// Type of target to deploy to.
+const (
+	CreateAccountSettingsAssignmentOptionsTargetTypeAccountConst = "Account"
+	CreateAccountSettingsAssignmentOptionsTargetTypeAccountgroupConst = "AccountGroup"
+)
+
+// NewCreateAccountSettingsAssignmentOptions : Instantiate CreateAccountSettingsAssignmentOptions
+func (*IamIdentityV1) NewCreateAccountSettingsAssignmentOptions(templateID string, templateVersion int64, targetType string, target string) *CreateAccountSettingsAssignmentOptions {
+	return &CreateAccountSettingsAssignmentOptions{
+		TemplateID: core.StringPtr(templateID),
+		TemplateVersion: core.Int64Ptr(templateVersion),
+		TargetType: core.StringPtr(targetType),
+		Target: core.StringPtr(target),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CreateAccountSettingsAssignmentOptions) SetTemplateID(templateID string) *CreateAccountSettingsAssignmentOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *CreateAccountSettingsAssignmentOptions) SetTemplateVersion(templateVersion int64) *CreateAccountSettingsAssignmentOptions {
+	_options.TemplateVersion = core.Int64Ptr(templateVersion)
+	return _options
+}
+
+// SetTargetType : Allow user to set TargetType
+func (_options *CreateAccountSettingsAssignmentOptions) SetTargetType(targetType string) *CreateAccountSettingsAssignmentOptions {
+	_options.TargetType = core.StringPtr(targetType)
+	return _options
+}
+
+// SetTarget : Allow user to set Target
+func (_options *CreateAccountSettingsAssignmentOptions) SetTarget(target string) *CreateAccountSettingsAssignmentOptions {
+	_options.Target = core.StringPtr(target)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateAccountSettingsAssignmentOptions) SetHeaders(param map[string]string) *CreateAccountSettingsAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateAccountSettingsTemplateOptions : The CreateAccountSettingsTemplate options.
+type CreateAccountSettingsTemplateOptions struct {
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	AccountSettings *AccountSettingsComponent `json:"account_settings,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateAccountSettingsTemplateOptions : Instantiate CreateAccountSettingsTemplateOptions
+func (*IamIdentityV1) NewCreateAccountSettingsTemplateOptions() *CreateAccountSettingsTemplateOptions {
+	return &CreateAccountSettingsTemplateOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *CreateAccountSettingsTemplateOptions) SetAccountID(accountID string) *CreateAccountSettingsTemplateOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateAccountSettingsTemplateOptions) SetName(name string) *CreateAccountSettingsTemplateOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *CreateAccountSettingsTemplateOptions) SetDescription(description string) *CreateAccountSettingsTemplateOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetAccountSettings : Allow user to set AccountSettings
+func (_options *CreateAccountSettingsTemplateOptions) SetAccountSettings(accountSettings *AccountSettingsComponent) *CreateAccountSettingsTemplateOptions {
+	_options.AccountSettings = accountSettings
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateAccountSettingsTemplateOptions) SetHeaders(param map[string]string) *CreateAccountSettingsTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateAccountSettingsTemplateVersionOptions : The CreateAccountSettingsTemplateVersion options.
+type CreateAccountSettingsTemplateVersionOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	AccountSettings *AccountSettingsComponent `json:"account_settings,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateAccountSettingsTemplateVersionOptions : Instantiate CreateAccountSettingsTemplateVersionOptions
+func (*IamIdentityV1) NewCreateAccountSettingsTemplateVersionOptions(templateID string) *CreateAccountSettingsTemplateVersionOptions {
+	return &CreateAccountSettingsTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CreateAccountSettingsTemplateVersionOptions) SetTemplateID(templateID string) *CreateAccountSettingsTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *CreateAccountSettingsTemplateVersionOptions) SetAccountID(accountID string) *CreateAccountSettingsTemplateVersionOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateAccountSettingsTemplateVersionOptions) SetName(name string) *CreateAccountSettingsTemplateVersionOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *CreateAccountSettingsTemplateVersionOptions) SetDescription(description string) *CreateAccountSettingsTemplateVersionOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetAccountSettings : Allow user to set AccountSettings
+func (_options *CreateAccountSettingsTemplateVersionOptions) SetAccountSettings(accountSettings *AccountSettingsComponent) *CreateAccountSettingsTemplateVersionOptions {
+	_options.AccountSettings = accountSettings
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateAccountSettingsTemplateVersionOptions) SetHeaders(param map[string]string) *CreateAccountSettingsTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // CreateAPIKeyOptions : The CreateAPIKey options.
 type CreateAPIKeyOptions struct {
 	// Name of the API key. The name is not checked for uniqueness. Therefore multiple names with the same value can exist.
@@ -3575,7 +6176,7 @@ type CreateAPIKeyOptions struct {
 // NewCreateAPIKeyOptions : Instantiate CreateAPIKeyOptions
 func (*IamIdentityV1) NewCreateAPIKeyOptions(name string, iamID string) *CreateAPIKeyOptions {
 	return &CreateAPIKeyOptions{
-		Name:  core.StringPtr(name),
+		Name: core.StringPtr(name),
 		IamID: core.StringPtr(iamID),
 	}
 }
@@ -3663,8 +6264,8 @@ type CreateClaimRuleOptions struct {
 // NewCreateClaimRuleOptions : Instantiate CreateClaimRuleOptions
 func (*IamIdentityV1) NewCreateClaimRuleOptions(profileID string, typeVar string, conditions []ProfileClaimRuleConditions) *CreateClaimRuleOptions {
 	return &CreateClaimRuleOptions{
-		ProfileID:  core.StringPtr(profileID),
-		Type:       core.StringPtr(typeVar),
+		ProfileID: core.StringPtr(profileID),
+		Type: core.StringPtr(typeVar),
 		Conditions: conditions,
 	}
 }
@@ -3745,8 +6346,8 @@ type CreateLinkOptions struct {
 func (*IamIdentityV1) NewCreateLinkOptions(profileID string, crType string, link *CreateProfileLinkRequestLink) *CreateLinkOptions {
 	return &CreateLinkOptions{
 		ProfileID: core.StringPtr(profileID),
-		CrType:    core.StringPtr(crType),
-		Link:      link,
+		CrType: core.StringPtr(crType),
+		Link: link,
 	}
 }
 
@@ -3832,7 +6433,7 @@ type CreateProfileLinkRequestLink struct {
 // NewCreateProfileLinkRequestLink : Instantiate CreateProfileLinkRequestLink (Generic Model Constructor)
 func (*IamIdentityV1) NewCreateProfileLinkRequestLink(crn string, namespace string) (_model *CreateProfileLinkRequestLink, err error) {
 	_model = &CreateProfileLinkRequestLink{
-		CRN:       core.StringPtr(crn),
+		CRN: core.StringPtr(crn),
 		Namespace: core.StringPtr(namespace),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -3878,7 +6479,7 @@ type CreateProfileOptions struct {
 // NewCreateProfileOptions : Instantiate CreateProfileOptions
 func (*IamIdentityV1) NewCreateProfileOptions(name string, accountID string) *CreateProfileOptions {
 	return &CreateProfileOptions{
-		Name:      core.StringPtr(name),
+		Name: core.StringPtr(name),
 		AccountID: core.StringPtr(accountID),
 	}
 }
@@ -3907,6 +6508,141 @@ func (options *CreateProfileOptions) SetHeaders(param map[string]string) *Create
 	return options
 }
 
+// CreateProfileTemplateOptions : The CreateProfileTemplate options.
+type CreateProfileTemplateOptions struct {
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	// Input body parameters for the TemplateProfileComponent.
+	Profile *TemplateProfileComponentRequest `json:"profile,omitempty"`
+
+	// Policy templates to be deployed for the Profile component.
+	PolicyTemplateReferences []PolicyTemplateReference `json:"policy_template_references,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateProfileTemplateOptions : Instantiate CreateProfileTemplateOptions
+func (*IamIdentityV1) NewCreateProfileTemplateOptions() *CreateProfileTemplateOptions {
+	return &CreateProfileTemplateOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *CreateProfileTemplateOptions) SetAccountID(accountID string) *CreateProfileTemplateOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateProfileTemplateOptions) SetName(name string) *CreateProfileTemplateOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *CreateProfileTemplateOptions) SetDescription(description string) *CreateProfileTemplateOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetProfile : Allow user to set Profile
+func (_options *CreateProfileTemplateOptions) SetProfile(profile *TemplateProfileComponentRequest) *CreateProfileTemplateOptions {
+	_options.Profile = profile
+	return _options
+}
+
+// SetPolicyTemplateReferences : Allow user to set PolicyTemplateReferences
+func (_options *CreateProfileTemplateOptions) SetPolicyTemplateReferences(policyTemplateReferences []PolicyTemplateReference) *CreateProfileTemplateOptions {
+	_options.PolicyTemplateReferences = policyTemplateReferences
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateProfileTemplateOptions) SetHeaders(param map[string]string) *CreateProfileTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateProfileTemplateVersionOptions : The CreateProfileTemplateVersion options.
+type CreateProfileTemplateVersionOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	// Input body parameters for the TemplateProfileComponent.
+	Profile *TemplateProfileComponentRequest `json:"profile,omitempty"`
+
+	// Policy templates to be deployed for the Profile component.
+	PolicyTemplateReferences []PolicyTemplateReference `json:"policy_template_references,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewCreateProfileTemplateVersionOptions : Instantiate CreateProfileTemplateVersionOptions
+func (*IamIdentityV1) NewCreateProfileTemplateVersionOptions(templateID string) *CreateProfileTemplateVersionOptions {
+	return &CreateProfileTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CreateProfileTemplateVersionOptions) SetTemplateID(templateID string) *CreateProfileTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *CreateProfileTemplateVersionOptions) SetAccountID(accountID string) *CreateProfileTemplateVersionOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *CreateProfileTemplateVersionOptions) SetName(name string) *CreateProfileTemplateVersionOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *CreateProfileTemplateVersionOptions) SetDescription(description string) *CreateProfileTemplateVersionOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetProfile : Allow user to set Profile
+func (_options *CreateProfileTemplateVersionOptions) SetProfile(profile *TemplateProfileComponentRequest) *CreateProfileTemplateVersionOptions {
+	_options.Profile = profile
+	return _options
+}
+
+// SetPolicyTemplateReferences : Allow user to set PolicyTemplateReferences
+func (_options *CreateProfileTemplateVersionOptions) SetPolicyTemplateReferences(policyTemplateReferences []PolicyTemplateReference) *CreateProfileTemplateVersionOptions {
+	_options.PolicyTemplateReferences = policyTemplateReferences
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateProfileTemplateVersionOptions) SetHeaders(param map[string]string) *CreateProfileTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // CreateReportOptions : The CreateReport options.
 type CreateReportOptions struct {
 	// ID of the account.
@@ -3916,7 +6652,7 @@ type CreateReportOptions struct {
 	// time indicated by duration.
 	Type *string `json:"type,omitempty"`
 
-	// Optional duration of the report. The supported unit of duration is hours.
+	// Optional duration of the report, supported unit of duration is hours.
 	Duration *string `json:"duration,omitempty"`
 
 	// Allows users to set headers on API requests
@@ -3984,7 +6720,7 @@ type CreateServiceIDOptions struct {
 func (*IamIdentityV1) NewCreateServiceIDOptions(accountID string, name string) *CreateServiceIDOptions {
 	return &CreateServiceIDOptions{
 		AccountID: core.StringPtr(accountID),
-		Name:      core.StringPtr(name),
+		Name: core.StringPtr(name),
 	}
 }
 
@@ -4026,6 +6762,193 @@ func (_options *CreateServiceIDOptions) SetEntityLock(entityLock string) *Create
 
 // SetHeaders : Allow user to set Headers
 func (options *CreateServiceIDOptions) SetHeaders(param map[string]string) *CreateServiceIDOptions {
+	options.Headers = param
+	return options
+}
+
+// CreateTrustedProfileAssignmentOptions : The CreateTrustedProfileAssignment options.
+type CreateTrustedProfileAssignmentOptions struct {
+	// ID of the template to assign.
+	TemplateID *string `json:"template_id" validate:"required"`
+
+	// Version of the template to assign.
+	TemplateVersion *int64 `json:"template_version" validate:"required"`
+
+	// Type of target to deploy to.
+	TargetType *string `json:"target_type" validate:"required"`
+
+	// Identifier of target to deploy to.
+	Target *string `json:"target" validate:"required"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the CreateTrustedProfileAssignmentOptions.TargetType property.
+// Type of target to deploy to.
+const (
+	CreateTrustedProfileAssignmentOptionsTargetTypeAccountConst = "Account"
+	CreateTrustedProfileAssignmentOptionsTargetTypeAccountgroupConst = "AccountGroup"
+)
+
+// NewCreateTrustedProfileAssignmentOptions : Instantiate CreateTrustedProfileAssignmentOptions
+func (*IamIdentityV1) NewCreateTrustedProfileAssignmentOptions(templateID string, templateVersion int64, targetType string, target string) *CreateTrustedProfileAssignmentOptions {
+	return &CreateTrustedProfileAssignmentOptions{
+		TemplateID: core.StringPtr(templateID),
+		TemplateVersion: core.Int64Ptr(templateVersion),
+		TargetType: core.StringPtr(targetType),
+		Target: core.StringPtr(target),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *CreateTrustedProfileAssignmentOptions) SetTemplateID(templateID string) *CreateTrustedProfileAssignmentOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *CreateTrustedProfileAssignmentOptions) SetTemplateVersion(templateVersion int64) *CreateTrustedProfileAssignmentOptions {
+	_options.TemplateVersion = core.Int64Ptr(templateVersion)
+	return _options
+}
+
+// SetTargetType : Allow user to set TargetType
+func (_options *CreateTrustedProfileAssignmentOptions) SetTargetType(targetType string) *CreateTrustedProfileAssignmentOptions {
+	_options.TargetType = core.StringPtr(targetType)
+	return _options
+}
+
+// SetTarget : Allow user to set Target
+func (_options *CreateTrustedProfileAssignmentOptions) SetTarget(target string) *CreateTrustedProfileAssignmentOptions {
+	_options.Target = core.StringPtr(target)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *CreateTrustedProfileAssignmentOptions) SetHeaders(param map[string]string) *CreateTrustedProfileAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteAccountSettingsAssignmentOptions : The DeleteAccountSettingsAssignment options.
+type DeleteAccountSettingsAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteAccountSettingsAssignmentOptions : Instantiate DeleteAccountSettingsAssignmentOptions
+func (*IamIdentityV1) NewDeleteAccountSettingsAssignmentOptions(assignmentID string) *DeleteAccountSettingsAssignmentOptions {
+	return &DeleteAccountSettingsAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *DeleteAccountSettingsAssignmentOptions) SetAssignmentID(assignmentID string) *DeleteAccountSettingsAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteAccountSettingsAssignmentOptions) SetHeaders(param map[string]string) *DeleteAccountSettingsAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteAccountSettingsTemplateVersionOptions : The DeleteAccountSettingsTemplateVersion options.
+type DeleteAccountSettingsTemplateVersionOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Account Settings Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteAccountSettingsTemplateVersionOptions : Instantiate DeleteAccountSettingsTemplateVersionOptions
+func (*IamIdentityV1) NewDeleteAccountSettingsTemplateVersionOptions(templateID string, version string) *DeleteAccountSettingsTemplateVersionOptions {
+	return &DeleteAccountSettingsTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *DeleteAccountSettingsTemplateVersionOptions) SetTemplateID(templateID string) *DeleteAccountSettingsTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *DeleteAccountSettingsTemplateVersionOptions) SetVersion(version string) *DeleteAccountSettingsTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteAccountSettingsTemplateVersionOptions) SetHeaders(param map[string]string) *DeleteAccountSettingsTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteAllVersionsOfAccountSettingsTemplateOptions : The DeleteAllVersionsOfAccountSettingsTemplate options.
+type DeleteAllVersionsOfAccountSettingsTemplateOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteAllVersionsOfAccountSettingsTemplateOptions : Instantiate DeleteAllVersionsOfAccountSettingsTemplateOptions
+func (*IamIdentityV1) NewDeleteAllVersionsOfAccountSettingsTemplateOptions(templateID string) *DeleteAllVersionsOfAccountSettingsTemplateOptions {
+	return &DeleteAllVersionsOfAccountSettingsTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *DeleteAllVersionsOfAccountSettingsTemplateOptions) SetTemplateID(templateID string) *DeleteAllVersionsOfAccountSettingsTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteAllVersionsOfAccountSettingsTemplateOptions) SetHeaders(param map[string]string) *DeleteAllVersionsOfAccountSettingsTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteAllVersionsOfProfileTemplateOptions : The DeleteAllVersionsOfProfileTemplate options.
+type DeleteAllVersionsOfProfileTemplateOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteAllVersionsOfProfileTemplateOptions : Instantiate DeleteAllVersionsOfProfileTemplateOptions
+func (*IamIdentityV1) NewDeleteAllVersionsOfProfileTemplateOptions(templateID string) *DeleteAllVersionsOfProfileTemplateOptions {
+	return &DeleteAllVersionsOfProfileTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *DeleteAllVersionsOfProfileTemplateOptions) SetTemplateID(templateID string) *DeleteAllVersionsOfProfileTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteAllVersionsOfProfileTemplateOptions) SetHeaders(param map[string]string) *DeleteAllVersionsOfProfileTemplateOptions {
 	options.Headers = param
 	return options
 }
@@ -4074,7 +6997,7 @@ type DeleteClaimRuleOptions struct {
 func (*IamIdentityV1) NewDeleteClaimRuleOptions(profileID string, ruleID string) *DeleteClaimRuleOptions {
 	return &DeleteClaimRuleOptions{
 		ProfileID: core.StringPtr(profileID),
-		RuleID:    core.StringPtr(ruleID),
+		RuleID: core.StringPtr(ruleID),
 	}
 }
 
@@ -4112,7 +7035,7 @@ type DeleteLinkOptions struct {
 func (*IamIdentityV1) NewDeleteLinkOptions(profileID string, linkID string) *DeleteLinkOptions {
 	return &DeleteLinkOptions{
 		ProfileID: core.StringPtr(profileID),
-		LinkID:    core.StringPtr(linkID),
+		LinkID: core.StringPtr(linkID),
 	}
 }
 
@@ -4152,15 +7075,15 @@ type DeleteProfileIdentityOptions struct {
 // Constants associated with the DeleteProfileIdentityOptions.IdentityType property.
 // Type of the identity.
 const (
-	DeleteProfileIdentityOptionsIdentityTypeCRNConst       = "crn"
+	DeleteProfileIdentityOptionsIdentityTypeCRNConst = "crn"
 	DeleteProfileIdentityOptionsIdentityTypeServiceidConst = "serviceid"
-	DeleteProfileIdentityOptionsIdentityTypeUserConst      = "user"
+	DeleteProfileIdentityOptionsIdentityTypeUserConst = "user"
 )
 
 // NewDeleteProfileIdentityOptions : Instantiate DeleteProfileIdentityOptions
 func (*IamIdentityV1) NewDeleteProfileIdentityOptions(profileID string, identityType string, identifierID string) *DeleteProfileIdentityOptions {
 	return &DeleteProfileIdentityOptions{
-		ProfileID:    core.StringPtr(profileID),
+		ProfileID: core.StringPtr(profileID),
 		IdentityType: core.StringPtr(identityType),
 		IdentifierID: core.StringPtr(identifierID),
 	}
@@ -4218,6 +7141,44 @@ func (options *DeleteProfileOptions) SetHeaders(param map[string]string) *Delete
 	return options
 }
 
+// DeleteProfileTemplateVersionOptions : The DeleteProfileTemplateVersion options.
+type DeleteProfileTemplateVersionOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Profile Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteProfileTemplateVersionOptions : Instantiate DeleteProfileTemplateVersionOptions
+func (*IamIdentityV1) NewDeleteProfileTemplateVersionOptions(templateID string, version string) *DeleteProfileTemplateVersionOptions {
+	return &DeleteProfileTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *DeleteProfileTemplateVersionOptions) SetTemplateID(templateID string) *DeleteProfileTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *DeleteProfileTemplateVersionOptions) SetVersion(version string) *DeleteProfileTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteProfileTemplateVersionOptions) SetHeaders(param map[string]string) *DeleteProfileTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // DeleteServiceIDOptions : The DeleteServiceID options.
 type DeleteServiceIDOptions struct {
 	// Unique ID of the service ID.
@@ -4242,6 +7203,34 @@ func (_options *DeleteServiceIDOptions) SetID(id string) *DeleteServiceIDOptions
 
 // SetHeaders : Allow user to set Headers
 func (options *DeleteServiceIDOptions) SetHeaders(param map[string]string) *DeleteServiceIDOptions {
+	options.Headers = param
+	return options
+}
+
+// DeleteTrustedProfileAssignmentOptions : The DeleteTrustedProfileAssignment options.
+type DeleteTrustedProfileAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewDeleteTrustedProfileAssignmentOptions : Instantiate DeleteTrustedProfileAssignmentOptions
+func (*IamIdentityV1) NewDeleteTrustedProfileAssignmentOptions(assignmentID string) *DeleteTrustedProfileAssignmentOptions {
+	return &DeleteTrustedProfileAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *DeleteTrustedProfileAssignmentOptions) SetAssignmentID(assignmentID string) *DeleteTrustedProfileAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *DeleteTrustedProfileAssignmentOptions) SetHeaders(param map[string]string) *DeleteTrustedProfileAssignmentOptions {
 	options.Headers = param
 	return options
 }
@@ -4329,6 +7318,121 @@ func UnmarshalEntityActivity(m map[string]json.RawMessage, result interface{}) (
 	return
 }
 
+// Error : Error information.
+type Error struct {
+	// Error code of the REST Exception.
+	Code *string `json:"code" validate:"required"`
+
+	// Error message code of the REST Exception.
+	MessageCode *string `json:"message_code" validate:"required"`
+
+	// Error message of the REST Exception. Error messages are derived base on the input locale of the REST request and the
+	// available Message catalogs. Dynamic fallback to 'us-english' is happening if no message catalog is available for the
+	// provided input locale.
+	Message *string `json:"message" validate:"required"`
+
+	// Error details of the REST Exception.
+	Details *string `json:"details,omitempty"`
+}
+
+// UnmarshalError unmarshals an instance of Error from the specified map of raw messages.
+func UnmarshalError(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(Error)
+	err = core.UnmarshalPrimitive(m, "code", &obj.Code)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "message_code", &obj.MessageCode)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "message", &obj.Message)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "details", &obj.Details)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// ExceptionResponse : Response body parameters in case of error situations.
+type ExceptionResponse struct {
+	// Context with key properties for problem determination.
+	Context *ResponseContext `json:"context,omitempty"`
+
+	// Error message code of the REST Exception.
+	StatusCode *string `json:"status_code" validate:"required"`
+
+	// List of errors that occured.
+	Errors []Error `json:"errors" validate:"required"`
+
+	// Unique ID of the requst.
+	Trace *string `json:"trace,omitempty"`
+}
+
+// UnmarshalExceptionResponse unmarshals an instance of ExceptionResponse from the specified map of raw messages.
+func UnmarshalExceptionResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ExceptionResponse)
+	err = core.UnmarshalModel(m, "context", &obj.Context, UnmarshalResponseContext)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status_code", &obj.StatusCode)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "errors", &obj.Errors, UnmarshalError)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "trace", &obj.Trace)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// GetAccountSettingsAssignmentOptions : The GetAccountSettingsAssignment options.
+type GetAccountSettingsAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetAccountSettingsAssignmentOptions : Instantiate GetAccountSettingsAssignmentOptions
+func (*IamIdentityV1) NewGetAccountSettingsAssignmentOptions(assignmentID string) *GetAccountSettingsAssignmentOptions {
+	return &GetAccountSettingsAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *GetAccountSettingsAssignmentOptions) SetAssignmentID(assignmentID string) *GetAccountSettingsAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetAccountSettingsAssignmentOptions) SetIncludeHistory(includeHistory bool) *GetAccountSettingsAssignmentOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetAccountSettingsAssignmentOptions) SetHeaders(param map[string]string) *GetAccountSettingsAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
 // GetAccountSettingsOptions : The GetAccountSettings options.
 type GetAccountSettingsOptions struct {
 	// Unique ID of the account.
@@ -4362,6 +7466,53 @@ func (_options *GetAccountSettingsOptions) SetIncludeHistory(includeHistory bool
 
 // SetHeaders : Allow user to set Headers
 func (options *GetAccountSettingsOptions) SetHeaders(param map[string]string) *GetAccountSettingsOptions {
+	options.Headers = param
+	return options
+}
+
+// GetAccountSettingsTemplateVersionOptions : The GetAccountSettingsTemplateVersion options.
+type GetAccountSettingsTemplateVersionOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Account Settings Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetAccountSettingsTemplateVersionOptions : Instantiate GetAccountSettingsTemplateVersionOptions
+func (*IamIdentityV1) NewGetAccountSettingsTemplateVersionOptions(templateID string, version string) *GetAccountSettingsTemplateVersionOptions {
+	return &GetAccountSettingsTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *GetAccountSettingsTemplateVersionOptions) SetTemplateID(templateID string) *GetAccountSettingsTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *GetAccountSettingsTemplateVersionOptions) SetVersion(version string) *GetAccountSettingsTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetAccountSettingsTemplateVersionOptions) SetIncludeHistory(includeHistory bool) *GetAccountSettingsTemplateVersionOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetAccountSettingsTemplateVersionOptions) SetHeaders(param map[string]string) *GetAccountSettingsTemplateVersionOptions {
 	options.Headers = param
 	return options
 }
@@ -4464,7 +7615,7 @@ type GetClaimRuleOptions struct {
 func (*IamIdentityV1) NewGetClaimRuleOptions(profileID string, ruleID string) *GetClaimRuleOptions {
 	return &GetClaimRuleOptions{
 		ProfileID: core.StringPtr(profileID),
-		RuleID:    core.StringPtr(ruleID),
+		RuleID: core.StringPtr(ruleID),
 	}
 }
 
@@ -4486,6 +7637,80 @@ func (options *GetClaimRuleOptions) SetHeaders(param map[string]string) *GetClai
 	return options
 }
 
+// GetLatestAccountSettingsTemplateVersionOptions : The GetLatestAccountSettingsTemplateVersion options.
+type GetLatestAccountSettingsTemplateVersionOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetLatestAccountSettingsTemplateVersionOptions : Instantiate GetLatestAccountSettingsTemplateVersionOptions
+func (*IamIdentityV1) NewGetLatestAccountSettingsTemplateVersionOptions(templateID string) *GetLatestAccountSettingsTemplateVersionOptions {
+	return &GetLatestAccountSettingsTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *GetLatestAccountSettingsTemplateVersionOptions) SetTemplateID(templateID string) *GetLatestAccountSettingsTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetLatestAccountSettingsTemplateVersionOptions) SetIncludeHistory(includeHistory bool) *GetLatestAccountSettingsTemplateVersionOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetLatestAccountSettingsTemplateVersionOptions) SetHeaders(param map[string]string) *GetLatestAccountSettingsTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
+// GetLatestProfileTemplateVersionOptions : The GetLatestProfileTemplateVersion options.
+type GetLatestProfileTemplateVersionOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetLatestProfileTemplateVersionOptions : Instantiate GetLatestProfileTemplateVersionOptions
+func (*IamIdentityV1) NewGetLatestProfileTemplateVersionOptions(templateID string) *GetLatestProfileTemplateVersionOptions {
+	return &GetLatestProfileTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *GetLatestProfileTemplateVersionOptions) SetTemplateID(templateID string) *GetLatestProfileTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetLatestProfileTemplateVersionOptions) SetIncludeHistory(includeHistory bool) *GetLatestProfileTemplateVersionOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetLatestProfileTemplateVersionOptions) SetHeaders(param map[string]string) *GetLatestProfileTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // GetLinkOptions : The GetLink options.
 type GetLinkOptions struct {
 	// ID of the trusted profile.
@@ -4502,7 +7727,7 @@ type GetLinkOptions struct {
 func (*IamIdentityV1) NewGetLinkOptions(profileID string, linkID string) *GetLinkOptions {
 	return &GetLinkOptions{
 		ProfileID: core.StringPtr(profileID),
-		LinkID:    core.StringPtr(linkID),
+		LinkID: core.StringPtr(linkID),
 	}
 }
 
@@ -4578,7 +7803,7 @@ type GetMfaStatusOptions struct {
 func (*IamIdentityV1) NewGetMfaStatusOptions(accountID string, iamID string) *GetMfaStatusOptions {
 	return &GetMfaStatusOptions{
 		AccountID: core.StringPtr(accountID),
-		IamID:     core.StringPtr(iamID),
+		IamID: core.StringPtr(iamID),
 	}
 }
 
@@ -4646,15 +7871,15 @@ type GetProfileIdentityOptions struct {
 // Constants associated with the GetProfileIdentityOptions.IdentityType property.
 // Type of the identity.
 const (
-	GetProfileIdentityOptionsIdentityTypeCRNConst       = "crn"
+	GetProfileIdentityOptionsIdentityTypeCRNConst = "crn"
 	GetProfileIdentityOptionsIdentityTypeServiceidConst = "serviceid"
-	GetProfileIdentityOptionsIdentityTypeUserConst      = "user"
+	GetProfileIdentityOptionsIdentityTypeUserConst = "user"
 )
 
 // NewGetProfileIdentityOptions : Instantiate GetProfileIdentityOptions
 func (*IamIdentityV1) NewGetProfileIdentityOptions(profileID string, identityType string, identifierID string) *GetProfileIdentityOptions {
 	return &GetProfileIdentityOptions{
-		ProfileID:    core.StringPtr(profileID),
+		ProfileID: core.StringPtr(profileID),
 		IdentityType: core.StringPtr(identityType),
 		IdentifierID: core.StringPtr(identifierID),
 	}
@@ -4718,6 +7943,53 @@ func (_options *GetProfileOptions) SetIncludeActivity(includeActivity bool) *Get
 
 // SetHeaders : Allow user to set Headers
 func (options *GetProfileOptions) SetHeaders(param map[string]string) *GetProfileOptions {
+	options.Headers = param
+	return options
+}
+
+// GetProfileTemplateVersionOptions : The GetProfileTemplateVersion options.
+type GetProfileTemplateVersionOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Profile Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetProfileTemplateVersionOptions : Instantiate GetProfileTemplateVersionOptions
+func (*IamIdentityV1) NewGetProfileTemplateVersionOptions(templateID string, version string) *GetProfileTemplateVersionOptions {
+	return &GetProfileTemplateVersionOptions{
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *GetProfileTemplateVersionOptions) SetTemplateID(templateID string) *GetProfileTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *GetProfileTemplateVersionOptions) SetVersion(version string) *GetProfileTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetProfileTemplateVersionOptions) SetIncludeHistory(includeHistory bool) *GetProfileTemplateVersionOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetProfileTemplateVersionOptions) SetHeaders(param map[string]string) *GetProfileTemplateVersionOptions {
 	options.Headers = param
 	return options
 }
@@ -4807,6 +8079,43 @@ func (options *GetServiceIDOptions) SetHeaders(param map[string]string) *GetServ
 	return options
 }
 
+// GetTrustedProfileAssignmentOptions : The GetTrustedProfileAssignment options.
+type GetTrustedProfileAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewGetTrustedProfileAssignmentOptions : Instantiate GetTrustedProfileAssignmentOptions
+func (*IamIdentityV1) NewGetTrustedProfileAssignmentOptions(assignmentID string) *GetTrustedProfileAssignmentOptions {
+	return &GetTrustedProfileAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *GetTrustedProfileAssignmentOptions) SetAssignmentID(assignmentID string) *GetTrustedProfileAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *GetTrustedProfileAssignmentOptions) SetIncludeHistory(includeHistory bool) *GetTrustedProfileAssignmentOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetTrustedProfileAssignmentOptions) SetHeaders(param map[string]string) *GetTrustedProfileAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
 // IDBasedMfaEnrollment : IDBasedMfaEnrollment struct
 type IDBasedMfaEnrollment struct {
 	// Defines the MFA trait for the account. Valid values:
@@ -4845,59 +8154,59 @@ type IDBasedMfaEnrollment struct {
 
 // Constants associated with the IDBasedMfaEnrollment.TraitAccountDefault property.
 // Defines the MFA trait for the account. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	IDBasedMfaEnrollmentTraitAccountDefaultLevel1Const     = "LEVEL1"
-	IDBasedMfaEnrollmentTraitAccountDefaultLevel2Const     = "LEVEL2"
-	IDBasedMfaEnrollmentTraitAccountDefaultLevel3Const     = "LEVEL3"
-	IDBasedMfaEnrollmentTraitAccountDefaultNoneConst       = "NONE"
+	IDBasedMfaEnrollmentTraitAccountDefaultLevel1Const = "LEVEL1"
+	IDBasedMfaEnrollmentTraitAccountDefaultLevel2Const = "LEVEL2"
+	IDBasedMfaEnrollmentTraitAccountDefaultLevel3Const = "LEVEL3"
+	IDBasedMfaEnrollmentTraitAccountDefaultNoneConst = "NONE"
 	IDBasedMfaEnrollmentTraitAccountDefaultNoneNoRopcConst = "NONE_NO_ROPC"
-	IDBasedMfaEnrollmentTraitAccountDefaultTotpConst       = "TOTP"
-	IDBasedMfaEnrollmentTraitAccountDefaultTotp4allConst   = "TOTP4ALL"
+	IDBasedMfaEnrollmentTraitAccountDefaultTotpConst = "TOTP"
+	IDBasedMfaEnrollmentTraitAccountDefaultTotp4allConst = "TOTP4ALL"
 )
 
 // Constants associated with the IDBasedMfaEnrollment.TraitUserSpecific property.
 // Defines the MFA trait for the account. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	IDBasedMfaEnrollmentTraitUserSpecificLevel1Const     = "LEVEL1"
-	IDBasedMfaEnrollmentTraitUserSpecificLevel2Const     = "LEVEL2"
-	IDBasedMfaEnrollmentTraitUserSpecificLevel3Const     = "LEVEL3"
-	IDBasedMfaEnrollmentTraitUserSpecificNoneConst       = "NONE"
+	IDBasedMfaEnrollmentTraitUserSpecificLevel1Const = "LEVEL1"
+	IDBasedMfaEnrollmentTraitUserSpecificLevel2Const = "LEVEL2"
+	IDBasedMfaEnrollmentTraitUserSpecificLevel3Const = "LEVEL3"
+	IDBasedMfaEnrollmentTraitUserSpecificNoneConst = "NONE"
 	IDBasedMfaEnrollmentTraitUserSpecificNoneNoRopcConst = "NONE_NO_ROPC"
-	IDBasedMfaEnrollmentTraitUserSpecificTotpConst       = "TOTP"
-	IDBasedMfaEnrollmentTraitUserSpecificTotp4allConst   = "TOTP4ALL"
+	IDBasedMfaEnrollmentTraitUserSpecificTotpConst = "TOTP"
+	IDBasedMfaEnrollmentTraitUserSpecificTotp4allConst = "TOTP4ALL"
 )
 
 // Constants associated with the IDBasedMfaEnrollment.TraitEffective property.
 // Defines the MFA trait for the account. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	IDBasedMfaEnrollmentTraitEffectiveLevel1Const     = "LEVEL1"
-	IDBasedMfaEnrollmentTraitEffectiveLevel2Const     = "LEVEL2"
-	IDBasedMfaEnrollmentTraitEffectiveLevel3Const     = "LEVEL3"
-	IDBasedMfaEnrollmentTraitEffectiveNoneConst       = "NONE"
+	IDBasedMfaEnrollmentTraitEffectiveLevel1Const = "LEVEL1"
+	IDBasedMfaEnrollmentTraitEffectiveLevel2Const = "LEVEL2"
+	IDBasedMfaEnrollmentTraitEffectiveLevel3Const = "LEVEL3"
+	IDBasedMfaEnrollmentTraitEffectiveNoneConst = "NONE"
 	IDBasedMfaEnrollmentTraitEffectiveNoneNoRopcConst = "NONE_NO_ROPC"
-	IDBasedMfaEnrollmentTraitEffectiveTotpConst       = "TOTP"
-	IDBasedMfaEnrollmentTraitEffectiveTotp4allConst   = "TOTP4ALL"
+	IDBasedMfaEnrollmentTraitEffectiveTotpConst = "TOTP"
+	IDBasedMfaEnrollmentTraitEffectiveTotp4allConst = "TOTP4ALL"
 )
 
 // UnmarshalIDBasedMfaEnrollment unmarshals an instance of IDBasedMfaEnrollment from the specified map of raw messages.
@@ -4923,14 +8232,229 @@ func UnmarshalIDBasedMfaEnrollment(m map[string]json.RawMessage, result interfac
 	return
 }
 
+// ListAccountSettingsAssignmentsOptions : The ListAccountSettingsAssignments options.
+type ListAccountSettingsAssignmentsOptions struct {
+	// Account ID of the Assignments to query. This parameter is required unless using a pagetoken.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Filter results by Template Id.
+	TemplateID *string `json:"template_id,omitempty"`
+
+	// Filter results Template Version.
+	TemplateVersion *string `json:"template_version,omitempty"`
+
+	// Filter results by the assignment target.
+	Target *string `json:"target,omitempty"`
+
+	// Filter results by the assignment's target type.
+	TargetType *string `json:"target_type,omitempty"`
+
+	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// If specified, the items are sorted by the value of this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListAccountSettingsAssignmentsOptions.TargetType property.
+// Filter results by the assignment's target type.
+const (
+	ListAccountSettingsAssignmentsOptionsTargetTypeAccountConst = "Account"
+	ListAccountSettingsAssignmentsOptionsTargetTypeAccountgroupConst = "AccountGroup"
+)
+
+// Constants associated with the ListAccountSettingsAssignmentsOptions.Sort property.
+// If specified, the items are sorted by the value of this property.
+const (
+	ListAccountSettingsAssignmentsOptionsSortCreatedAtConst = "created_at"
+	ListAccountSettingsAssignmentsOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListAccountSettingsAssignmentsOptionsSortTemplateIDConst = "template_id"
+)
+
+// Constants associated with the ListAccountSettingsAssignmentsOptions.Order property.
+// Sort order.
+const (
+	ListAccountSettingsAssignmentsOptionsOrderAscConst = "asc"
+	ListAccountSettingsAssignmentsOptionsOrderDescConst = "desc"
+)
+
+// NewListAccountSettingsAssignmentsOptions : Instantiate ListAccountSettingsAssignmentsOptions
+func (*IamIdentityV1) NewListAccountSettingsAssignmentsOptions() *ListAccountSettingsAssignmentsOptions {
+	return &ListAccountSettingsAssignmentsOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *ListAccountSettingsAssignmentsOptions) SetAccountID(accountID string) *ListAccountSettingsAssignmentsOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *ListAccountSettingsAssignmentsOptions) SetTemplateID(templateID string) *ListAccountSettingsAssignmentsOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *ListAccountSettingsAssignmentsOptions) SetTemplateVersion(templateVersion string) *ListAccountSettingsAssignmentsOptions {
+	_options.TemplateVersion = core.StringPtr(templateVersion)
+	return _options
+}
+
+// SetTarget : Allow user to set Target
+func (_options *ListAccountSettingsAssignmentsOptions) SetTarget(target string) *ListAccountSettingsAssignmentsOptions {
+	_options.Target = core.StringPtr(target)
+	return _options
+}
+
+// SetTargetType : Allow user to set TargetType
+func (_options *ListAccountSettingsAssignmentsOptions) SetTargetType(targetType string) *ListAccountSettingsAssignmentsOptions {
+	_options.TargetType = core.StringPtr(targetType)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListAccountSettingsAssignmentsOptions) SetLimit(limit int64) *ListAccountSettingsAssignmentsOptions {
+	_options.Limit = core.Int64Ptr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListAccountSettingsAssignmentsOptions) SetPagetoken(pagetoken string) *ListAccountSettingsAssignmentsOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListAccountSettingsAssignmentsOptions) SetSort(sort string) *ListAccountSettingsAssignmentsOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListAccountSettingsAssignmentsOptions) SetOrder(order string) *ListAccountSettingsAssignmentsOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListAccountSettingsAssignmentsOptions) SetIncludeHistory(includeHistory bool) *ListAccountSettingsAssignmentsOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListAccountSettingsAssignmentsOptions) SetHeaders(param map[string]string) *ListAccountSettingsAssignmentsOptions {
+	options.Headers = param
+	return options
+}
+
+// ListAccountSettingsTemplatesOptions : The ListAccountSettingsTemplates options.
+type ListAccountSettingsTemplatesOptions struct {
+	// Account ID of the Account Settings Templates to query. This parameter is required unless using a pagetoken.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Optional size of a single page.
+	Limit *string `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// Optional sort property. If specified, the returned templated are sorted according to this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Optional sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *string `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListAccountSettingsTemplatesOptions.Sort property.
+// Optional sort property. If specified, the returned templated are sorted according to this property.
+const (
+	ListAccountSettingsTemplatesOptionsSortCreatedAtConst = "created_at"
+	ListAccountSettingsTemplatesOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListAccountSettingsTemplatesOptionsSortNameConst = "name"
+)
+
+// Constants associated with the ListAccountSettingsTemplatesOptions.Order property.
+// Optional sort order.
+const (
+	ListAccountSettingsTemplatesOptionsOrderAscConst = "asc"
+	ListAccountSettingsTemplatesOptionsOrderDescConst = "desc"
+)
+
+// NewListAccountSettingsTemplatesOptions : Instantiate ListAccountSettingsTemplatesOptions
+func (*IamIdentityV1) NewListAccountSettingsTemplatesOptions() *ListAccountSettingsTemplatesOptions {
+	return &ListAccountSettingsTemplatesOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *ListAccountSettingsTemplatesOptions) SetAccountID(accountID string) *ListAccountSettingsTemplatesOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListAccountSettingsTemplatesOptions) SetLimit(limit string) *ListAccountSettingsTemplatesOptions {
+	_options.Limit = core.StringPtr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListAccountSettingsTemplatesOptions) SetPagetoken(pagetoken string) *ListAccountSettingsTemplatesOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListAccountSettingsTemplatesOptions) SetSort(sort string) *ListAccountSettingsTemplatesOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListAccountSettingsTemplatesOptions) SetOrder(order string) *ListAccountSettingsTemplatesOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListAccountSettingsTemplatesOptions) SetIncludeHistory(includeHistory string) *ListAccountSettingsTemplatesOptions {
+	_options.IncludeHistory = core.StringPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListAccountSettingsTemplatesOptions) SetHeaders(param map[string]string) *ListAccountSettingsTemplatesOptions {
+	options.Headers = param
+	return options
+}
+
 // ListAPIKeysOptions : The ListAPIKeys options.
 type ListAPIKeysOptions struct {
-	// Account ID of the API keys to query. If a service IAM ID is specified in iam_id then account_id must match the
+	// Account ID of the API keys(s) to query. If a service IAM ID is specified in iam_id then account_id must match the
 	// account of the IAM ID. If a user IAM ID is specified in iam_id then then account_id must match the account of the
 	// Authorization token.
 	AccountID *string `json:"account_id,omitempty"`
 
-	// IAM ID of the API keys to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id must
+	// IAM ID of the API key(s) to be queried. The IAM ID may be that of a user or a service. For a user IAM ID iam_id must
 	// match the Authorization token.
 	IamID *string `json:"iam_id,omitempty"`
 
@@ -4940,10 +8464,10 @@ type ListAPIKeysOptions struct {
 	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
 	Pagetoken *string `json:"pagetoken,omitempty"`
 
-	// Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
+	// Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
 	Scope *string `json:"scope,omitempty"`
 
-	// Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
+	// Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
 	Type *string `json:"type,omitempty"`
 
 	// Optional sort property, valid values are name, description, created_at and created_by. If specified, the items are
@@ -4961,23 +8485,23 @@ type ListAPIKeysOptions struct {
 }
 
 // Constants associated with the ListAPIKeysOptions.Scope property.
-// Optional parameter to define the scope of the queried API keys. Can be 'entity' (default) or 'account'.
+// Optional parameter to define the scope of the queried API Keys. Can be 'entity' (default) or 'account'.
 const (
 	ListAPIKeysOptionsScopeAccountConst = "account"
-	ListAPIKeysOptionsScopeEntityConst  = "entity"
+	ListAPIKeysOptionsScopeEntityConst = "entity"
 )
 
 // Constants associated with the ListAPIKeysOptions.Type property.
-// Optional parameter to filter the type of the queried API keys. Can be 'user' or 'serviceid'.
+// Optional parameter to filter the type of the queried API Keys. Can be 'user' or 'serviceid'.
 const (
 	ListAPIKeysOptionsTypeServiceidConst = "serviceid"
-	ListAPIKeysOptionsTypeUserConst      = "user"
+	ListAPIKeysOptionsTypeUserConst = "user"
 )
 
 // Constants associated with the ListAPIKeysOptions.Order property.
 // Optional sort order, valid values are asc and desc. Default: asc.
 const (
-	ListAPIKeysOptionsOrderAscConst  = "asc"
+	ListAPIKeysOptionsOrderAscConst = "asc"
 	ListAPIKeysOptionsOrderDescConst = "desc"
 )
 
@@ -5102,6 +8626,92 @@ func (options *ListLinksOptions) SetHeaders(param map[string]string) *ListLinksO
 	return options
 }
 
+// ListProfileTemplatesOptions : The ListProfileTemplates options.
+type ListProfileTemplatesOptions struct {
+	// Account ID of the Profile Templates to query. This parameter is required unless using a pagetoken.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Optional size of a single page.
+	Limit *string `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// Optional sort property. If specified, the returned templated are sorted according to this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Optional sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *string `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListProfileTemplatesOptions.Sort property.
+// Optional sort property. If specified, the returned templated are sorted according to this property.
+const (
+	ListProfileTemplatesOptionsSortCreatedAtConst = "created_at"
+	ListProfileTemplatesOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListProfileTemplatesOptionsSortNameConst = "name"
+)
+
+// Constants associated with the ListProfileTemplatesOptions.Order property.
+// Optional sort order.
+const (
+	ListProfileTemplatesOptionsOrderAscConst = "asc"
+	ListProfileTemplatesOptionsOrderDescConst = "desc"
+)
+
+// NewListProfileTemplatesOptions : Instantiate ListProfileTemplatesOptions
+func (*IamIdentityV1) NewListProfileTemplatesOptions() *ListProfileTemplatesOptions {
+	return &ListProfileTemplatesOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *ListProfileTemplatesOptions) SetAccountID(accountID string) *ListProfileTemplatesOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListProfileTemplatesOptions) SetLimit(limit string) *ListProfileTemplatesOptions {
+	_options.Limit = core.StringPtr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListProfileTemplatesOptions) SetPagetoken(pagetoken string) *ListProfileTemplatesOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListProfileTemplatesOptions) SetSort(sort string) *ListProfileTemplatesOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListProfileTemplatesOptions) SetOrder(order string) *ListProfileTemplatesOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListProfileTemplatesOptions) SetIncludeHistory(includeHistory string) *ListProfileTemplatesOptions {
+	_options.IncludeHistory = core.StringPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListProfileTemplatesOptions) SetHeaders(param map[string]string) *ListProfileTemplatesOptions {
+	options.Headers = param
+	return options
+}
+
 // ListProfilesOptions : The ListProfiles options.
 type ListProfilesOptions struct {
 	// Account ID to query for trusted profiles.
@@ -5133,7 +8743,7 @@ type ListProfilesOptions struct {
 // Constants associated with the ListProfilesOptions.Order property.
 // Optional sort order, valid values are asc and desc. Default: asc.
 const (
-	ListProfilesOptionsOrderAscConst  = "asc"
+	ListProfilesOptionsOrderAscConst = "asc"
 	ListProfilesOptionsOrderDescConst = "desc"
 )
 
@@ -5223,7 +8833,7 @@ type ListServiceIdsOptions struct {
 // Constants associated with the ListServiceIdsOptions.Order property.
 // Optional sort order, valid values are asc and desc. Default: asc.
 const (
-	ListServiceIdsOptionsOrderAscConst  = "asc"
+	ListServiceIdsOptionsOrderAscConst = "asc"
 	ListServiceIdsOptionsOrderDescConst = "desc"
 )
 
@@ -5276,6 +8886,311 @@ func (_options *ListServiceIdsOptions) SetIncludeHistory(includeHistory bool) *L
 
 // SetHeaders : Allow user to set Headers
 func (options *ListServiceIdsOptions) SetHeaders(param map[string]string) *ListServiceIdsOptions {
+	options.Headers = param
+	return options
+}
+
+// ListTrustedProfileAssignmentsOptions : The ListTrustedProfileAssignments options.
+type ListTrustedProfileAssignmentsOptions struct {
+	// Account ID of the Assignments to query. This parameter is required unless using a pagetoken.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Filter results by Template Id.
+	TemplateID *string `json:"template_id,omitempty"`
+
+	// Filter results Template Version.
+	TemplateVersion *string `json:"template_version,omitempty"`
+
+	// Filter results by the assignment target.
+	Target *string `json:"target,omitempty"`
+
+	// Filter results by the assignment's target type.
+	TargetType *string `json:"target_type,omitempty"`
+
+	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// If specified, the items are sorted by the value of this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *bool `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListTrustedProfileAssignmentsOptions.TargetType property.
+// Filter results by the assignment's target type.
+const (
+	ListTrustedProfileAssignmentsOptionsTargetTypeAccountConst = "Account"
+	ListTrustedProfileAssignmentsOptionsTargetTypeAccountgroupConst = "AccountGroup"
+)
+
+// Constants associated with the ListTrustedProfileAssignmentsOptions.Sort property.
+// If specified, the items are sorted by the value of this property.
+const (
+	ListTrustedProfileAssignmentsOptionsSortCreatedAtConst = "created_at"
+	ListTrustedProfileAssignmentsOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListTrustedProfileAssignmentsOptionsSortTemplateIDConst = "template_id"
+)
+
+// Constants associated with the ListTrustedProfileAssignmentsOptions.Order property.
+// Sort order.
+const (
+	ListTrustedProfileAssignmentsOptionsOrderAscConst = "asc"
+	ListTrustedProfileAssignmentsOptionsOrderDescConst = "desc"
+)
+
+// NewListTrustedProfileAssignmentsOptions : Instantiate ListTrustedProfileAssignmentsOptions
+func (*IamIdentityV1) NewListTrustedProfileAssignmentsOptions() *ListTrustedProfileAssignmentsOptions {
+	return &ListTrustedProfileAssignmentsOptions{}
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *ListTrustedProfileAssignmentsOptions) SetAccountID(accountID string) *ListTrustedProfileAssignmentsOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *ListTrustedProfileAssignmentsOptions) SetTemplateID(templateID string) *ListTrustedProfileAssignmentsOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *ListTrustedProfileAssignmentsOptions) SetTemplateVersion(templateVersion string) *ListTrustedProfileAssignmentsOptions {
+	_options.TemplateVersion = core.StringPtr(templateVersion)
+	return _options
+}
+
+// SetTarget : Allow user to set Target
+func (_options *ListTrustedProfileAssignmentsOptions) SetTarget(target string) *ListTrustedProfileAssignmentsOptions {
+	_options.Target = core.StringPtr(target)
+	return _options
+}
+
+// SetTargetType : Allow user to set TargetType
+func (_options *ListTrustedProfileAssignmentsOptions) SetTargetType(targetType string) *ListTrustedProfileAssignmentsOptions {
+	_options.TargetType = core.StringPtr(targetType)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListTrustedProfileAssignmentsOptions) SetLimit(limit int64) *ListTrustedProfileAssignmentsOptions {
+	_options.Limit = core.Int64Ptr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListTrustedProfileAssignmentsOptions) SetPagetoken(pagetoken string) *ListTrustedProfileAssignmentsOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListTrustedProfileAssignmentsOptions) SetSort(sort string) *ListTrustedProfileAssignmentsOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListTrustedProfileAssignmentsOptions) SetOrder(order string) *ListTrustedProfileAssignmentsOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListTrustedProfileAssignmentsOptions) SetIncludeHistory(includeHistory bool) *ListTrustedProfileAssignmentsOptions {
+	_options.IncludeHistory = core.BoolPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListTrustedProfileAssignmentsOptions) SetHeaders(param map[string]string) *ListTrustedProfileAssignmentsOptions {
+	options.Headers = param
+	return options
+}
+
+// ListVersionsOfAccountSettingsTemplateOptions : The ListVersionsOfAccountSettingsTemplate options.
+type ListVersionsOfAccountSettingsTemplateOptions struct {
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Optional size of a single page.
+	Limit *string `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// Optional sort property. If specified, the returned templated are sorted according to this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Optional sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *string `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListVersionsOfAccountSettingsTemplateOptions.Sort property.
+// Optional sort property. If specified, the returned templated are sorted according to this property.
+const (
+	ListVersionsOfAccountSettingsTemplateOptionsSortCreatedAtConst = "created_at"
+	ListVersionsOfAccountSettingsTemplateOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListVersionsOfAccountSettingsTemplateOptionsSortNameConst = "name"
+)
+
+// Constants associated with the ListVersionsOfAccountSettingsTemplateOptions.Order property.
+// Optional sort order.
+const (
+	ListVersionsOfAccountSettingsTemplateOptionsOrderAscConst = "asc"
+	ListVersionsOfAccountSettingsTemplateOptionsOrderDescConst = "desc"
+)
+
+// NewListVersionsOfAccountSettingsTemplateOptions : Instantiate ListVersionsOfAccountSettingsTemplateOptions
+func (*IamIdentityV1) NewListVersionsOfAccountSettingsTemplateOptions(templateID string) *ListVersionsOfAccountSettingsTemplateOptions {
+	return &ListVersionsOfAccountSettingsTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetTemplateID(templateID string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetLimit(limit string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.Limit = core.StringPtr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetPagetoken(pagetoken string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetSort(sort string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetOrder(order string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListVersionsOfAccountSettingsTemplateOptions) SetIncludeHistory(includeHistory string) *ListVersionsOfAccountSettingsTemplateOptions {
+	_options.IncludeHistory = core.StringPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListVersionsOfAccountSettingsTemplateOptions) SetHeaders(param map[string]string) *ListVersionsOfAccountSettingsTemplateOptions {
+	options.Headers = param
+	return options
+}
+
+// ListVersionsOfProfileTemplateOptions : The ListVersionsOfProfileTemplate options.
+type ListVersionsOfProfileTemplateOptions struct {
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Optional size of a single page.
+	Limit *string `json:"limit,omitempty"`
+
+	// Optional Prev or Next page token returned from a previous query execution. Default is start with first page.
+	Pagetoken *string `json:"pagetoken,omitempty"`
+
+	// Optional sort property. If specified, the returned templated are sorted according to this property.
+	Sort *string `json:"sort,omitempty"`
+
+	// Optional sort order.
+	Order *string `json:"order,omitempty"`
+
+	// Defines if the entity history is included in the response.
+	IncludeHistory *string `json:"include_history,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// Constants associated with the ListVersionsOfProfileTemplateOptions.Sort property.
+// Optional sort property. If specified, the returned templated are sorted according to this property.
+const (
+	ListVersionsOfProfileTemplateOptionsSortCreatedAtConst = "created_at"
+	ListVersionsOfProfileTemplateOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListVersionsOfProfileTemplateOptionsSortNameConst = "name"
+)
+
+// Constants associated with the ListVersionsOfProfileTemplateOptions.Order property.
+// Optional sort order.
+const (
+	ListVersionsOfProfileTemplateOptionsOrderAscConst = "asc"
+	ListVersionsOfProfileTemplateOptionsOrderDescConst = "desc"
+)
+
+// NewListVersionsOfProfileTemplateOptions : Instantiate ListVersionsOfProfileTemplateOptions
+func (*IamIdentityV1) NewListVersionsOfProfileTemplateOptions(templateID string) *ListVersionsOfProfileTemplateOptions {
+	return &ListVersionsOfProfileTemplateOptions{
+		TemplateID: core.StringPtr(templateID),
+	}
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *ListVersionsOfProfileTemplateOptions) SetTemplateID(templateID string) *ListVersionsOfProfileTemplateOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetLimit : Allow user to set Limit
+func (_options *ListVersionsOfProfileTemplateOptions) SetLimit(limit string) *ListVersionsOfProfileTemplateOptions {
+	_options.Limit = core.StringPtr(limit)
+	return _options
+}
+
+// SetPagetoken : Allow user to set Pagetoken
+func (_options *ListVersionsOfProfileTemplateOptions) SetPagetoken(pagetoken string) *ListVersionsOfProfileTemplateOptions {
+	_options.Pagetoken = core.StringPtr(pagetoken)
+	return _options
+}
+
+// SetSort : Allow user to set Sort
+func (_options *ListVersionsOfProfileTemplateOptions) SetSort(sort string) *ListVersionsOfProfileTemplateOptions {
+	_options.Sort = core.StringPtr(sort)
+	return _options
+}
+
+// SetOrder : Allow user to set Order
+func (_options *ListVersionsOfProfileTemplateOptions) SetOrder(order string) *ListVersionsOfProfileTemplateOptions {
+	_options.Order = core.StringPtr(order)
+	return _options
+}
+
+// SetIncludeHistory : Allow user to set IncludeHistory
+func (_options *ListVersionsOfProfileTemplateOptions) SetIncludeHistory(includeHistory string) *ListVersionsOfProfileTemplateOptions {
+	_options.IncludeHistory = core.StringPtr(includeHistory)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *ListVersionsOfProfileTemplateOptions) SetHeaders(param map[string]string) *ListVersionsOfProfileTemplateOptions {
 	options.Headers = param
 	return options
 }
@@ -5389,6 +9304,40 @@ func UnmarshalMfaEnrollments(m map[string]json.RawMessage, result interface{}) (
 	return
 }
 
+// PolicyTemplateReference : Metadata for external access policy.
+type PolicyTemplateReference struct {
+	// ID of Access Policy Template.
+	ID *string `json:"id" validate:"required"`
+
+	// Version of Access Policy Template.
+	Version *string `json:"version" validate:"required"`
+}
+
+// NewPolicyTemplateReference : Instantiate PolicyTemplateReference (Generic Model Constructor)
+func (*IamIdentityV1) NewPolicyTemplateReference(id string, version string) (_model *PolicyTemplateReference, err error) {
+	_model = &PolicyTemplateReference{
+		ID: core.StringPtr(id),
+		Version: core.StringPtr(version),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalPolicyTemplateReference unmarshals an instance of PolicyTemplateReference from the specified map of raw messages.
+func UnmarshalPolicyTemplateReference(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PolicyTemplateReference)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version", &obj.Version)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // ProfileClaimRule : ProfileClaimRule struct
 type ProfileClaimRule struct {
 	// the unique identifier of the claim rule.
@@ -5471,8 +9420,7 @@ func UnmarshalProfileClaimRule(m map[string]json.RawMessage, result interface{})
 
 // ProfileClaimRuleConditions : ProfileClaimRuleConditions struct
 type ProfileClaimRuleConditions struct {
-	// The claim to evaluate against. [Learn
-	// more](/docs/account?topic=account-iam-condition-properties&interface=ui#cr-attribute-names).
+	// The claim to evaluate against.
 	Claim *string `json:"claim" validate:"required"`
 
 	// The operation to perform on the claim. valid values are EQUALS, NOT_EQUALS, EQUALS_IGNORE_CASE,
@@ -5486,9 +9434,9 @@ type ProfileClaimRuleConditions struct {
 // NewProfileClaimRuleConditions : Instantiate ProfileClaimRuleConditions (Generic Model Constructor)
 func (*IamIdentityV1) NewProfileClaimRuleConditions(claim string, operator string, value string) (_model *ProfileClaimRuleConditions, err error) {
 	_model = &ProfileClaimRuleConditions{
-		Claim:    core.StringPtr(claim),
+		Claim: core.StringPtr(claim),
 		Operator: core.StringPtr(operator),
-		Value:    core.StringPtr(value),
+		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5543,7 +9491,7 @@ type ProfileIdentitiesResponse struct {
 	EntityTag *string `json:"entity_tag,omitempty"`
 
 	// List of identities.
-	Identities []ProfileIdentity `json:"identities,omitempty"`
+	Identities []ProfileIdentityResponse `json:"identities,omitempty"`
 }
 
 // UnmarshalProfileIdentitiesResponse unmarshals an instance of ProfileIdentitiesResponse from the specified map of raw messages.
@@ -5553,7 +9501,7 @@ func UnmarshalProfileIdentitiesResponse(m map[string]json.RawMessage, result int
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "identities", &obj.Identities, UnmarshalProfileIdentity)
+	err = core.UnmarshalModel(m, "identities", &obj.Identities, UnmarshalProfileIdentityResponse)
 	if err != nil {
 		return
 	}
@@ -5561,10 +9509,70 @@ func UnmarshalProfileIdentitiesResponse(m map[string]json.RawMessage, result int
 	return
 }
 
-// ProfileIdentity : ProfileIdentity struct
-type ProfileIdentity struct {
+// ProfileIdentityRequest : ProfileIdentityRequest struct
+type ProfileIdentityRequest struct {
+	// Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid
+	// or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn'
+	// it uses account id contained in the CRN.
+	Identifier *string `json:"identifier" validate:"required"`
+
+	// Type of the identity.
+	Type *string `json:"type" validate:"required"`
+
+	// Only valid for the type user. Accounts from which a user can assume the trusted profile.
+	Accounts []string `json:"accounts,omitempty"`
+
+	// Description of the identity that can assume the trusted profile. This is optional field for all the types of
+	// identities. When this field is not set for the identity type 'serviceid' then the description of the service id is
+	// used. Description is recommended for the identity type 'crn' E.g. 'Instance 1234 of IBM Cloud Service project'.
+	Description *string `json:"description,omitempty"`
+}
+
+// Constants associated with the ProfileIdentityRequest.Type property.
+// Type of the identity.
+const (
+	ProfileIdentityRequestTypeCRNConst = "crn"
+	ProfileIdentityRequestTypeServiceidConst = "serviceid"
+	ProfileIdentityRequestTypeUserConst = "user"
+)
+
+// NewProfileIdentityRequest : Instantiate ProfileIdentityRequest (Generic Model Constructor)
+func (*IamIdentityV1) NewProfileIdentityRequest(identifier string, typeVar string) (_model *ProfileIdentityRequest, err error) {
+	_model = &ProfileIdentityRequest{
+		Identifier: core.StringPtr(identifier),
+		Type: core.StringPtr(typeVar),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalProfileIdentityRequest unmarshals an instance of ProfileIdentityRequest from the specified map of raw messages.
+func UnmarshalProfileIdentityRequest(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ProfileIdentityRequest)
+	err = core.UnmarshalPrimitive(m, "identifier", &obj.Identifier)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "accounts", &obj.Accounts)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// ProfileIdentityResponse : ProfileIdentityResponse struct
+type ProfileIdentityResponse struct {
 	// IAM ID of the identity.
-	IamID *string `json:"iam_id,omitempty"`
+	IamID *string `json:"iam_id" validate:"required"`
 
 	// Identifier of the identity that can assume the trusted profiles. This can be a user identifier (IAM id), serviceid
 	// or crn. Internally it uses account id of the service id for the identifier 'serviceid' and for the identifier 'crn'
@@ -5583,27 +9591,17 @@ type ProfileIdentity struct {
 	Description *string `json:"description,omitempty"`
 }
 
-// Constants associated with the ProfileIdentity.Type property.
+// Constants associated with the ProfileIdentityResponse.Type property.
 // Type of the identity.
 const (
-	ProfileIdentityTypeCRNConst       = "crn"
-	ProfileIdentityTypeServiceidConst = "serviceid"
-	ProfileIdentityTypeUserConst      = "user"
+	ProfileIdentityResponseTypeCRNConst = "crn"
+	ProfileIdentityResponseTypeServiceidConst = "serviceid"
+	ProfileIdentityResponseTypeUserConst = "user"
 )
 
-// NewProfileIdentity : Instantiate ProfileIdentity (Generic Model Constructor)
-func (*IamIdentityV1) NewProfileIdentity(identifier string, typeVar string) (_model *ProfileIdentity, err error) {
-	_model = &ProfileIdentity{
-		Identifier: core.StringPtr(identifier),
-		Type:       core.StringPtr(typeVar),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	return
-}
-
-// UnmarshalProfileIdentity unmarshals an instance of ProfileIdentity from the specified map of raw messages.
-func UnmarshalProfileIdentity(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(ProfileIdentity)
+// UnmarshalProfileIdentityResponse unmarshals an instance of ProfileIdentityResponse from the specified map of raw messages.
+func UnmarshalProfileIdentityResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(ProfileIdentityResponse)
 	err = core.UnmarshalPrimitive(m, "iam_id", &obj.IamID)
 	if err != nil {
 		return
@@ -6153,7 +10151,7 @@ type SetProfileIdentitiesOptions struct {
 	IfMatch *string `json:"If-Match" validate:"required"`
 
 	// List of identities that can assume the trusted profile.
-	Identities []ProfileIdentity `json:"identities,omitempty"`
+	Identities []ProfileIdentityRequest `json:"identities,omitempty"`
 
 	// Allows users to set headers on API requests
 	Headers map[string]string
@@ -6163,7 +10161,7 @@ type SetProfileIdentitiesOptions struct {
 func (*IamIdentityV1) NewSetProfileIdentitiesOptions(profileID string, ifMatch string) *SetProfileIdentitiesOptions {
 	return &SetProfileIdentitiesOptions{
 		ProfileID: core.StringPtr(profileID),
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -6180,7 +10178,7 @@ func (_options *SetProfileIdentitiesOptions) SetIfMatch(ifMatch string) *SetProf
 }
 
 // SetIdentities : Allow user to set Identities
-func (_options *SetProfileIdentitiesOptions) SetIdentities(identities []ProfileIdentity) *SetProfileIdentitiesOptions {
+func (_options *SetProfileIdentitiesOptions) SetIdentities(identities []ProfileIdentityRequest) *SetProfileIdentitiesOptions {
 	_options.Identities = identities
 	return _options
 }
@@ -6207,9 +10205,6 @@ type SetProfileIdentityOptions struct {
 	// Type of the identity.
 	Type *string `json:"type" validate:"required"`
 
-	// IAM ID of the identity.
-	IamID *string `json:"iam_id,omitempty"`
-
 	// Only valid for the type user. Accounts from which a user can assume the trusted profile.
 	Accounts []string `json:"accounts,omitempty"`
 
@@ -6225,26 +10220,26 @@ type SetProfileIdentityOptions struct {
 // Constants associated with the SetProfileIdentityOptions.IdentityType property.
 // Type of the identity.
 const (
-	SetProfileIdentityOptionsIdentityTypeCRNConst       = "crn"
+	SetProfileIdentityOptionsIdentityTypeCRNConst = "crn"
 	SetProfileIdentityOptionsIdentityTypeServiceidConst = "serviceid"
-	SetProfileIdentityOptionsIdentityTypeUserConst      = "user"
+	SetProfileIdentityOptionsIdentityTypeUserConst = "user"
 )
 
 // Constants associated with the SetProfileIdentityOptions.Type property.
 // Type of the identity.
 const (
-	SetProfileIdentityOptionsTypeCRNConst       = "crn"
+	SetProfileIdentityOptionsTypeCRNConst = "crn"
 	SetProfileIdentityOptionsTypeServiceidConst = "serviceid"
-	SetProfileIdentityOptionsTypeUserConst      = "user"
+	SetProfileIdentityOptionsTypeUserConst = "user"
 )
 
 // NewSetProfileIdentityOptions : Instantiate SetProfileIdentityOptions
 func (*IamIdentityV1) NewSetProfileIdentityOptions(profileID string, identityType string, identifier string, typeVar string) *SetProfileIdentityOptions {
 	return &SetProfileIdentityOptions{
-		ProfileID:    core.StringPtr(profileID),
+		ProfileID: core.StringPtr(profileID),
 		IdentityType: core.StringPtr(identityType),
-		Identifier:   core.StringPtr(identifier),
-		Type:         core.StringPtr(typeVar),
+		Identifier: core.StringPtr(identifier),
+		Type: core.StringPtr(typeVar),
 	}
 }
 
@@ -6272,12 +10267,6 @@ func (_options *SetProfileIdentityOptions) SetType(typeVar string) *SetProfileId
 	return _options
 }
 
-// SetIamID : Allow user to set IamID
-func (_options *SetProfileIdentityOptions) SetIamID(iamID string) *SetProfileIdentityOptions {
-	_options.IamID = core.StringPtr(iamID)
-	return _options
-}
-
 // SetAccounts : Allow user to set Accounts
 func (_options *SetProfileIdentityOptions) SetAccounts(accounts []string) *SetProfileIdentityOptions {
 	_options.Accounts = accounts
@@ -6294,6 +10283,412 @@ func (_options *SetProfileIdentityOptions) SetDescription(description string) *S
 func (options *SetProfileIdentityOptions) SetHeaders(param map[string]string) *SetProfileIdentityOptions {
 	options.Headers = param
 	return options
+}
+
+// TemplateAssignmentListResponse : List Response body format for Template Assignments Records.
+type TemplateAssignmentListResponse struct {
+	// Context with key properties for problem determination.
+	Context *ResponseContext `json:"context,omitempty"`
+
+	// The offset of the current page.
+	Offset *int64 `json:"offset,omitempty"`
+
+	// Optional size of a single page. Default is 20 items per page. Valid range is 1 to 100.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Link to the first page.
+	First *string `json:"first,omitempty"`
+
+	// Link to the previous available page. If 'previous' property is not part of the response no previous page is
+	// available.
+	Previous *string `json:"previous,omitempty"`
+
+	// Link to the next available page. If 'next' property is not part of the response no next page is available.
+	Next *string `json:"next,omitempty"`
+
+	// List of Assignments based on the query paramters and the page size. The assignments array is always part of the
+	// response but might be empty depending on the query parameter values provided.
+	Assignments []TemplateAssignmentResponse `json:"assignments" validate:"required"`
+}
+
+// UnmarshalTemplateAssignmentListResponse unmarshals an instance of TemplateAssignmentListResponse from the specified map of raw messages.
+func UnmarshalTemplateAssignmentListResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentListResponse)
+	err = core.UnmarshalModel(m, "context", &obj.Context, UnmarshalResponseContext)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "first", &obj.First)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "previous", &obj.Previous)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "next", &obj.Next)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "assignments", &obj.Assignments, UnmarshalTemplateAssignmentResponse)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateAssignmentResource : Body parameters for created resource.
+type TemplateAssignmentResource struct {
+	// Id of the created resource.
+	ID *string `json:"id,omitempty"`
+}
+
+// UnmarshalTemplateAssignmentResource unmarshals an instance of TemplateAssignmentResource from the specified map of raw messages.
+func UnmarshalTemplateAssignmentResource(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentResource)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateAssignmentResourceError : Body parameters for assignment error.
+type TemplateAssignmentResourceError struct {
+	// Name of the error.
+	Name *string `json:"name,omitempty"`
+
+	// Internal error code.
+	ErrorCode *string `json:"errorCode,omitempty"`
+
+	// Error message detailing the nature of the error.
+	Message *string `json:"message,omitempty"`
+
+	// Internal status code for the error.
+	StatusCode *string `json:"statusCode,omitempty"`
+}
+
+// UnmarshalTemplateAssignmentResourceError unmarshals an instance of TemplateAssignmentResourceError from the specified map of raw messages.
+func UnmarshalTemplateAssignmentResourceError(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentResourceError)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "errorCode", &obj.ErrorCode)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "message", &obj.Message)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "statusCode", &obj.StatusCode)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateAssignmentResponse : Response body format for Template Assignment Record.
+type TemplateAssignmentResponse struct {
+	// Context with key properties for problem determination.
+	Context *ResponseContext `json:"context,omitempty"`
+
+	// Assignment record Id.
+	ID *string `json:"id" validate:"required"`
+
+	// Enterprise Account Id.
+	AccountID *string `json:"account_id" validate:"required"`
+
+	// Template Id.
+	TemplateID *string `json:"template_id" validate:"required"`
+
+	// Template Version.
+	TemplateVersion *int64 `json:"template_version" validate:"required"`
+
+	// Assignment Target Type.
+	TargetType *string `json:"target_type" validate:"required"`
+
+	// Assignment Target.
+	Target *string `json:"target" validate:"required"`
+
+	// Assignment Status.
+	Status *string `json:"status" validate:"required"`
+
+	// Status breakdown per target account of resources created or errors encountered in attempting to create those
+	// resources. Resources are only included in the response providing the assignment is not in progress. Resources are
+	// also only included when getting a single assignment, and excluded by list apis.
+	Resources []TemplateAssignmentResponseResource `json:"resources,omitempty"`
+
+	// Assignment history.
+	History []EnityHistoryRecord `json:"history,omitempty"`
+
+	// Href.
+	Href *string `json:"href,omitempty"`
+
+	// Assignment created at.
+	CreatedAt *string `json:"created_at" validate:"required"`
+
+	// IAMid of the identity that created the assignment.
+	CreatedByID *string `json:"created_by_id" validate:"required"`
+
+	// Assignment modified at.
+	LastModifiedAt *string `json:"last_modified_at" validate:"required"`
+
+	// IAMid of the identity that last modified the assignment.
+	LastModifiedByID *string `json:"last_modified_by_id" validate:"required"`
+
+	// Entity tag for this assignment record.
+	EntityTag *string `json:"entity_tag" validate:"required"`
+}
+
+// UnmarshalTemplateAssignmentResponse unmarshals an instance of TemplateAssignmentResponse from the specified map of raw messages.
+func UnmarshalTemplateAssignmentResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentResponse)
+	err = core.UnmarshalModel(m, "context", &obj.Context, UnmarshalResponseContext)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "template_id", &obj.TemplateID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "template_version", &obj.TemplateVersion)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "target_type", &obj.TargetType)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "target", &obj.Target)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "resources", &obj.Resources, UnmarshalTemplateAssignmentResponseResource)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "history", &obj.History, UnmarshalEnityHistoryRecord)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_by_id", &obj.CreatedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_at", &obj.LastModifiedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_by_id", &obj.LastModifiedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "entity_tag", &obj.EntityTag)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateAssignmentResponseResource : Overview of resources assignment per target account.
+type TemplateAssignmentResponseResource struct {
+	// Target account the resource is created in.
+	Target *string `json:"target" validate:"required"`
+
+	Profile *TemplateAssignmentResponseResourceDetail `json:"profile,omitempty"`
+
+	AccountSettings *TemplateAssignmentResponseResourceDetail `json:"account_settings,omitempty"`
+
+	// Policy resource(s) included only for Trusted Profile Assignments with Policy references.
+	PolicyTemplateRefs []TemplateAssignmentResponseResourceDetail `json:"policy_template_refs,omitempty"`
+}
+
+// UnmarshalTemplateAssignmentResponseResource unmarshals an instance of TemplateAssignmentResponseResource from the specified map of raw messages.
+func UnmarshalTemplateAssignmentResponseResource(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentResponseResource)
+	err = core.UnmarshalPrimitive(m, "target", &obj.Target)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalTemplateAssignmentResponseResourceDetail)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "account_settings", &obj.AccountSettings, UnmarshalTemplateAssignmentResponseResourceDetail)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "policy_template_refs", &obj.PolicyTemplateRefs, UnmarshalTemplateAssignmentResponseResourceDetail)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateAssignmentResponseResourceDetail : TemplateAssignmentResponseResourceDetail struct
+type TemplateAssignmentResponseResourceDetail struct {
+	// Policy Template Id, only returned for a profile assignment with policy references.
+	ID *string `json:"id,omitempty"`
+
+	// Policy verser, only returned for a profile assignment with policy references.
+	Version *string `json:"version,omitempty"`
+
+	// Body parameters for created resource.
+	ResourceCreated *TemplateAssignmentResource `json:"resource_created,omitempty"`
+
+	// Body parameters for assignment error.
+	ErrorMessage *TemplateAssignmentResourceError `json:"error_message,omitempty"`
+
+	// Status for the target account's assignment.
+	Status *string `json:"status" validate:"required"`
+}
+
+// UnmarshalTemplateAssignmentResponseResourceDetail unmarshals an instance of TemplateAssignmentResponseResourceDetail from the specified map of raw messages.
+func UnmarshalTemplateAssignmentResponseResourceDetail(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateAssignmentResponseResourceDetail)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version", &obj.Version)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "resource_created", &obj.ResourceCreated, UnmarshalTemplateAssignmentResource)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "error_message", &obj.ErrorMessage, UnmarshalTemplateAssignmentResourceError)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "status", &obj.Status)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateProfileComponentRequest : Input body parameters for the TemplateProfileComponent.
+type TemplateProfileComponentRequest struct {
+	// Name of the Profile.
+	Name *string `json:"name" validate:"required"`
+
+	// Description of the Profile.
+	Description *string `json:"description,omitempty"`
+
+	// Rules for the Profile.
+	Rules []TrustedProfileTemplateClaimRule `json:"rules,omitempty"`
+
+	// Identities for the Profile.
+	Identities []ProfileIdentityRequest `json:"identities,omitempty"`
+}
+
+// NewTemplateProfileComponentRequest : Instantiate TemplateProfileComponentRequest (Generic Model Constructor)
+func (*IamIdentityV1) NewTemplateProfileComponentRequest(name string) (_model *TemplateProfileComponentRequest, err error) {
+	_model = &TemplateProfileComponentRequest{
+		Name: core.StringPtr(name),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalTemplateProfileComponentRequest unmarshals an instance of TemplateProfileComponentRequest from the specified map of raw messages.
+func UnmarshalTemplateProfileComponentRequest(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateProfileComponentRequest)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "rules", &obj.Rules, UnmarshalTrustedProfileTemplateClaimRule)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "identities", &obj.Identities, UnmarshalProfileIdentityRequest)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateProfileComponentResponse : Input body parameters for the TemplateProfileComponent.
+type TemplateProfileComponentResponse struct {
+	// Name of the Profile.
+	Name *string `json:"name" validate:"required"`
+
+	// Description of the Profile.
+	Description *string `json:"description,omitempty"`
+
+	// Rules for the Profile.
+	Rules []TrustedProfileTemplateClaimRule `json:"rules,omitempty"`
+
+	// Identities for the Profile.
+	Identities []ProfileIdentityResponse `json:"identities,omitempty"`
+}
+
+// UnmarshalTemplateProfileComponentResponse unmarshals an instance of TemplateProfileComponentResponse from the specified map of raw messages.
+func UnmarshalTemplateProfileComponentResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateProfileComponentResponse)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "rules", &obj.Rules, UnmarshalTrustedProfileTemplateClaimRule)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "identities", &obj.Identities, UnmarshalProfileIdentityResponse)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
 }
 
 // TrustedProfile : Response body format for trusted profile V1 REST requests.
@@ -6400,6 +10795,244 @@ func UnmarshalTrustedProfile(m map[string]json.RawMessage, result interface{}) (
 		return
 	}
 	err = core.UnmarshalModel(m, "activity", &obj.Activity, UnmarshalActivity)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TrustedProfileTemplateClaimRule : TrustedProfileTemplateClaimRule struct
+type TrustedProfileTemplateClaimRule struct {
+	// Name of the claim rule to be created or updated.
+	Name *string `json:"name,omitempty"`
+
+	// Type of the claim rule.
+	Type *string `json:"type" validate:"required"`
+
+	// The realm name of the Idp this claim rule applies to. This field is required only if the type is specified as
+	// 'Profile-SAML'.
+	RealmName *string `json:"realm_name,omitempty"`
+
+	// Session expiration in seconds, only required if type is 'Profile-SAML'.
+	Expiration *int64 `json:"expiration,omitempty"`
+
+	// Conditions of this claim rule.
+	Conditions []ProfileClaimRuleConditions `json:"conditions" validate:"required"`
+}
+
+// Constants associated with the TrustedProfileTemplateClaimRule.Type property.
+// Type of the claim rule.
+const (
+	TrustedProfileTemplateClaimRuleTypeProfileSamlConst = "Profile-SAML"
+)
+
+// NewTrustedProfileTemplateClaimRule : Instantiate TrustedProfileTemplateClaimRule (Generic Model Constructor)
+func (*IamIdentityV1) NewTrustedProfileTemplateClaimRule(typeVar string, conditions []ProfileClaimRuleConditions) (_model *TrustedProfileTemplateClaimRule, err error) {
+	_model = &TrustedProfileTemplateClaimRule{
+		Type: core.StringPtr(typeVar),
+		Conditions: conditions,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalTrustedProfileTemplateClaimRule unmarshals an instance of TrustedProfileTemplateClaimRule from the specified map of raw messages.
+func UnmarshalTrustedProfileTemplateClaimRule(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TrustedProfileTemplateClaimRule)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "type", &obj.Type)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "realm_name", &obj.RealmName)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "expiration", &obj.Expiration)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalProfileClaimRuleConditions)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TrustedProfileTemplateList : TrustedProfileTemplateList struct
+type TrustedProfileTemplateList struct {
+	// Context with key properties for problem determination.
+	Context *ResponseContext `json:"context,omitempty"`
+
+	// The offset of the current page.
+	Offset *int64 `json:"offset,omitempty"`
+
+	// Optional size of a single page.
+	Limit *int64 `json:"limit,omitempty"`
+
+	// Link to the first page.
+	First *string `json:"first,omitempty"`
+
+	// Link to the previous available page. If 'previous' property is not part of the response no previous page is
+	// available.
+	Previous *string `json:"previous,omitempty"`
+
+	// Link to the next available page. If 'next' property is not part of the response no next page is available.
+	Next *string `json:"next,omitempty"`
+
+	// List of Profile Templates based on the query paramters and the page size. The profile_templates array is always part
+	// of the response but might be empty depending on the query parameter values provided.
+	ProfileTemplates []TrustedProfileTemplateResponse `json:"profile_templates" validate:"required"`
+}
+
+// UnmarshalTrustedProfileTemplateList unmarshals an instance of TrustedProfileTemplateList from the specified map of raw messages.
+func UnmarshalTrustedProfileTemplateList(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TrustedProfileTemplateList)
+	err = core.UnmarshalModel(m, "context", &obj.Context, UnmarshalResponseContext)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "first", &obj.First)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "previous", &obj.Previous)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "next", &obj.Next)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "profile_templates", &obj.ProfileTemplates, UnmarshalTrustedProfileTemplateResponse)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TrustedProfileTemplateResponse : Response body format for Trusted Profile Template REST requests.
+type TrustedProfileTemplateResponse struct {
+	// ID of the the template.
+	ID *string `json:"id" validate:"required"`
+
+	// Version of the the template.
+	Version *int64 `json:"version" validate:"required"`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id" validate:"required"`
+
+	// Name of the Template.
+	Name *string `json:"name" validate:"required"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	// Committed flag determines if the template is ready for assignment.
+	Committed *bool `json:"committed,omitempty"`
+
+	// Input body parameters for the TemplateProfileComponent.
+	Profile *TemplateProfileComponentResponse `json:"profile,omitempty"`
+
+	// Policy templates to be deployed for the Profile component.
+	PolicyTemplateReferences []PolicyTemplateReference `json:"policy_template_references,omitempty"`
+
+	// History of the Profile Template.
+	History []EnityHistoryRecord `json:"history,omitempty"`
+
+	// Entity tag for this templateId-version combination.
+	EntityTag *string `json:"entity_tag,omitempty"`
+
+	// Cloud resource name.
+	CRN *string `json:"crn,omitempty"`
+
+	// Template Created At.
+	CreatedAt *string `json:"created_at,omitempty"`
+
+	// IAMid of the creator.
+	CreatedByID *string `json:"created_by_id,omitempty"`
+
+	// Template last modified at.
+	LastModifiedAt *string `json:"last_modified_at,omitempty"`
+
+	// IAMid of the identity that made the latest modification.
+	LastModifiedByID *string `json:"last_modified_by_id,omitempty"`
+}
+
+// UnmarshalTrustedProfileTemplateResponse unmarshals an instance of TrustedProfileTemplateResponse from the specified map of raw messages.
+func UnmarshalTrustedProfileTemplateResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TrustedProfileTemplateResponse)
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version", &obj.Version)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "committed", &obj.Committed)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "profile", &obj.Profile, UnmarshalTemplateProfileComponentResponse)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "policy_template_references", &obj.PolicyTemplateReferences, UnmarshalPolicyTemplateReference)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "history", &obj.History, UnmarshalEnityHistoryRecord)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "entity_tag", &obj.EntityTag)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "crn", &obj.CRN)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_by_id", &obj.CreatedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_at", &obj.LastModifiedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_by_id", &obj.LastModifiedByID)
 	if err != nil {
 		return
 	}
@@ -6523,6 +11156,58 @@ func (options *UnlockServiceIDOptions) SetHeaders(param map[string]string) *Unlo
 	return options
 }
 
+// UpdateAccountSettingsAssignmentOptions : The UpdateAccountSettingsAssignment options.
+type UpdateAccountSettingsAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Version of the Assignment to be updated. Specify the version that you retrieved when reading the Assignment. This
+	// value  helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might
+	// result in stale updates.
+	IfMatch *string `json:"If-Match" validate:"required"`
+
+	// Template version which shall be applied to the assignment. Providing the existing version indicates to retry all
+	// failed assignments. Providing a new version start the assignment process from the beginning, migrating previously
+	// assignment resources to the new Version.
+	TemplateVersion *int64 `json:"template_version" validate:"required"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewUpdateAccountSettingsAssignmentOptions : Instantiate UpdateAccountSettingsAssignmentOptions
+func (*IamIdentityV1) NewUpdateAccountSettingsAssignmentOptions(assignmentID string, ifMatch string, templateVersion int64) *UpdateAccountSettingsAssignmentOptions {
+	return &UpdateAccountSettingsAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+		IfMatch: core.StringPtr(ifMatch),
+		TemplateVersion: core.Int64Ptr(templateVersion),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *UpdateAccountSettingsAssignmentOptions) SetAssignmentID(assignmentID string) *UpdateAccountSettingsAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetIfMatch : Allow user to set IfMatch
+func (_options *UpdateAccountSettingsAssignmentOptions) SetIfMatch(ifMatch string) *UpdateAccountSettingsAssignmentOptions {
+	_options.IfMatch = core.StringPtr(ifMatch)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *UpdateAccountSettingsAssignmentOptions) SetTemplateVersion(templateVersion int64) *UpdateAccountSettingsAssignmentOptions {
+	_options.TemplateVersion = core.Int64Ptr(templateVersion)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateAccountSettingsAssignmentOptions) SetHeaders(param map[string]string) *UpdateAccountSettingsAssignmentOptions {
+	options.Headers = param
+	return options
+}
+
 // UpdateAccountSettingsOptions : The UpdateAccountSettings options.
 type UpdateAccountSettingsOptions struct {
 	// Version of the account settings to be updated. Specify the version that you retrieved as entity_tag (ETag header)
@@ -6592,49 +11277,49 @@ type UpdateAccountSettingsOptions struct {
 
 // Constants associated with the UpdateAccountSettingsOptions.RestrictCreateServiceID property.
 // Defines whether or not creating a Service Id is access controlled. Valid values:
-//   - RESTRICTED - to apply access control
-//   - NOT_RESTRICTED - to remove access control
-//   - NOT_SET - to unset a previously set value.
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to unset a previously set value.
 const (
 	UpdateAccountSettingsOptionsRestrictCreateServiceIDNotRestrictedConst = "NOT_RESTRICTED"
-	UpdateAccountSettingsOptionsRestrictCreateServiceIDNotSetConst        = "NOT_SET"
-	UpdateAccountSettingsOptionsRestrictCreateServiceIDRestrictedConst    = "RESTRICTED"
+	UpdateAccountSettingsOptionsRestrictCreateServiceIDNotSetConst = "NOT_SET"
+	UpdateAccountSettingsOptionsRestrictCreateServiceIDRestrictedConst = "RESTRICTED"
 )
 
 // Constants associated with the UpdateAccountSettingsOptions.RestrictCreatePlatformApikey property.
 // Defines whether or not creating platform API keys is access controlled. Valid values:
-//   - RESTRICTED - to apply access control
-//   - NOT_RESTRICTED - to remove access control
-//   - NOT_SET - to 'unset' a previous set value.
+//   * RESTRICTED - to apply access control
+//   * NOT_RESTRICTED - to remove access control
+//   * NOT_SET - to 'unset' a previous set value.
 const (
 	UpdateAccountSettingsOptionsRestrictCreatePlatformApikeyNotRestrictedConst = "NOT_RESTRICTED"
-	UpdateAccountSettingsOptionsRestrictCreatePlatformApikeyNotSetConst        = "NOT_SET"
-	UpdateAccountSettingsOptionsRestrictCreatePlatformApikeyRestrictedConst    = "RESTRICTED"
+	UpdateAccountSettingsOptionsRestrictCreatePlatformApikeyNotSetConst = "NOT_SET"
+	UpdateAccountSettingsOptionsRestrictCreatePlatformApikeyRestrictedConst = "RESTRICTED"
 )
 
 // Constants associated with the UpdateAccountSettingsOptions.Mfa property.
 // Defines the MFA trait for the account. Valid values:
-//   - NONE - No MFA trait set
-//   - NONE_NO_ROPC- No MFA, disable CLI logins with only a password
-//   - TOTP - For all non-federated IBMId users
-//   - TOTP4ALL - For all users
-//   - LEVEL1 - Email-based MFA for all users
-//   - LEVEL2 - TOTP-based MFA for all users
-//   - LEVEL3 - U2F MFA for all users.
+//   * NONE - No MFA trait set
+//   * NONE_NO_ROPC- No MFA, disable CLI logins with only a password
+//   * TOTP - For all non-federated IBMId users
+//   * TOTP4ALL - For all users
+//   * LEVEL1 - Email-based MFA for all users
+//   * LEVEL2 - TOTP-based MFA for all users
+//   * LEVEL3 - U2F MFA for all users.
 const (
-	UpdateAccountSettingsOptionsMfaLevel1Const     = "LEVEL1"
-	UpdateAccountSettingsOptionsMfaLevel2Const     = "LEVEL2"
-	UpdateAccountSettingsOptionsMfaLevel3Const     = "LEVEL3"
-	UpdateAccountSettingsOptionsMfaNoneConst       = "NONE"
+	UpdateAccountSettingsOptionsMfaLevel1Const = "LEVEL1"
+	UpdateAccountSettingsOptionsMfaLevel2Const = "LEVEL2"
+	UpdateAccountSettingsOptionsMfaLevel3Const = "LEVEL3"
+	UpdateAccountSettingsOptionsMfaNoneConst = "NONE"
 	UpdateAccountSettingsOptionsMfaNoneNoRopcConst = "NONE_NO_ROPC"
-	UpdateAccountSettingsOptionsMfaTotpConst       = "TOTP"
-	UpdateAccountSettingsOptionsMfaTotp4allConst   = "TOTP4ALL"
+	UpdateAccountSettingsOptionsMfaTotpConst = "TOTP"
+	UpdateAccountSettingsOptionsMfaTotp4allConst = "TOTP4ALL"
 )
 
 // NewUpdateAccountSettingsOptions : Instantiate UpdateAccountSettingsOptions
 func (*IamIdentityV1) NewUpdateAccountSettingsOptions(ifMatch string, accountID string) *UpdateAccountSettingsOptions {
 	return &UpdateAccountSettingsOptions{
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 		AccountID: core.StringPtr(accountID),
 	}
 }
@@ -6717,6 +11402,91 @@ func (options *UpdateAccountSettingsOptions) SetHeaders(param map[string]string)
 	return options
 }
 
+// UpdateAccountSettingsTemplateVersionOptions : The UpdateAccountSettingsTemplateVersion options.
+type UpdateAccountSettingsTemplateVersionOptions struct {
+	// Entity tag of the Template to be updated. Specify the tag that you retrieved when reading the Account Settings
+	// Template. This value  helps identifying parallel usage of this API. Pass * to indicate to update any version
+	// available. This might result in stale updates.
+	IfMatch *string `json:"If-Match" validate:"required"`
+
+	// ID of the Account Settings Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Account Settings Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	AccountSettings *AccountSettingsComponent `json:"account_settings,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewUpdateAccountSettingsTemplateVersionOptions : Instantiate UpdateAccountSettingsTemplateVersionOptions
+func (*IamIdentityV1) NewUpdateAccountSettingsTemplateVersionOptions(ifMatch string, templateID string, version string) *UpdateAccountSettingsTemplateVersionOptions {
+	return &UpdateAccountSettingsTemplateVersionOptions{
+		IfMatch: core.StringPtr(ifMatch),
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetIfMatch : Allow user to set IfMatch
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetIfMatch(ifMatch string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.IfMatch = core.StringPtr(ifMatch)
+	return _options
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetTemplateID(templateID string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetVersion(version string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetAccountID(accountID string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetName(name string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetDescription(description string) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetAccountSettings : Allow user to set AccountSettings
+func (_options *UpdateAccountSettingsTemplateVersionOptions) SetAccountSettings(accountSettings *AccountSettingsComponent) *UpdateAccountSettingsTemplateVersionOptions {
+	_options.AccountSettings = accountSettings
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateAccountSettingsTemplateVersionOptions) SetHeaders(param map[string]string) *UpdateAccountSettingsTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // UpdateAPIKeyOptions : The UpdateAPIKey options.
 type UpdateAPIKeyOptions struct {
 	// Unique ID of the API key to be updated.
@@ -6742,7 +11512,7 @@ type UpdateAPIKeyOptions struct {
 // NewUpdateAPIKeyOptions : Instantiate UpdateAPIKeyOptions
 func (*IamIdentityV1) NewUpdateAPIKeyOptions(id string, ifMatch string) *UpdateAPIKeyOptions {
 	return &UpdateAPIKeyOptions{
-		ID:      core.StringPtr(id),
+		ID: core.StringPtr(id),
 		IfMatch: core.StringPtr(ifMatch),
 	}
 }
@@ -6820,10 +11590,10 @@ type UpdateClaimRuleOptions struct {
 // NewUpdateClaimRuleOptions : Instantiate UpdateClaimRuleOptions
 func (*IamIdentityV1) NewUpdateClaimRuleOptions(profileID string, ruleID string, ifMatch string, typeVar string, conditions []ProfileClaimRuleConditions) *UpdateClaimRuleOptions {
 	return &UpdateClaimRuleOptions{
-		ProfileID:  core.StringPtr(profileID),
-		RuleID:     core.StringPtr(ruleID),
-		IfMatch:    core.StringPtr(ifMatch),
-		Type:       core.StringPtr(typeVar),
+		ProfileID: core.StringPtr(profileID),
+		RuleID: core.StringPtr(ruleID),
+		IfMatch: core.StringPtr(ifMatch),
+		Type: core.StringPtr(typeVar),
 		Conditions: conditions,
 	}
 }
@@ -6920,7 +11690,7 @@ type UpdateProfileOptions struct {
 func (*IamIdentityV1) NewUpdateProfileOptions(profileID string, ifMatch string) *UpdateProfileOptions {
 	return &UpdateProfileOptions{
 		ProfileID: core.StringPtr(profileID),
-		IfMatch:   core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -6954,6 +11724,101 @@ func (options *UpdateProfileOptions) SetHeaders(param map[string]string) *Update
 	return options
 }
 
+// UpdateProfileTemplateVersionOptions : The UpdateProfileTemplateVersion options.
+type UpdateProfileTemplateVersionOptions struct {
+	// Entity tag of the Template to be updated. Specify the tag that you retrieved when reading the Profile Template. This
+	// value  helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might
+	// result in stale updates.
+	IfMatch *string `json:"If-Match" validate:"required"`
+
+	// ID of the Profile Template.
+	TemplateID *string `json:"template_id" validate:"required,ne="`
+
+	// Version of the Profile Template.
+	Version *string `json:"version" validate:"required,ne="`
+
+	// ID of the account where the template resides.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// Name of the Template.
+	Name *string `json:"name,omitempty"`
+
+	// Description of the Template.
+	Description *string `json:"description,omitempty"`
+
+	// Input body parameters for the TemplateProfileComponent.
+	Profile *TemplateProfileComponentRequest `json:"profile,omitempty"`
+
+	// Policy templates to be deployed for the Profile component.
+	PolicyTemplateReferences []PolicyTemplateReference `json:"policy_template_references,omitempty"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewUpdateProfileTemplateVersionOptions : Instantiate UpdateProfileTemplateVersionOptions
+func (*IamIdentityV1) NewUpdateProfileTemplateVersionOptions(ifMatch string, templateID string, version string) *UpdateProfileTemplateVersionOptions {
+	return &UpdateProfileTemplateVersionOptions{
+		IfMatch: core.StringPtr(ifMatch),
+		TemplateID: core.StringPtr(templateID),
+		Version: core.StringPtr(version),
+	}
+}
+
+// SetIfMatch : Allow user to set IfMatch
+func (_options *UpdateProfileTemplateVersionOptions) SetIfMatch(ifMatch string) *UpdateProfileTemplateVersionOptions {
+	_options.IfMatch = core.StringPtr(ifMatch)
+	return _options
+}
+
+// SetTemplateID : Allow user to set TemplateID
+func (_options *UpdateProfileTemplateVersionOptions) SetTemplateID(templateID string) *UpdateProfileTemplateVersionOptions {
+	_options.TemplateID = core.StringPtr(templateID)
+	return _options
+}
+
+// SetVersion : Allow user to set Version
+func (_options *UpdateProfileTemplateVersionOptions) SetVersion(version string) *UpdateProfileTemplateVersionOptions {
+	_options.Version = core.StringPtr(version)
+	return _options
+}
+
+// SetAccountID : Allow user to set AccountID
+func (_options *UpdateProfileTemplateVersionOptions) SetAccountID(accountID string) *UpdateProfileTemplateVersionOptions {
+	_options.AccountID = core.StringPtr(accountID)
+	return _options
+}
+
+// SetName : Allow user to set Name
+func (_options *UpdateProfileTemplateVersionOptions) SetName(name string) *UpdateProfileTemplateVersionOptions {
+	_options.Name = core.StringPtr(name)
+	return _options
+}
+
+// SetDescription : Allow user to set Description
+func (_options *UpdateProfileTemplateVersionOptions) SetDescription(description string) *UpdateProfileTemplateVersionOptions {
+	_options.Description = core.StringPtr(description)
+	return _options
+}
+
+// SetProfile : Allow user to set Profile
+func (_options *UpdateProfileTemplateVersionOptions) SetProfile(profile *TemplateProfileComponentRequest) *UpdateProfileTemplateVersionOptions {
+	_options.Profile = profile
+	return _options
+}
+
+// SetPolicyTemplateReferences : Allow user to set PolicyTemplateReferences
+func (_options *UpdateProfileTemplateVersionOptions) SetPolicyTemplateReferences(policyTemplateReferences []PolicyTemplateReference) *UpdateProfileTemplateVersionOptions {
+	_options.PolicyTemplateReferences = policyTemplateReferences
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateProfileTemplateVersionOptions) SetHeaders(param map[string]string) *UpdateProfileTemplateVersionOptions {
+	options.Headers = param
+	return options
+}
+
 // UpdateServiceIDOptions : The UpdateServiceID options.
 type UpdateServiceIDOptions struct {
 	// Unique ID of the service ID to be updated.
@@ -6983,7 +11848,7 @@ type UpdateServiceIDOptions struct {
 // NewUpdateServiceIDOptions : Instantiate UpdateServiceIDOptions
 func (*IamIdentityV1) NewUpdateServiceIDOptions(id string, ifMatch string) *UpdateServiceIDOptions {
 	return &UpdateServiceIDOptions{
-		ID:      core.StringPtr(id),
+		ID: core.StringPtr(id),
 		IfMatch: core.StringPtr(ifMatch),
 	}
 }
@@ -7020,6 +11885,58 @@ func (_options *UpdateServiceIDOptions) SetUniqueInstanceCrns(uniqueInstanceCrns
 
 // SetHeaders : Allow user to set Headers
 func (options *UpdateServiceIDOptions) SetHeaders(param map[string]string) *UpdateServiceIDOptions {
+	options.Headers = param
+	return options
+}
+
+// UpdateTrustedProfileAssignmentOptions : The UpdateTrustedProfileAssignment options.
+type UpdateTrustedProfileAssignmentOptions struct {
+	// ID of the Assignment Record.
+	AssignmentID *string `json:"assignment_id" validate:"required,ne="`
+
+	// Version of the Assignment to be updated. Specify the version that you retrieved when reading the Assignment. This
+	// value  helps identifying parallel usage of this API. Pass * to indicate to update any version available. This might
+	// result in stale updates.
+	IfMatch *string `json:"If-Match" validate:"required"`
+
+	// Template version which shall be applied to the assignment. Providing the existing version indicates to retry all
+	// failed assignments. Providing a new version start the assignment process from the beginning, migrating previously
+	// assignment resources to the new Version.
+	TemplateVersion *int64 `json:"template_version" validate:"required"`
+
+	// Allows users to set headers on API requests
+	Headers map[string]string
+}
+
+// NewUpdateTrustedProfileAssignmentOptions : Instantiate UpdateTrustedProfileAssignmentOptions
+func (*IamIdentityV1) NewUpdateTrustedProfileAssignmentOptions(assignmentID string, ifMatch string, templateVersion int64) *UpdateTrustedProfileAssignmentOptions {
+	return &UpdateTrustedProfileAssignmentOptions{
+		AssignmentID: core.StringPtr(assignmentID),
+		IfMatch: core.StringPtr(ifMatch),
+		TemplateVersion: core.Int64Ptr(templateVersion),
+	}
+}
+
+// SetAssignmentID : Allow user to set AssignmentID
+func (_options *UpdateTrustedProfileAssignmentOptions) SetAssignmentID(assignmentID string) *UpdateTrustedProfileAssignmentOptions {
+	_options.AssignmentID = core.StringPtr(assignmentID)
+	return _options
+}
+
+// SetIfMatch : Allow user to set IfMatch
+func (_options *UpdateTrustedProfileAssignmentOptions) SetIfMatch(ifMatch string) *UpdateTrustedProfileAssignmentOptions {
+	_options.IfMatch = core.StringPtr(ifMatch)
+	return _options
+}
+
+// SetTemplateVersion : Allow user to set TemplateVersion
+func (_options *UpdateTrustedProfileAssignmentOptions) SetTemplateVersion(templateVersion int64) *UpdateTrustedProfileAssignmentOptions {
+	_options.TemplateVersion = core.Int64Ptr(templateVersion)
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateTrustedProfileAssignmentOptions) SetHeaders(param map[string]string) *UpdateTrustedProfileAssignmentOptions {
 	options.Headers = param
 	return options
 }

--- a/iamidentityv1/iam_identity_v1_integration_test.go
+++ b/iamidentityv1/iam_identity_v1_integration_test.go
@@ -1692,11 +1692,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateProfileTemplate`, func() {
+	Describe(`CreateProfileTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`CreateProfileTemplate`, func() {
+		It(`CreateProfileTemplateIT`, func() {
 			profileClaimRuleConditions := new(iamidentityv1.ProfileClaimRuleConditions)
 			profileClaimRuleConditions.Claim = core.StringPtr("blueGroups")
 			profileClaimRuleConditions.Operator = core.StringPtr("EQUALS")
@@ -1736,11 +1736,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetProfileTemplate`, func() {
+	Describe(`GetProfileTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`GetProfileTemplate`, func() {
+		It(`GetProfileTemplateIT`, func() {
 			getOptions := &iamidentityv1.GetProfileTemplateVersionOptions{
 				TemplateID: &profileTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(profileTemplateVersion, 10)),
@@ -1756,11 +1756,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListProfileTemplates`, func() {
+	Describe(`ListProfileTemplatesIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListProfileTemplates`, func() {
+		It(`ListProfileTemplatesIT`, func() {
 			listOptions := &iamidentityv1.ListProfileTemplatesOptions{
 				AccountID: &enterpriseAccountID,
 			}
@@ -1771,11 +1771,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateProfileTemplate`, func() {
+	Describe(`UpdateProfileTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`UpdateProfileTemplate`, func() {
+		It(`UpdateProfileTemplateIT`, func() {
 			updateOptions := &iamidentityv1.UpdateProfileTemplateVersionOptions{
 				AccountID:   &enterpriseAccountID,
 				TemplateID:  &profileTemplateId,
@@ -1795,11 +1795,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`AssignProfileTemplate`, func() {
+	Describe(`AssignProfileTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`AssignProfileTemplate`, func() {
+		It(`AssignProfileTemplateIT`, func() {
 			commitOptions := &iamidentityv1.CommitProfileTemplateOptions{
 				TemplateID: &profileTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(profileTemplateVersion, 10)),
@@ -1827,11 +1827,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListProfileTemplateAssignments`, func() {
+	Describe(`ListProfileTemplateAssignmentsIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListProfileTemplateAssignments`, func() {
+		It(`ListProfileTemplateAssignmentsIT`, func() {
 			listOptions := &iamidentityv1.ListTrustedProfileAssignmentsOptions{
 				AccountID:  &enterpriseAccountID,
 				TemplateID: &profileTemplateId,
@@ -1846,11 +1846,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateNewProfileTemplateVersion`, func() {
+	Describe(`CreateNewProfileTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`CreateNewProfileTemplateVersion`, func() {
+		It(`CreateNewProfileTemplateVersionIT`, func() {
 			profileClaimRuleConditions := new(iamidentityv1.ProfileClaimRuleConditions)
 			profileClaimRuleConditions.Claim = core.StringPtr("blueGroups")
 			profileClaimRuleConditions.Operator = core.StringPtr("EQUALS")
@@ -1886,11 +1886,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetLatestProfileTemplateVersion`, func() {
+	Describe(`GetLatestProfileTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`GetLatestProfileTemplateVersion`, func() {
+		It(`GetLatestProfileTemplateVersionIT`, func() {
 			getOptions := &iamidentityv1.GetLatestProfileTemplateVersionOptions{
 				TemplateID: &profileTemplateId,
 			}
@@ -1901,11 +1901,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListProfileTemplateVersions`, func() {
+	Describe(`ListProfileTemplateVersionsIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListProfileTemplateVersions`, func() {
+		It(`ListProfileTemplateVersionsIT`, func() {
 			listOptions := &iamidentityv1.ListVersionsOfProfileTemplateOptions{
 				TemplateID: &profileTemplateId,
 			}
@@ -1919,11 +1919,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateProfileTemplateAssignment`, func() {
+	Describe(`UpdateProfileTemplateAssignmentIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`UpdateProfileTemplateAssignment`, func() {
+		It(`UpdateProfileTemplateAssignmentIT`, func() {
 			commitOptions := &iamidentityv1.CommitProfileTemplateOptions{
 				TemplateID: &profileTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(profileTemplateVersion, 10)),
@@ -1932,7 +1932,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(cResponse.StatusCode).To(Equal(204))
 			Expect(cErr).To(BeNil())
 
-			waitUntilTrustedProfileAssignmentFinished(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
+			waitUntilTrustedProfileAssignmentFinishedIT(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
 
 			updateOptions := &iamidentityv1.UpdateTrustedProfileAssignmentOptions{
 				AssignmentID:    &profileTemplateAssignmentId,
@@ -1950,12 +1950,12 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteProfileTemplateAssignment`, func() {
+	Describe(`DeleteProfileTemplateAssignmentIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteProfileTemplateAssignment`, func() {
-			waitUntilTrustedProfileAssignmentFinished(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
+		It(`DeleteProfileTemplateAssignmentIT`, func() {
+			waitUntilTrustedProfileAssignmentFinishedIT(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
 
 			deleteOptions := &iamidentityv1.DeleteTrustedProfileAssignmentOptions{
 				AssignmentID: &profileTemplateAssignmentId,
@@ -1967,11 +1967,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteProfileTemplateVersion`, func() {
+	Describe(`DeleteProfileTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteProfileTemplateVersion`, func() {
+		It(`DeleteProfileTemplateVersionIT`, func() {
 			deleteOptions := &iamidentityv1.DeleteProfileTemplateVersionOptions{
 				TemplateID: &profileTemplateId,
 				Version:    core.StringPtr("1"),
@@ -1982,12 +1982,12 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteProfileTemplate`, func() {
+	Describe(`DeleteProfileTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteProfileTemplate`, func() {
-			waitUntilTrustedProfileAssignmentFinished(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
+		It(`DeleteProfileTemplateIT`, func() {
+			waitUntilTrustedProfileAssignmentFinishedIT(iamIdentityService, &profileTemplateAssignmentId, &profileTemplateAssignmentEtag)
 
 			deleteOptions := &iamidentityv1.DeleteAllVersionsOfProfileTemplateOptions{
 				TemplateID: &profileTemplateId,
@@ -1998,11 +1998,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateAccountSettingsTemplate`, func() {
+	Describe(`CreateAccountSettingsTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`CreateAccountSettingsTemplate`, func() {
+		It(`CreateAccountSettingsTemplateIT`, func() {
 
 			settings := &iamidentityv1.AccountSettingsComponent{
 				Mfa:                                  core.StringPtr("LEVEL1"),
@@ -2030,11 +2030,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetAccountSettingsTemplate`, func() {
+	Describe(`GetAccountSettingsTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`GetAccountSettingsTemplate`, func() {
+		It(`GetAccountSettingsTemplateIT`, func() {
 			getOptions := &iamidentityv1.GetAccountSettingsTemplateVersionOptions{
 				TemplateID: &accountSettingsTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(accountSettingsTemplateVersion, 10)),
@@ -2050,11 +2050,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListAccountSettingsTemplates`, func() {
+	Describe(`ListAccountSettingsTemplatesIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListAccountSettingsTemplates`, func() {
+		It(`ListAccountSettingsTemplatesIT`, func() {
 			listOptions := &iamidentityv1.ListAccountSettingsTemplatesOptions{
 				AccountID: &enterpriseAccountID,
 			}
@@ -2065,11 +2065,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateAccountSettingsTemplate`, func() {
+	Describe(`UpdateAccountSettingsTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`UpdateAccountSettingsTemplate`, func() {
+		It(`UpdateAccountSettingsTemplateIT`, func() {
 			settings := &iamidentityv1.AccountSettingsComponent{
 				Mfa:                                  core.StringPtr("LEVEL1"),
 				SystemAccessTokenExpirationInSeconds: core.StringPtr("3000"),
@@ -2094,11 +2094,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`AssignAccountSettingsTemplate`, func() {
+	Describe(`AssignAccountSettingsTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`AssignAccountSettingsTemplate`, func() {
+		It(`AssignAccountSettingsTemplateIT`, func() {
 			commitOptions := &iamidentityv1.CommitAccountSettingsTemplateOptions{
 				TemplateID: &accountSettingsTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(accountSettingsTemplateVersion, 10)),
@@ -2126,11 +2126,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListAccountSettingsTemplateAssignments`, func() {
+	Describe(`ListAccountSettingsTemplateAssignmentsIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListAccountSettingsTemplateAssignments`, func() {
+		It(`ListAccountSettingsTemplateAssignmentsIT`, func() {
 			listOptions := &iamidentityv1.ListAccountSettingsAssignmentsOptions{
 				AccountID:  &enterpriseAccountID,
 				TemplateID: &accountSettingsTemplateId,
@@ -2145,11 +2145,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`CreateNewAccountSettingsTemplateVersion`, func() {
+	Describe(`CreateNewAccountSettingsTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`CreateNewAccountSettingsTemplateVersion`, func() {
+		It(`CreateNewAccountSettingsTemplateVersionIT`, func() {
 			settings := &iamidentityv1.AccountSettingsComponent{
 				Mfa:                                  core.StringPtr("LEVEL1"),
 				SystemAccessTokenExpirationInSeconds: core.StringPtr("2600"),
@@ -2174,11 +2174,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`GetLatestAccountSettingsTemplateVersion`, func() {
+	Describe(`GetLatestAccountSettingsTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`GetLatestAccountSettingsTemplateVersion`, func() {
+		It(`GetLatestAccountSettingsTemplateVersionIT`, func() {
 			getOptions := &iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions{
 				TemplateID: &accountSettingsTemplateId,
 			}
@@ -2189,11 +2189,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`ListAccountSettingsTemplateVersions`, func() {
+	Describe(`ListAccountSettingsTemplateVersionsIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`ListAccountSettingsTemplateVersions`, func() {
+		It(`ListAccountSettingsTemplateVersionsIT`, func() {
 			listOptions := &iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions{
 				TemplateID: &accountSettingsTemplateId,
 			}
@@ -2207,11 +2207,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`UpdateAccountSettingsTemplateAssignment`, func() {
+	Describe(`UpdateAccountSettingsTemplateAssignmentIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`UpdateAccountSettingsTemplateAssignment`, func() {
+		It(`UpdateAccountSettingsTemplateAssignmentIT`, func() {
 			commitOptions := &iamidentityv1.CommitAccountSettingsTemplateOptions{
 				TemplateID: &accountSettingsTemplateId,
 				Version:    core.StringPtr(strconv.FormatInt(accountSettingsTemplateVersion, 10)),
@@ -2220,7 +2220,7 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 			Expect(cResponse.StatusCode).To(Equal(204))
 			Expect(cErr).To(BeNil())
 
-			waitUntilAccountSettingsAssignmentFinished(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
+			waitUntilAccountSettingsAssignmentFinishedIT(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
 
 			updateOptions := &iamidentityv1.UpdateAccountSettingsAssignmentOptions{
 				AssignmentID:    &accountSettingsTemplateAssignmentId,
@@ -2238,12 +2238,12 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteAccountSettingsTemplateAssignment`, func() {
+	Describe(`DeleteAccountSettingsTemplateAssignmentIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteAccountSettingsTemplateAssignment`, func() {
-			waitUntilAccountSettingsAssignmentFinished(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
+		It(`DeleteAccountSettingsTemplateAssignmentIT`, func() {
+			waitUntilAccountSettingsAssignmentFinishedIT(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
 
 			deleteOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{
 				AssignmentID: &accountSettingsTemplateAssignmentId,
@@ -2255,11 +2255,11 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteAccountSettingsTemplateVersion`, func() {
+	Describe(`DeleteAccountSettingsTemplateVersionIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteAccountSettingsTemplateVersion`, func() {
+		It(`DeleteAccountSettingsTemplateVersionIT`, func() {
 			deleteOptions := &iamidentityv1.DeleteAccountSettingsTemplateVersionOptions{
 				TemplateID: &accountSettingsTemplateId,
 				Version:    core.StringPtr("1"),
@@ -2270,12 +2270,12 @@ var _ = Describe(`IamIdentityV1 Integration Tests`, func() {
 		})
 	})
 
-	Describe(`DeleteAccountSettingsTemplate`, func() {
+	Describe(`DeleteAccountSettingsTemplateIT`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()
 		})
-		It(`DeleteAccountSettingsTemplate`, func() {
-			waitUntilAccountSettingsAssignmentFinished(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
+		It(`DeleteAccountSettingsTemplateIT`, func() {
+			waitUntilAccountSettingsAssignmentFinishedIT(iamIdentityService, &accountSettingsTemplateAssignmentId, &accountSettingsTemplateAssignmentEtag)
 
 			deleteOptions := &iamidentityv1.DeleteAllVersionsOfAccountSettingsTemplateOptions{
 				TemplateID: &accountSettingsTemplateId,
@@ -2335,7 +2335,7 @@ func getLink(service *iamidentityv1.IamIdentityV1, profileID string, linkID stri
 	return link
 }
 
-func isFinished(status *string) bool {
+func isFinishedIT(status *string) bool {
 	var finished = false
 	if strings.EqualFold(*status, "succeeded") || strings.EqualFold(*status, "failed") {
 		finished = true
@@ -2343,7 +2343,7 @@ func isFinished(status *string) bool {
 	return finished
 }
 
-func waitUntilTrustedProfileAssignmentFinished(service *iamidentityv1.IamIdentityV1, assignmentId *string, profileTemplateAssignmentEtag *string) {
+func waitUntilTrustedProfileAssignmentFinishedIT(service *iamidentityv1.IamIdentityV1, assignmentId *string, profileTemplateAssignmentEtag *string) {
 	getAssignmentOptions := &iamidentityv1.GetTrustedProfileAssignmentOptions{
 		AssignmentID: assignmentId,
 	}
@@ -2356,7 +2356,7 @@ func waitUntilTrustedProfileAssignmentFinished(service *iamidentityv1.IamIdentit
 			finished = true // assignment removed
 			break
 		} else {
-			finished = isFinished(assignment.Status)
+			finished = isFinishedIT(assignment.Status)
 			if finished {
 				// Grab the Etag value from the response for use in the update operation.
 				Expect(response.GetHeaders()).ToNot(BeNil())
@@ -2370,7 +2370,7 @@ func waitUntilTrustedProfileAssignmentFinished(service *iamidentityv1.IamIdentit
 	Expect(finished).To(BeTrue())
 }
 
-func waitUntilAccountSettingsAssignmentFinished(service *iamidentityv1.IamIdentityV1, assignmentId *string, accountSettingsTemplateAssignmentEtag *string) {
+func waitUntilAccountSettingsAssignmentFinishedIT(service *iamidentityv1.IamIdentityV1, assignmentId *string, accountSettingsTemplateAssignmentEtag *string) {
 	getAssignmentOptions := &iamidentityv1.GetAccountSettingsAssignmentOptions{
 		AssignmentID: assignmentId,
 	}
@@ -2383,7 +2383,7 @@ func waitUntilAccountSettingsAssignmentFinished(service *iamidentityv1.IamIdenti
 			finished = true // assignment removed
 			break
 		} else {
-			finished = isFinished(assignment.Status)
+			finished = isFinishedIT(assignment.Status)
 			if finished {
 				// Grab the Etag value from the response for use in the update operation.
 				Expect(response.GetHeaders()).ToNot(BeNil())
@@ -2534,8 +2534,8 @@ func cleanupResources(service *iamidentityv1.IamIdentityV1, accountID string, ia
 				numAssignments := len(assignmentsList.Assignments)
 				if numAssignments > 0 {
 					for _, assignment := range assignmentsList.Assignments {
-						if !isFinished(assignment.Status) {
-							waitUntilTrustedProfileAssignmentFinished(service, assignment.ID, profileTemplateAssignmentEtag)
+						if !isFinishedIT(assignment.Status) {
+							waitUntilTrustedProfileAssignmentFinishedIT(service, assignment.ID, profileTemplateAssignmentEtag)
 						}
 						deleteAssignmentOptions := &iamidentityv1.DeleteTrustedProfileAssignmentOptions{
 							AssignmentID: assignment.ID,
@@ -2544,7 +2544,7 @@ func cleanupResources(service *iamidentityv1.IamIdentityV1, accountID string, ia
 						Expect(exceptionRsp).To(BeNil())
 						Expect(daResponse).ToNot(BeNil())
 						Expect(daErr).To(BeNil())
-						waitUntilTrustedProfileAssignmentFinished(service, assignment.ID, profileTemplateAssignmentEtag)
+						waitUntilTrustedProfileAssignmentFinishedIT(service, assignment.ID, profileTemplateAssignmentEtag)
 					}
 				}
 
@@ -2584,8 +2584,8 @@ func cleanupResources(service *iamidentityv1.IamIdentityV1, accountID string, ia
 				numAssignments := len(assignmentsList.Assignments)
 				if numAssignments > 0 {
 					for _, assignment := range assignmentsList.Assignments {
-						if !isFinished(assignment.Status) {
-							waitUntilAccountSettingsAssignmentFinished(service, assignment.ID, accountSettingsTemplateAssignmentEtag)
+						if !isFinishedIT(assignment.Status) {
+							waitUntilAccountSettingsAssignmentFinishedIT(service, assignment.ID, accountSettingsTemplateAssignmentEtag)
 						}
 						deleteAssignmentOptions := &iamidentityv1.DeleteAccountSettingsAssignmentOptions{
 							AssignmentID: assignment.ID,
@@ -2594,7 +2594,7 @@ func cleanupResources(service *iamidentityv1.IamIdentityV1, accountID string, ia
 						Expect(exceptionRsp).To(BeNil())
 						Expect(daResponse).ToNot(BeNil())
 						Expect(daErr).To(BeNil())
-						waitUntilAccountSettingsAssignmentFinished(service, assignment.ID, accountSettingsTemplateAssignmentEtag)
+						waitUntilAccountSettingsAssignmentFinishedIT(service, assignment.ID, accountSettingsTemplateAssignmentEtag)
 					}
 				}
 

--- a/iamidentityv1/iam_identity_v1_test.go
+++ b/iamidentityv1/iam_identity_v1_test.go
@@ -6267,19 +6267,18 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(iamIdentityService).ToNot(BeNil())
 
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				setProfileIdentitiesOptionsModel := new(iamidentityv1.SetProfileIdentitiesOptions)
 				setProfileIdentitiesOptionsModel.ProfileID = core.StringPtr("testString")
 				setProfileIdentitiesOptionsModel.IfMatch = core.StringPtr("testString")
-				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentity{*profileIdentityModel}
+				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
 				setProfileIdentitiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := iamIdentityService.SetProfileIdentities(setProfileIdentitiesOptionsModel)
@@ -6346,19 +6345,18 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(iamIdentityService).ToNot(BeNil())
 				iamIdentityService.EnableRetries(0, 0)
 
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				setProfileIdentitiesOptionsModel := new(iamidentityv1.SetProfileIdentitiesOptions)
 				setProfileIdentitiesOptionsModel.ProfileID = core.StringPtr("testString")
 				setProfileIdentitiesOptionsModel.IfMatch = core.StringPtr("testString")
-				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentity{*profileIdentityModel}
+				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
 				setProfileIdentitiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -6433,19 +6431,18 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(response).To(BeNil())
 				Expect(result).To(BeNil())
 
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				setProfileIdentitiesOptionsModel := new(iamidentityv1.SetProfileIdentitiesOptions)
 				setProfileIdentitiesOptionsModel.ProfileID = core.StringPtr("testString")
 				setProfileIdentitiesOptionsModel.IfMatch = core.StringPtr("testString")
-				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentity{*profileIdentityModel}
+				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
 				setProfileIdentitiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -6463,19 +6460,18 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(iamIdentityService).ToNot(BeNil())
 
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				setProfileIdentitiesOptionsModel := new(iamidentityv1.SetProfileIdentitiesOptions)
 				setProfileIdentitiesOptionsModel.ProfileID = core.StringPtr("testString")
 				setProfileIdentitiesOptionsModel.IfMatch = core.StringPtr("testString")
-				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentity{*profileIdentityModel}
+				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
 				setProfileIdentitiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := iamIdentityService.SetServiceURL("")
@@ -6514,19 +6510,18 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(serviceErr).To(BeNil())
 				Expect(iamIdentityService).ToNot(BeNil())
 
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				setProfileIdentitiesOptionsModel := new(iamidentityv1.SetProfileIdentitiesOptions)
 				setProfileIdentitiesOptionsModel.ProfileID = core.StringPtr("testString")
 				setProfileIdentitiesOptionsModel.IfMatch = core.StringPtr("testString")
-				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentity{*profileIdentityModel}
+				setProfileIdentitiesOptionsModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
 				setProfileIdentitiesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -6571,7 +6566,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.IdentityType = core.StringPtr("user")
 				setProfileIdentityOptionsModel.Identifier = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Type = core.StringPtr("user")
-				setProfileIdentityOptionsModel.IamID = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Accounts = []string{"testString"}
 				setProfileIdentityOptionsModel.Description = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6644,7 +6638,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.IdentityType = core.StringPtr("user")
 				setProfileIdentityOptionsModel.Identifier = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Type = core.StringPtr("user")
-				setProfileIdentityOptionsModel.IamID = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Accounts = []string{"testString"}
 				setProfileIdentityOptionsModel.Description = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6725,7 +6718,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.IdentityType = core.StringPtr("user")
 				setProfileIdentityOptionsModel.Identifier = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Type = core.StringPtr("user")
-				setProfileIdentityOptionsModel.IamID = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Accounts = []string{"testString"}
 				setProfileIdentityOptionsModel.Description = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6751,7 +6743,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.IdentityType = core.StringPtr("user")
 				setProfileIdentityOptionsModel.Identifier = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Type = core.StringPtr("user")
-				setProfileIdentityOptionsModel.IamID = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Accounts = []string{"testString"}
 				setProfileIdentityOptionsModel.Description = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -6798,7 +6789,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.IdentityType = core.StringPtr("user")
 				setProfileIdentityOptionsModel.Identifier = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Type = core.StringPtr("user")
-				setProfileIdentityOptionsModel.IamID = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Accounts = []string{"testString"}
 				setProfileIdentityOptionsModel.Description = core.StringPtr("testString")
 				setProfileIdentityOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -8317,6 +8307,3456 @@ var _ = Describe(`IamIdentityV1`, func() {
 			})
 		})
 	})
+	Describe(`ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptions *ListAccountSettingsAssignmentsOptions) - Operation response error`, func() {
+		listAccountSettingsAssignmentsPath := "/v1/account_settings_assignments/"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsAssignments with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := new(iamidentityv1.ListAccountSettingsAssignmentsOptions)
+				listAccountSettingsAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listAccountSettingsAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listAccountSettingsAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptions *ListAccountSettingsAssignmentsOptions)`, func() {
+		listAccountSettingsAssignmentsPath := "/v1/account_settings_assignments/"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "assignments": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}]}`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsAssignments successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := new(iamidentityv1.ListAccountSettingsAssignmentsOptions)
+				listAccountSettingsAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listAccountSettingsAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listAccountSettingsAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListAccountSettingsAssignmentsWithContext(ctx, listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListAccountSettingsAssignmentsWithContext(ctx, listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "assignments": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}]}`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsAssignments successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListAccountSettingsAssignments(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := new(iamidentityv1.ListAccountSettingsAssignmentsOptions)
+				listAccountSettingsAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listAccountSettingsAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listAccountSettingsAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListAccountSettingsAssignments with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := new(iamidentityv1.ListAccountSettingsAssignmentsOptions)
+				listAccountSettingsAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listAccountSettingsAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listAccountSettingsAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListAccountSettingsAssignments successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := new(iamidentityv1.ListAccountSettingsAssignmentsOptions)
+				listAccountSettingsAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listAccountSettingsAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listAccountSettingsAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListAccountSettingsAssignments(listAccountSettingsAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptions *CreateAccountSettingsAssignmentOptions) - Operation response error`, func() {
+		createAccountSettingsAssignmentPath := "/v1/account_settings_assignments/"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsModel := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				createAccountSettingsAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createAccountSettingsAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createAccountSettingsAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptions *CreateAccountSettingsAssignmentOptions)`, func() {
+		createAccountSettingsAssignmentPath := "/v1/account_settings_assignments/"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsModel := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				createAccountSettingsAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createAccountSettingsAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createAccountSettingsAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateAccountSettingsAssignmentWithContext(ctx, createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateAccountSettingsAssignmentWithContext(ctx, createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsModel := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				createAccountSettingsAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createAccountSettingsAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createAccountSettingsAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateAccountSettingsAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsModel := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				createAccountSettingsAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createAccountSettingsAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createAccountSettingsAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateAccountSettingsAssignmentOptions model with no property values
+				createAccountSettingsAssignmentOptionsModelNew := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsModel := new(iamidentityv1.CreateAccountSettingsAssignmentOptions)
+				createAccountSettingsAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createAccountSettingsAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createAccountSettingsAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsAssignment(createAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetAccountSettingsAssignment(getAccountSettingsAssignmentOptions *GetAccountSettingsAssignmentOptions) - Operation response error`, func() {
+		getAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				getAccountSettingsAssignmentOptionsModel := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				getAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getAccountSettingsAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetAccountSettingsAssignment(getAccountSettingsAssignmentOptions *GetAccountSettingsAssignmentOptions)`, func() {
+		getAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				getAccountSettingsAssignmentOptionsModel := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				getAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getAccountSettingsAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetAccountSettingsAssignmentWithContext(ctx, getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetAccountSettingsAssignmentWithContext(ctx, getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetAccountSettingsAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				getAccountSettingsAssignmentOptionsModel := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				getAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getAccountSettingsAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetAccountSettingsAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				getAccountSettingsAssignmentOptionsModel := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				getAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getAccountSettingsAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetAccountSettingsAssignmentOptions model with no property values
+				getAccountSettingsAssignmentOptionsModelNew := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				getAccountSettingsAssignmentOptionsModel := new(iamidentityv1.GetAccountSettingsAssignmentOptions)
+				getAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getAccountSettingsAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetAccountSettingsAssignment(getAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptions *DeleteAccountSettingsAssignmentOptions) - Operation response error`, func() {
+		deleteAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke DeleteAccountSettingsAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				deleteAccountSettingsAssignmentOptionsModel := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				deleteAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptions *DeleteAccountSettingsAssignmentOptions)`, func() {
+		deleteAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "status_code": "StatusCode", "errors": [{"code": "Code", "message_code": "MessageCode", "message": "Message", "details": "Details"}], "trace": "Trace"}`)
+				}))
+			})
+			It(`Invoke DeleteAccountSettingsAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				deleteAccountSettingsAssignmentOptionsModel := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				deleteAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.DeleteAccountSettingsAssignmentWithContext(ctx, deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.DeleteAccountSettingsAssignmentWithContext(ctx, deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "status_code": "StatusCode", "errors": [{"code": "Code", "message_code": "MessageCode", "message": "Message", "details": "Details"}], "trace": "Trace"}`)
+				}))
+			})
+			It(`Invoke DeleteAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.DeleteAccountSettingsAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				deleteAccountSettingsAssignmentOptionsModel := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				deleteAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke DeleteAccountSettingsAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				deleteAccountSettingsAssignmentOptionsModel := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				deleteAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the DeleteAccountSettingsAssignmentOptions model with no property values
+				deleteAccountSettingsAssignmentOptionsModelNew := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke DeleteAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				deleteAccountSettingsAssignmentOptionsModel := new(iamidentityv1.DeleteAccountSettingsAssignmentOptions)
+				deleteAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.DeleteAccountSettingsAssignment(deleteAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptions *UpdateAccountSettingsAssignmentOptions) - Operation response error`, func() {
+		updateAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				updateAccountSettingsAssignmentOptionsModel := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				updateAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptions *UpdateAccountSettingsAssignmentOptions)`, func() {
+		updateAccountSettingsAssignmentPath := "/v1/account_settings_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				updateAccountSettingsAssignmentOptionsModel := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				updateAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.UpdateAccountSettingsAssignmentWithContext(ctx, updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.UpdateAccountSettingsAssignmentWithContext(ctx, updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				updateAccountSettingsAssignmentOptionsModel := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				updateAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke UpdateAccountSettingsAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				updateAccountSettingsAssignmentOptionsModel := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				updateAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the UpdateAccountSettingsAssignmentOptions model with no property values
+				updateAccountSettingsAssignmentOptionsModelNew := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				updateAccountSettingsAssignmentOptionsModel := new(iamidentityv1.UpdateAccountSettingsAssignmentOptions)
+				updateAccountSettingsAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsAssignment(updateAccountSettingsAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListAccountSettingsTemplates(listAccountSettingsTemplatesOptions *ListAccountSettingsTemplatesOptions) - Operation response error`, func() {
+		listAccountSettingsTemplatesPath := "/v1/account_settings_templates"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsTemplates with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := new(iamidentityv1.ListAccountSettingsTemplatesOptions)
+				listAccountSettingsTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listAccountSettingsTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listAccountSettingsTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListAccountSettingsTemplates(listAccountSettingsTemplatesOptions *ListAccountSettingsTemplatesOptions)`, func() {
+		listAccountSettingsTemplatesPath := "/v1/account_settings_templates"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "account_settings_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsTemplates successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := new(iamidentityv1.ListAccountSettingsTemplatesOptions)
+				listAccountSettingsTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listAccountSettingsTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listAccountSettingsTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListAccountSettingsTemplatesWithContext(ctx, listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListAccountSettingsTemplatesWithContext(ctx, listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listAccountSettingsTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "account_settings_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListAccountSettingsTemplates successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListAccountSettingsTemplates(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := new(iamidentityv1.ListAccountSettingsTemplatesOptions)
+				listAccountSettingsTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listAccountSettingsTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listAccountSettingsTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListAccountSettingsTemplates with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := new(iamidentityv1.ListAccountSettingsTemplatesOptions)
+				listAccountSettingsTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listAccountSettingsTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listAccountSettingsTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListAccountSettingsTemplates successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := new(iamidentityv1.ListAccountSettingsTemplatesOptions)
+				listAccountSettingsTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listAccountSettingsTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listAccountSettingsTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listAccountSettingsTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listAccountSettingsTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listAccountSettingsTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListAccountSettingsTemplates(listAccountSettingsTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsTemplate(createAccountSettingsTemplateOptions *CreateAccountSettingsTemplateOptions) - Operation response error`, func() {
+		createAccountSettingsTemplatePath := "/v1/account_settings_templates"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplate with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateOptions)
+				createAccountSettingsTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsTemplate(createAccountSettingsTemplateOptions *CreateAccountSettingsTemplateOptions)`, func() {
+		createAccountSettingsTemplatePath := "/v1/account_settings_templates"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplate successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateOptions)
+				createAccountSettingsTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateAccountSettingsTemplateWithContext(ctx, createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateAccountSettingsTemplateWithContext(ctx, createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateOptions)
+				createAccountSettingsTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateAccountSettingsTemplate with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateOptions)
+				createAccountSettingsTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateOptions)
+				createAccountSettingsTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplate(createAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptions *GetLatestAccountSettingsTemplateVersionOptions) - Operation response error`, func() {
+		getLatestAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetLatestAccountSettingsTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				getLatestAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptions *GetLatestAccountSettingsTemplateVersionOptions)`, func() {
+		getLatestAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetLatestAccountSettingsTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				getLatestAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersionWithContext(ctx, getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetLatestAccountSettingsTemplateVersionWithContext(ctx, getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetLatestAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				getLatestAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetLatestAccountSettingsTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				getLatestAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetLatestAccountSettingsTemplateVersionOptions model with no property values
+				getLatestAccountSettingsTemplateVersionOptionsModelNew := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetLatestAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				getLatestAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetLatestAccountSettingsTemplateVersionOptions)
+				getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetLatestAccountSettingsTemplateVersion(getLatestAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptions *DeleteAllVersionsOfAccountSettingsTemplateOptions)`, func() {
+		deleteAllVersionsOfAccountSettingsTemplatePath := "/v1/account_settings_templates/testString"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAllVersionsOfAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke DeleteAllVersionsOfAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.DeleteAllVersionsOfAccountSettingsTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the DeleteAllVersionsOfAccountSettingsTemplateOptions model
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.DeleteAllVersionsOfAccountSettingsTemplateOptions)
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.DeleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke DeleteAllVersionsOfAccountSettingsTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAllVersionsOfAccountSettingsTemplateOptions model
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.DeleteAllVersionsOfAccountSettingsTemplateOptions)
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.DeleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the DeleteAllVersionsOfAccountSettingsTemplateOptions model with no property values
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModelNew := new(iamidentityv1.DeleteAllVersionsOfAccountSettingsTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.DeleteAllVersionsOfAccountSettingsTemplate(deleteAllVersionsOfAccountSettingsTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptions *ListVersionsOfAccountSettingsTemplateOptions) - Operation response error`, func() {
+		listVersionsOfAccountSettingsTemplatePath := "/v1/account_settings_templates/testString/versions"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListVersionsOfAccountSettingsTemplate with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				listVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptions *ListVersionsOfAccountSettingsTemplateOptions)`, func() {
+		listVersionsOfAccountSettingsTemplatePath := "/v1/account_settings_templates/testString/versions"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "account_settings_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListVersionsOfAccountSettingsTemplate successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				listVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplateWithContext(ctx, listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListVersionsOfAccountSettingsTemplateWithContext(ctx, listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "account_settings_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListVersionsOfAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				listVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListVersionsOfAccountSettingsTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				listVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the ListVersionsOfAccountSettingsTemplateOptions model with no property values
+				listVersionsOfAccountSettingsTemplateOptionsModelNew := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListVersionsOfAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				listVersionsOfAccountSettingsTemplateOptionsModel := new(iamidentityv1.ListVersionsOfAccountSettingsTemplateOptions)
+				listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListVersionsOfAccountSettingsTemplate(listVersionsOfAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptions *CreateAccountSettingsTemplateVersionOptions) - Operation response error`, func() {
+		createAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				createAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				createAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptions *CreateAccountSettingsTemplateVersionOptions)`, func() {
+		createAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				createAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				createAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersionWithContext(ctx, createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateAccountSettingsTemplateVersionWithContext(ctx, createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				createAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				createAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateAccountSettingsTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				createAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				createAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateAccountSettingsTemplateVersionOptions model with no property values
+				createAccountSettingsTemplateVersionOptionsModelNew := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				createAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.CreateAccountSettingsTemplateVersionOptions)
+				createAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				createAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateAccountSettingsTemplateVersion(createAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptions *GetAccountSettingsTemplateVersionOptions) - Operation response error`, func() {
+		getAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				getAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				getAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptions *GetAccountSettingsTemplateVersionOptions)`, func() {
+		getAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				getAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				getAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetAccountSettingsTemplateVersionWithContext(ctx, getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetAccountSettingsTemplateVersionWithContext(ctx, getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetAccountSettingsTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				getAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				getAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetAccountSettingsTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				getAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				getAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetAccountSettingsTemplateVersionOptions model with no property values
+				getAccountSettingsTemplateVersionOptionsModelNew := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				getAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.GetAccountSettingsTemplateVersionOptions)
+				getAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getAccountSettingsTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetAccountSettingsTemplateVersion(getAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptions *UpdateAccountSettingsTemplateVersionOptions) - Operation response error`, func() {
+		updateAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				updateAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				updateAccountSettingsTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				updateAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptions *UpdateAccountSettingsTemplateVersionOptions)`, func() {
+		updateAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				updateAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				updateAccountSettingsTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				updateAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersionWithContext(ctx, updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.UpdateAccountSettingsTemplateVersionWithContext(ctx, updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "account_settings": {"restrict_create_service_id": "NOT_SET", "restrict_create_platform_apikey": "NOT_SET", "allowed_ip_addresses": "AllowedIPAddresses", "mfa": "NONE", "user_mfa": [{"iam_id": "IamID", "mfa": "NONE"}], "session_expiration_in_seconds": "86400", "session_invalidation_in_seconds": "7200", "max_sessions_per_identity": "MaxSessionsPerIdentity", "system_access_token_expiration_in_seconds": "3600", "system_refresh_token_expiration_in_seconds": "259200"}, "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				updateAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				updateAccountSettingsTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				updateAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke UpdateAccountSettingsTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				updateAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				updateAccountSettingsTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				updateAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the UpdateAccountSettingsTemplateVersionOptions model with no property values
+				updateAccountSettingsTemplateVersionOptionsModelNew := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				updateAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.UpdateAccountSettingsTemplateVersionOptions)
+				updateAccountSettingsTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.AccountSettings = accountSettingsComponentModel
+				updateAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.UpdateAccountSettingsTemplateVersion(updateAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptions *DeleteAccountSettingsTemplateVersionOptions)`, func() {
+		deleteAccountSettingsTemplateVersionPath := "/v1/account_settings_templates/testString/versions/testString"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAccountSettingsTemplateVersionPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke DeleteAccountSettingsTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.DeleteAccountSettingsTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsTemplateVersionOptions model
+				deleteAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.DeleteAccountSettingsTemplateVersionOptions)
+				deleteAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.DeleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke DeleteAccountSettingsTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAccountSettingsTemplateVersionOptions model
+				deleteAccountSettingsTemplateVersionOptionsModel := new(iamidentityv1.DeleteAccountSettingsTemplateVersionOptions)
+				deleteAccountSettingsTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.DeleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the DeleteAccountSettingsTemplateVersionOptions model with no property values
+				deleteAccountSettingsTemplateVersionOptionsModelNew := new(iamidentityv1.DeleteAccountSettingsTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.DeleteAccountSettingsTemplateVersion(deleteAccountSettingsTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CommitAccountSettingsTemplate(commitAccountSettingsTemplateOptions *CommitAccountSettingsTemplateOptions)`, func() {
+		commitAccountSettingsTemplatePath := "/v1/account_settings_templates/testString/versions/testString/commit"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(commitAccountSettingsTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke CommitAccountSettingsTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.CommitAccountSettingsTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the CommitAccountSettingsTemplateOptions model
+				commitAccountSettingsTemplateOptionsModel := new(iamidentityv1.CommitAccountSettingsTemplateOptions)
+				commitAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				commitAccountSettingsTemplateOptionsModel.Version = core.StringPtr("testString")
+				commitAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.CommitAccountSettingsTemplate(commitAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke CommitAccountSettingsTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CommitAccountSettingsTemplateOptions model
+				commitAccountSettingsTemplateOptionsModel := new(iamidentityv1.CommitAccountSettingsTemplateOptions)
+				commitAccountSettingsTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				commitAccountSettingsTemplateOptionsModel.Version = core.StringPtr("testString")
+				commitAccountSettingsTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.CommitAccountSettingsTemplate(commitAccountSettingsTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the CommitAccountSettingsTemplateOptions model with no property values
+				commitAccountSettingsTemplateOptionsModelNew := new(iamidentityv1.CommitAccountSettingsTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.CommitAccountSettingsTemplate(commitAccountSettingsTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`CreateReport(createReportOptions *CreateReportOptions) - Operation response error`, func() {
 		createReportPath := "/v1/activity/accounts/testString/report"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
@@ -8762,6 +12202,3696 @@ var _ = Describe(`IamIdentityV1`, func() {
 			})
 		})
 	})
+	Describe(`ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptions *ListTrustedProfileAssignmentsOptions) - Operation response error`, func() {
+		listTrustedProfileAssignmentsPath := "/v1/profile_assignments/"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listTrustedProfileAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListTrustedProfileAssignments with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := new(iamidentityv1.ListTrustedProfileAssignmentsOptions)
+				listTrustedProfileAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listTrustedProfileAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listTrustedProfileAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listTrustedProfileAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listTrustedProfileAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptions *ListTrustedProfileAssignmentsOptions)`, func() {
+		listTrustedProfileAssignmentsPath := "/v1/profile_assignments/"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listTrustedProfileAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "assignments": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}]}`)
+				}))
+			})
+			It(`Invoke ListTrustedProfileAssignments successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := new(iamidentityv1.ListTrustedProfileAssignmentsOptions)
+				listTrustedProfileAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listTrustedProfileAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listTrustedProfileAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listTrustedProfileAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listTrustedProfileAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListTrustedProfileAssignmentsWithContext(ctx, listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListTrustedProfileAssignmentsWithContext(ctx, listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listTrustedProfileAssignmentsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["template_version"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["target_type"]).To(Equal([]string{"Account"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{fmt.Sprint(int64(20))}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 5, "first": "First", "previous": "Previous", "next": "Next", "assignments": [{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}]}`)
+				}))
+			})
+			It(`Invoke ListTrustedProfileAssignments successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListTrustedProfileAssignments(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := new(iamidentityv1.ListTrustedProfileAssignmentsOptions)
+				listTrustedProfileAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listTrustedProfileAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listTrustedProfileAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listTrustedProfileAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listTrustedProfileAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListTrustedProfileAssignments with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := new(iamidentityv1.ListTrustedProfileAssignmentsOptions)
+				listTrustedProfileAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listTrustedProfileAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listTrustedProfileAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listTrustedProfileAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listTrustedProfileAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListTrustedProfileAssignments successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := new(iamidentityv1.ListTrustedProfileAssignmentsOptions)
+				listTrustedProfileAssignmentsOptionsModel.AccountID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateID = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TemplateVersion = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Target = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.TargetType = core.StringPtr("Account")
+				listTrustedProfileAssignmentsOptionsModel.Limit = core.Int64Ptr(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.Pagetoken = core.StringPtr("testString")
+				listTrustedProfileAssignmentsOptionsModel.Sort = core.StringPtr("created_at")
+				listTrustedProfileAssignmentsOptionsModel.Order = core.StringPtr("asc")
+				listTrustedProfileAssignmentsOptionsModel.IncludeHistory = core.BoolPtr(false)
+				listTrustedProfileAssignmentsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListTrustedProfileAssignments(listTrustedProfileAssignmentsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptions *CreateTrustedProfileAssignmentOptions) - Operation response error`, func() {
+		createTrustedProfileAssignmentPath := "/v1/profile_assignments/"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateTrustedProfileAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsModel := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				createTrustedProfileAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createTrustedProfileAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createTrustedProfileAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptions *CreateTrustedProfileAssignmentOptions)`, func() {
+		createTrustedProfileAssignmentPath := "/v1/profile_assignments/"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke CreateTrustedProfileAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsModel := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				createTrustedProfileAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createTrustedProfileAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createTrustedProfileAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateTrustedProfileAssignmentWithContext(ctx, createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateTrustedProfileAssignmentWithContext(ctx, createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke CreateTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateTrustedProfileAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsModel := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				createTrustedProfileAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createTrustedProfileAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createTrustedProfileAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateTrustedProfileAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsModel := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				createTrustedProfileAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createTrustedProfileAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createTrustedProfileAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateTrustedProfileAssignmentOptions model with no property values
+				createTrustedProfileAssignmentOptionsModelNew := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke CreateTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsModel := new(iamidentityv1.CreateTrustedProfileAssignmentOptions)
+				createTrustedProfileAssignmentOptionsModel.TemplateID = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				createTrustedProfileAssignmentOptionsModel.TargetType = core.StringPtr("Account")
+				createTrustedProfileAssignmentOptionsModel.Target = core.StringPtr("testString")
+				createTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateTrustedProfileAssignment(createTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetTrustedProfileAssignment(getTrustedProfileAssignmentOptions *GetTrustedProfileAssignmentOptions) - Operation response error`, func() {
+		getTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetTrustedProfileAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				getTrustedProfileAssignmentOptionsModel := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				getTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getTrustedProfileAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetTrustedProfileAssignment(getTrustedProfileAssignmentOptions *GetTrustedProfileAssignmentOptions)`, func() {
+		getTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke GetTrustedProfileAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				getTrustedProfileAssignmentOptionsModel := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				getTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getTrustedProfileAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetTrustedProfileAssignmentWithContext(ctx, getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetTrustedProfileAssignmentWithContext(ctx, getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke GetTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetTrustedProfileAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				getTrustedProfileAssignmentOptionsModel := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				getTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getTrustedProfileAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetTrustedProfileAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				getTrustedProfileAssignmentOptionsModel := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				getTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getTrustedProfileAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetTrustedProfileAssignmentOptions model with no property values
+				getTrustedProfileAssignmentOptionsModelNew := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				getTrustedProfileAssignmentOptionsModel := new(iamidentityv1.GetTrustedProfileAssignmentOptions)
+				getTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				getTrustedProfileAssignmentOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetTrustedProfileAssignment(getTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptions *DeleteTrustedProfileAssignmentOptions) - Operation response error`, func() {
+		deleteTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke DeleteTrustedProfileAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				deleteTrustedProfileAssignmentOptionsModel := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				deleteTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptions *DeleteTrustedProfileAssignmentOptions)`, func() {
+		deleteTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "status_code": "StatusCode", "errors": [{"code": "Code", "message_code": "MessageCode", "message": "Message", "details": "Details"}], "trace": "Trace"}`)
+				}))
+			})
+			It(`Invoke DeleteTrustedProfileAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				deleteTrustedProfileAssignmentOptionsModel := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				deleteTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.DeleteTrustedProfileAssignmentWithContext(ctx, deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.DeleteTrustedProfileAssignmentWithContext(ctx, deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(202)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "status_code": "StatusCode", "errors": [{"code": "Code", "message_code": "MessageCode", "message": "Message", "details": "Details"}], "trace": "Trace"}`)
+				}))
+			})
+			It(`Invoke DeleteTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.DeleteTrustedProfileAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				deleteTrustedProfileAssignmentOptionsModel := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				deleteTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke DeleteTrustedProfileAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				deleteTrustedProfileAssignmentOptionsModel := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				deleteTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the DeleteTrustedProfileAssignmentOptions model with no property values
+				deleteTrustedProfileAssignmentOptionsModelNew := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(202)
+				}))
+			})
+			It(`Invoke DeleteTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				deleteTrustedProfileAssignmentOptionsModel := new(iamidentityv1.DeleteTrustedProfileAssignmentOptions)
+				deleteTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				deleteTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.DeleteTrustedProfileAssignment(deleteTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptions *UpdateTrustedProfileAssignmentOptions) - Operation response error`, func() {
+		updateTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateTrustedProfileAssignment with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				updateTrustedProfileAssignmentOptionsModel := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				updateTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptions *UpdateTrustedProfileAssignmentOptions)`, func() {
+		updateTrustedProfileAssignmentPath := "/v1/profile_assignments/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke UpdateTrustedProfileAssignment successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				updateTrustedProfileAssignmentOptionsModel := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				updateTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.UpdateTrustedProfileAssignmentWithContext(ctx, updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.UpdateTrustedProfileAssignmentWithContext(ctx, updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateTrustedProfileAssignmentPath))
+					Expect(req.Method).To(Equal("PATCH"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "id": "ID", "account_id": "AccountID", "template_id": "TemplateID", "template_version": 15, "target_type": "TargetType", "target": "Target", "status": "Status", "resources": [{"target": "Target", "profile": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "account_settings": {"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}, "policy_template_refs": [{"id": "ID", "version": "Version", "resource_created": {"id": "ID"}, "error_message": {"name": "Name", "errorCode": "ErrorCode", "message": "Message", "statusCode": "StatusCode"}, "status": "Status"}]}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "href": "Href", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID", "entity_tag": "EntityTag"}`)
+				}))
+			})
+			It(`Invoke UpdateTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.UpdateTrustedProfileAssignment(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				updateTrustedProfileAssignmentOptionsModel := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				updateTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke UpdateTrustedProfileAssignment with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				updateTrustedProfileAssignmentOptionsModel := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				updateTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the UpdateTrustedProfileAssignmentOptions model with no property values
+				updateTrustedProfileAssignmentOptionsModelNew := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateTrustedProfileAssignment successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				updateTrustedProfileAssignmentOptionsModel := new(iamidentityv1.UpdateTrustedProfileAssignmentOptions)
+				updateTrustedProfileAssignmentOptionsModel.AssignmentID = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.IfMatch = core.StringPtr("testString")
+				updateTrustedProfileAssignmentOptionsModel.TemplateVersion = core.Int64Ptr(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.UpdateTrustedProfileAssignment(updateTrustedProfileAssignmentOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListProfileTemplates(listProfileTemplatesOptions *ListProfileTemplatesOptions) - Operation response error`, func() {
+		listProfileTemplatesPath := "/v1/profile_templates"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listProfileTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListProfileTemplates with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := new(iamidentityv1.ListProfileTemplatesOptions)
+				listProfileTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listProfileTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listProfileTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listProfileTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listProfileTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListProfileTemplates(listProfileTemplatesOptions *ListProfileTemplatesOptions)`, func() {
+		listProfileTemplatesPath := "/v1/profile_templates"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listProfileTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "profile_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListProfileTemplates successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := new(iamidentityv1.ListProfileTemplatesOptions)
+				listProfileTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listProfileTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listProfileTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listProfileTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listProfileTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListProfileTemplatesWithContext(ctx, listProfileTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListProfileTemplatesWithContext(ctx, listProfileTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listProfileTemplatesPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["account_id"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "profile_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListProfileTemplates successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListProfileTemplates(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := new(iamidentityv1.ListProfileTemplatesOptions)
+				listProfileTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listProfileTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listProfileTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listProfileTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listProfileTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListProfileTemplates with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := new(iamidentityv1.ListProfileTemplatesOptions)
+				listProfileTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listProfileTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listProfileTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listProfileTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listProfileTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListProfileTemplates successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := new(iamidentityv1.ListProfileTemplatesOptions)
+				listProfileTemplatesOptionsModel.AccountID = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Limit = core.StringPtr("20")
+				listProfileTemplatesOptionsModel.Pagetoken = core.StringPtr("testString")
+				listProfileTemplatesOptionsModel.Sort = core.StringPtr("created_at")
+				listProfileTemplatesOptionsModel.Order = core.StringPtr("asc")
+				listProfileTemplatesOptionsModel.IncludeHistory = core.StringPtr("false")
+				listProfileTemplatesOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListProfileTemplates(listProfileTemplatesOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateProfileTemplate(createProfileTemplateOptions *CreateProfileTemplateOptions) - Operation response error`, func() {
+		createProfileTemplatePath := "/v1/profile_templates"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplate with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := new(iamidentityv1.CreateProfileTemplateOptions)
+				createProfileTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateProfileTemplate(createProfileTemplateOptions *CreateProfileTemplateOptions)`, func() {
+		createProfileTemplatePath := "/v1/profile_templates"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplate successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := new(iamidentityv1.CreateProfileTemplateOptions)
+				createProfileTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateProfileTemplateWithContext(ctx, createProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateProfileTemplateWithContext(ctx, createProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateProfileTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := new(iamidentityv1.CreateProfileTemplateOptions)
+				createProfileTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateProfileTemplate with error: Operation request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := new(iamidentityv1.CreateProfileTemplateOptions)
+				createProfileTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := new(iamidentityv1.CreateProfileTemplateOptions)
+				createProfileTemplateOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateProfileTemplate(createProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptions *GetLatestProfileTemplateVersionOptions) - Operation response error`, func() {
+		getLatestProfileTemplateVersionPath := "/v1/profile_templates/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetLatestProfileTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				getLatestProfileTemplateVersionOptionsModel := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				getLatestProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptions *GetLatestProfileTemplateVersionOptions)`, func() {
+		getLatestProfileTemplateVersionPath := "/v1/profile_templates/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetLatestProfileTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				getLatestProfileTemplateVersionOptionsModel := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				getLatestProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetLatestProfileTemplateVersionWithContext(ctx, getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetLatestProfileTemplateVersionWithContext(ctx, getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLatestProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetLatestProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetLatestProfileTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				getLatestProfileTemplateVersionOptionsModel := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				getLatestProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetLatestProfileTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				getLatestProfileTemplateVersionOptionsModel := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				getLatestProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetLatestProfileTemplateVersionOptions model with no property values
+				getLatestProfileTemplateVersionOptionsModelNew := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetLatestProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				getLatestProfileTemplateVersionOptionsModel := new(iamidentityv1.GetLatestProfileTemplateVersionOptions)
+				getLatestProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getLatestProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getLatestProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetLatestProfileTemplateVersion(getLatestProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptions *DeleteAllVersionsOfProfileTemplateOptions)`, func() {
+		deleteAllVersionsOfProfileTemplatePath := "/v1/profile_templates/testString"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteAllVersionsOfProfileTemplatePath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke DeleteAllVersionsOfProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.DeleteAllVersionsOfProfileTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the DeleteAllVersionsOfProfileTemplateOptions model
+				deleteAllVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.DeleteAllVersionsOfProfileTemplateOptions)
+				deleteAllVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAllVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.DeleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke DeleteAllVersionsOfProfileTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteAllVersionsOfProfileTemplateOptions model
+				deleteAllVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.DeleteAllVersionsOfProfileTemplateOptions)
+				deleteAllVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteAllVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.DeleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the DeleteAllVersionsOfProfileTemplateOptions model with no property values
+				deleteAllVersionsOfProfileTemplateOptionsModelNew := new(iamidentityv1.DeleteAllVersionsOfProfileTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.DeleteAllVersionsOfProfileTemplate(deleteAllVersionsOfProfileTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptions *ListVersionsOfProfileTemplateOptions) - Operation response error`, func() {
+		listVersionsOfProfileTemplatePath := "/v1/profile_templates/testString/versions"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfProfileTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ListVersionsOfProfileTemplate with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				listVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				listVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfProfileTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfProfileTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfProfileTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptions *ListVersionsOfProfileTemplateOptions)`, func() {
+		listVersionsOfProfileTemplatePath := "/v1/profile_templates/testString/versions"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfProfileTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "profile_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListVersionsOfProfileTemplate successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				listVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				listVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfProfileTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfProfileTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfProfileTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.ListVersionsOfProfileTemplateWithContext(ctx, listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.ListVersionsOfProfileTemplateWithContext(ctx, listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(listVersionsOfProfileTemplatePath))
+					Expect(req.Method).To(Equal("GET"))
+
+					Expect(req.URL.Query()["limit"]).To(Equal([]string{"20"}))
+					Expect(req.URL.Query()["pagetoken"]).To(Equal([]string{"testString"}))
+					Expect(req.URL.Query()["sort"]).To(Equal([]string{"created_at"}))
+					Expect(req.URL.Query()["order"]).To(Equal([]string{"asc"}))
+					Expect(req.URL.Query()["include_history"]).To(Equal([]string{"false"}))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"context": {"transaction_id": "TransactionID", "operation": "Operation", "user_agent": "UserAgent", "url": "URL", "instance_id": "InstanceID", "thread_id": "ThreadID", "host": "Host", "start_time": "StartTime", "end_time": "EndTime", "elapsed_time": "ElapsedTime", "cluster_name": "ClusterName"}, "offset": 6, "limit": 20, "first": "First", "previous": "Previous", "next": "Next", "profile_templates": [{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}]}`)
+				}))
+			})
+			It(`Invoke ListVersionsOfProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.ListVersionsOfProfileTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				listVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				listVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfProfileTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfProfileTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfProfileTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ListVersionsOfProfileTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				listVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				listVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfProfileTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfProfileTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfProfileTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the ListVersionsOfProfileTemplateOptions model with no property values
+				listVersionsOfProfileTemplateOptionsModelNew := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ListVersionsOfProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				listVersionsOfProfileTemplateOptionsModel := new(iamidentityv1.ListVersionsOfProfileTemplateOptions)
+				listVersionsOfProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Limit = core.StringPtr("20")
+				listVersionsOfProfileTemplateOptionsModel.Pagetoken = core.StringPtr("testString")
+				listVersionsOfProfileTemplateOptionsModel.Sort = core.StringPtr("created_at")
+				listVersionsOfProfileTemplateOptionsModel.Order = core.StringPtr("asc")
+				listVersionsOfProfileTemplateOptionsModel.IncludeHistory = core.StringPtr("false")
+				listVersionsOfProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.ListVersionsOfProfileTemplate(listVersionsOfProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateProfileTemplateVersion(createProfileTemplateVersionOptions *CreateProfileTemplateVersionOptions) - Operation response error`, func() {
+		createProfileTemplateVersionPath := "/v1/profile_templates/testString/versions"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				createProfileTemplateVersionOptionsModel := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				createProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CreateProfileTemplateVersion(createProfileTemplateVersionOptions *CreateProfileTemplateVersionOptions)`, func() {
+		createProfileTemplateVersionPath := "/v1/profile_templates/testString/versions"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				createProfileTemplateVersionOptionsModel := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				createProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.CreateProfileTemplateVersionWithContext(ctx, createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.CreateProfileTemplateVersionWithContext(ctx, createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(createProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(201)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke CreateProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.CreateProfileTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				createProfileTemplateVersionOptionsModel := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				createProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke CreateProfileTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				createProfileTemplateVersionOptionsModel := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				createProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the CreateProfileTemplateVersionOptions model with no property values
+				createProfileTemplateVersionOptionsModelNew := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(201)
+				}))
+			})
+			It(`Invoke CreateProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				createProfileTemplateVersionOptionsModel := new(iamidentityv1.CreateProfileTemplateVersionOptions)
+				createProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				createProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				createProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				createProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.CreateProfileTemplateVersion(createProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetProfileTemplateVersion(getProfileTemplateVersionOptions *GetProfileTemplateVersionOptions) - Operation response error`, func() {
+		getProfileTemplateVersionPath := "/v1/profile_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+					// TODO: Add check for include_history query parameter
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetProfileTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				getProfileTemplateVersionOptionsModel := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				getProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetProfileTemplateVersion(getProfileTemplateVersionOptions *GetProfileTemplateVersionOptions)`, func() {
+		getProfileTemplateVersionPath := "/v1/profile_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetProfileTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				getProfileTemplateVersionOptionsModel := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				getProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.GetProfileTemplateVersionWithContext(ctx, getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.GetProfileTemplateVersionWithContext(ctx, getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// TODO: Add check for include_history query parameter
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke GetProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.GetProfileTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				getProfileTemplateVersionOptionsModel := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				getProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetProfileTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				getProfileTemplateVersionOptionsModel := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				getProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the GetProfileTemplateVersionOptions model with no property values
+				getProfileTemplateVersionOptionsModelNew := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				getProfileTemplateVersionOptionsModel := new(iamidentityv1.GetProfileTemplateVersionOptions)
+				getProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				getProfileTemplateVersionOptionsModel.IncludeHistory = core.BoolPtr(false)
+				getProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.GetProfileTemplateVersion(getProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateProfileTemplateVersion(updateProfileTemplateVersionOptions *UpdateProfileTemplateVersionOptions) - Operation response error`, func() {
+		updateProfileTemplateVersionPath := "/v1/profile_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke UpdateProfileTemplateVersion with error: Operation response processing error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				updateProfileTemplateVersionOptionsModel := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				updateProfileTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				updateProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				iamIdentityService.EnableRetries(0, 0)
+				result, response, operationErr = iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateProfileTemplateVersion(updateProfileTemplateVersionOptions *UpdateProfileTemplateVersionOptions)`, func() {
+		updateProfileTemplateVersionPath := "/v1/profile_templates/testString/versions/testString"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke UpdateProfileTemplateVersion successfully with retries`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+				iamIdentityService.EnableRetries(0, 0)
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				updateProfileTemplateVersionOptionsModel := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				updateProfileTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				updateProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := iamIdentityService.UpdateProfileTemplateVersionWithContext(ctx, updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				iamIdentityService.DisableRetries()
+				result, response, operationErr := iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = iamIdentityService.UpdateProfileTemplateVersionWithContext(ctx, updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					Expect(req.Header["If-Match"]).ToNot(BeNil())
+					Expect(req.Header["If-Match"][0]).To(Equal(fmt.Sprintf("%v", "testString")))
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"id": "ID", "version": 7, "account_id": "AccountID", "name": "Name", "description": "Description", "committed": false, "profile": {"name": "Name", "description": "Description", "rules": [{"name": "Name", "type": "Profile-SAML", "realm_name": "RealmName", "expiration": 10, "conditions": [{"claim": "Claim", "operator": "Operator", "value": "Value"}]}], "identities": [{"iam_id": "IamID", "identifier": "Identifier", "type": "user", "accounts": ["Accounts"], "description": "Description"}]}, "policy_template_references": [{"id": "ID", "version": "Version"}], "history": [{"timestamp": "Timestamp", "iam_id": "IamID", "iam_id_account": "IamIDAccount", "action": "Action", "params": ["Params"], "message": "Message"}], "entity_tag": "EntityTag", "crn": "CRN", "created_at": "CreatedAt", "created_by_id": "CreatedByID", "last_modified_at": "LastModifiedAt", "last_modified_by_id": "LastModifiedByID"}`)
+				}))
+			})
+			It(`Invoke UpdateProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := iamIdentityService.UpdateProfileTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				updateProfileTemplateVersionOptionsModel := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				updateProfileTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				updateProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke UpdateProfileTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				updateProfileTemplateVersionOptionsModel := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				updateProfileTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				updateProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the UpdateProfileTemplateVersionOptions model with no property values
+				updateProfileTemplateVersionOptionsModelNew := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke UpdateProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				updateProfileTemplateVersionOptionsModel := new(iamidentityv1.UpdateProfileTemplateVersionOptions)
+				updateProfileTemplateVersionOptionsModel.IfMatch = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.AccountID = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Name = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Description = core.StringPtr("testString")
+				updateProfileTemplateVersionOptionsModel.Profile = templateProfileComponentRequestModel
+				updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences = []iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}
+				updateProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := iamIdentityService.UpdateProfileTemplateVersion(updateProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`DeleteProfileTemplateVersion(deleteProfileTemplateVersionOptions *DeleteProfileTemplateVersionOptions)`, func() {
+		deleteProfileTemplateVersionPath := "/v1/profile_templates/testString/versions/testString"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(deleteProfileTemplateVersionPath))
+					Expect(req.Method).To(Equal("DELETE"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke DeleteProfileTemplateVersion successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.DeleteProfileTemplateVersion(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the DeleteProfileTemplateVersionOptions model
+				deleteProfileTemplateVersionOptionsModel := new(iamidentityv1.DeleteProfileTemplateVersionOptions)
+				deleteProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				deleteProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.DeleteProfileTemplateVersion(deleteProfileTemplateVersionOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke DeleteProfileTemplateVersion with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the DeleteProfileTemplateVersionOptions model
+				deleteProfileTemplateVersionOptionsModel := new(iamidentityv1.DeleteProfileTemplateVersionOptions)
+				deleteProfileTemplateVersionOptionsModel.TemplateID = core.StringPtr("testString")
+				deleteProfileTemplateVersionOptionsModel.Version = core.StringPtr("testString")
+				deleteProfileTemplateVersionOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.DeleteProfileTemplateVersion(deleteProfileTemplateVersionOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the DeleteProfileTemplateVersionOptions model with no property values
+				deleteProfileTemplateVersionOptionsModelNew := new(iamidentityv1.DeleteProfileTemplateVersionOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.DeleteProfileTemplateVersion(deleteProfileTemplateVersionOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`CommitProfileTemplate(commitProfileTemplateOptions *CommitProfileTemplateOptions)`, func() {
+		commitProfileTemplatePath := "/v1/profile_templates/testString/versions/testString/commit"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(commitProfileTemplatePath))
+					Expect(req.Method).To(Equal("POST"))
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke CommitProfileTemplate successfully`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := iamIdentityService.CommitProfileTemplate(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the CommitProfileTemplateOptions model
+				commitProfileTemplateOptionsModel := new(iamidentityv1.CommitProfileTemplateOptions)
+				commitProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				commitProfileTemplateOptionsModel.Version = core.StringPtr("testString")
+				commitProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = iamIdentityService.CommitProfileTemplate(commitProfileTemplateOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke CommitProfileTemplate with error: Operation validation and request error`, func() {
+				iamIdentityService, serviceErr := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(iamIdentityService).ToNot(BeNil())
+
+				// Construct an instance of the CommitProfileTemplateOptions model
+				commitProfileTemplateOptionsModel := new(iamidentityv1.CommitProfileTemplateOptions)
+				commitProfileTemplateOptionsModel.TemplateID = core.StringPtr("testString")
+				commitProfileTemplateOptionsModel.Version = core.StringPtr("testString")
+				commitProfileTemplateOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := iamIdentityService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := iamIdentityService.CommitProfileTemplate(commitProfileTemplateOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the CommitProfileTemplateOptions model with no property values
+				commitProfileTemplateOptionsModelNew := new(iamidentityv1.CommitProfileTemplateOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = iamIdentityService.CommitProfileTemplate(commitProfileTemplateOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`Model constructor tests`, func() {
 		Context(`Using a service client instance`, func() {
 			iamIdentityService, _ := iamidentityv1.NewIamIdentityV1(&iamidentityv1.IamIdentityV1Options{
@@ -8780,6 +15910,148 @@ var _ = Describe(`IamIdentityV1`, func() {
 				_model, err := iamIdentityService.NewAPIKeyInsideCreateServiceIDRequest(name)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewCommitAccountSettingsTemplateOptions successfully`, func() {
+				// Construct an instance of the CommitAccountSettingsTemplateOptions model
+				templateID := "testString"
+				version := "testString"
+				commitAccountSettingsTemplateOptionsModel := iamIdentityService.NewCommitAccountSettingsTemplateOptions(templateID, version)
+				commitAccountSettingsTemplateOptionsModel.SetTemplateID("testString")
+				commitAccountSettingsTemplateOptionsModel.SetVersion("testString")
+				commitAccountSettingsTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(commitAccountSettingsTemplateOptionsModel).ToNot(BeNil())
+				Expect(commitAccountSettingsTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(commitAccountSettingsTemplateOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(commitAccountSettingsTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCommitProfileTemplateOptions successfully`, func() {
+				// Construct an instance of the CommitProfileTemplateOptions model
+				templateID := "testString"
+				version := "testString"
+				commitProfileTemplateOptionsModel := iamIdentityService.NewCommitProfileTemplateOptions(templateID, version)
+				commitProfileTemplateOptionsModel.SetTemplateID("testString")
+				commitProfileTemplateOptionsModel.SetVersion("testString")
+				commitProfileTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(commitProfileTemplateOptionsModel).ToNot(BeNil())
+				Expect(commitProfileTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(commitProfileTemplateOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(commitProfileTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCreateAccountSettingsAssignmentOptions successfully`, func() {
+				// Construct an instance of the CreateAccountSettingsAssignmentOptions model
+				createAccountSettingsAssignmentOptionsTemplateID := "testString"
+				createAccountSettingsAssignmentOptionsTemplateVersion := int64(1)
+				createAccountSettingsAssignmentOptionsTargetType := "Account"
+				createAccountSettingsAssignmentOptionsTarget := "testString"
+				createAccountSettingsAssignmentOptionsModel := iamIdentityService.NewCreateAccountSettingsAssignmentOptions(createAccountSettingsAssignmentOptionsTemplateID, createAccountSettingsAssignmentOptionsTemplateVersion, createAccountSettingsAssignmentOptionsTargetType, createAccountSettingsAssignmentOptionsTarget)
+				createAccountSettingsAssignmentOptionsModel.SetTemplateID("testString")
+				createAccountSettingsAssignmentOptionsModel.SetTemplateVersion(int64(1))
+				createAccountSettingsAssignmentOptionsModel.SetTargetType("Account")
+				createAccountSettingsAssignmentOptionsModel.SetTarget("testString")
+				createAccountSettingsAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createAccountSettingsAssignmentOptionsModel).ToNot(BeNil())
+				Expect(createAccountSettingsAssignmentOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsAssignmentOptionsModel.TemplateVersion).To(Equal(core.Int64Ptr(int64(1))))
+				Expect(createAccountSettingsAssignmentOptionsModel.TargetType).To(Equal(core.StringPtr("Account")))
+				Expect(createAccountSettingsAssignmentOptionsModel.Target).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCreateAccountSettingsTemplateOptions successfully`, func() {
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				Expect(accountSettingsUserMfaModel).ToNot(BeNil())
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+				Expect(accountSettingsUserMfaModel.IamID).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsUserMfaModel.Mfa).To(Equal(core.StringPtr("NONE")))
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				Expect(accountSettingsComponentModel).ToNot(BeNil())
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+				Expect(accountSettingsComponentModel.RestrictCreateServiceID).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.RestrictCreatePlatformApikey).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.AllowedIPAddresses).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.Mfa).To(Equal(core.StringPtr("NONE")))
+				Expect(accountSettingsComponentModel.UserMfa).To(Equal([]iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}))
+				Expect(accountSettingsComponentModel.SessionExpirationInSeconds).To(Equal(core.StringPtr("86400")))
+				Expect(accountSettingsComponentModel.SessionInvalidationInSeconds).To(Equal(core.StringPtr("7200")))
+				Expect(accountSettingsComponentModel.MaxSessionsPerIdentity).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds).To(Equal(core.StringPtr("3600")))
+				Expect(accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds).To(Equal(core.StringPtr("259200")))
+
+				// Construct an instance of the CreateAccountSettingsTemplateOptions model
+				createAccountSettingsTemplateOptionsModel := iamIdentityService.NewCreateAccountSettingsTemplateOptions()
+				createAccountSettingsTemplateOptionsModel.SetAccountID("testString")
+				createAccountSettingsTemplateOptionsModel.SetName("testString")
+				createAccountSettingsTemplateOptionsModel.SetDescription("testString")
+				createAccountSettingsTemplateOptionsModel.SetAccountSettings(accountSettingsComponentModel)
+				createAccountSettingsTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createAccountSettingsTemplateOptionsModel).ToNot(BeNil())
+				Expect(createAccountSettingsTemplateOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateOptionsModel.AccountSettings).To(Equal(accountSettingsComponentModel))
+				Expect(createAccountSettingsTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCreateAccountSettingsTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				Expect(accountSettingsUserMfaModel).ToNot(BeNil())
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+				Expect(accountSettingsUserMfaModel.IamID).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsUserMfaModel.Mfa).To(Equal(core.StringPtr("NONE")))
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				Expect(accountSettingsComponentModel).ToNot(BeNil())
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+				Expect(accountSettingsComponentModel.RestrictCreateServiceID).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.RestrictCreatePlatformApikey).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.AllowedIPAddresses).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.Mfa).To(Equal(core.StringPtr("NONE")))
+				Expect(accountSettingsComponentModel.UserMfa).To(Equal([]iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}))
+				Expect(accountSettingsComponentModel.SessionExpirationInSeconds).To(Equal(core.StringPtr("86400")))
+				Expect(accountSettingsComponentModel.SessionInvalidationInSeconds).To(Equal(core.StringPtr("7200")))
+				Expect(accountSettingsComponentModel.MaxSessionsPerIdentity).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds).To(Equal(core.StringPtr("3600")))
+				Expect(accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds).To(Equal(core.StringPtr("259200")))
+
+				// Construct an instance of the CreateAccountSettingsTemplateVersionOptions model
+				templateID := "testString"
+				createAccountSettingsTemplateVersionOptionsModel := iamIdentityService.NewCreateAccountSettingsTemplateVersionOptions(templateID)
+				createAccountSettingsTemplateVersionOptionsModel.SetTemplateID("testString")
+				createAccountSettingsTemplateVersionOptionsModel.SetAccountID("testString")
+				createAccountSettingsTemplateVersionOptionsModel.SetName("testString")
+				createAccountSettingsTemplateVersionOptionsModel.SetDescription("testString")
+				createAccountSettingsTemplateVersionOptionsModel.SetAccountSettings(accountSettingsComponentModel)
+				createAccountSettingsTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createAccountSettingsTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(createAccountSettingsTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateVersionOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateVersionOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateVersionOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(createAccountSettingsTemplateVersionOptionsModel.AccountSettings).To(Equal(accountSettingsComponentModel))
+				Expect(createAccountSettingsTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewCreateAPIKeyOptions successfully`, func() {
 				// Construct an instance of the CreateAPIKeyOptions model
@@ -8928,6 +16200,155 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(createProfileOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(createProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewCreateProfileTemplateOptions successfully`, func() {
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				Expect(profileClaimRuleConditionsModel).ToNot(BeNil())
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+				Expect(profileClaimRuleConditionsModel.Claim).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				Expect(trustedProfileTemplateClaimRuleModel).ToNot(BeNil())
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+				Expect(trustedProfileTemplateClaimRuleModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Type).To(Equal(core.StringPtr("Profile-SAML")))
+				Expect(trustedProfileTemplateClaimRuleModel.RealmName).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Expiration).To(Equal(core.Int64Ptr(int64(38))))
+				Expect(trustedProfileTemplateClaimRuleModel.Conditions).To(Equal([]iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}))
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				Expect(profileIdentityRequestModel).ToNot(BeNil())
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+				Expect(profileIdentityRequestModel.Identifier).To(Equal(core.StringPtr("testString")))
+				Expect(profileIdentityRequestModel.Type).To(Equal(core.StringPtr("user")))
+				Expect(profileIdentityRequestModel.Accounts).To(Equal([]string{"testString"}))
+				Expect(profileIdentityRequestModel.Description).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				Expect(templateProfileComponentRequestModel).ToNot(BeNil())
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+				Expect(templateProfileComponentRequestModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Rules).To(Equal([]iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}))
+				Expect(templateProfileComponentRequestModel.Identities).To(Equal([]iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}))
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				Expect(policyTemplateReferenceModel).ToNot(BeNil())
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+				Expect(policyTemplateReferenceModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(policyTemplateReferenceModel.Version).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the CreateProfileTemplateOptions model
+				createProfileTemplateOptionsModel := iamIdentityService.NewCreateProfileTemplateOptions()
+				createProfileTemplateOptionsModel.SetAccountID("testString")
+				createProfileTemplateOptionsModel.SetName("testString")
+				createProfileTemplateOptionsModel.SetDescription("testString")
+				createProfileTemplateOptionsModel.SetProfile(templateProfileComponentRequestModel)
+				createProfileTemplateOptionsModel.SetPolicyTemplateReferences([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel})
+				createProfileTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createProfileTemplateOptionsModel).ToNot(BeNil())
+				Expect(createProfileTemplateOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateOptionsModel.Profile).To(Equal(templateProfileComponentRequestModel))
+				Expect(createProfileTemplateOptionsModel.PolicyTemplateReferences).To(Equal([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}))
+				Expect(createProfileTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCreateProfileTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				Expect(profileClaimRuleConditionsModel).ToNot(BeNil())
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+				Expect(profileClaimRuleConditionsModel.Claim).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				Expect(trustedProfileTemplateClaimRuleModel).ToNot(BeNil())
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+				Expect(trustedProfileTemplateClaimRuleModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Type).To(Equal(core.StringPtr("Profile-SAML")))
+				Expect(trustedProfileTemplateClaimRuleModel.RealmName).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Expiration).To(Equal(core.Int64Ptr(int64(38))))
+				Expect(trustedProfileTemplateClaimRuleModel.Conditions).To(Equal([]iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}))
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				Expect(profileIdentityRequestModel).ToNot(BeNil())
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+				Expect(profileIdentityRequestModel.Identifier).To(Equal(core.StringPtr("testString")))
+				Expect(profileIdentityRequestModel.Type).To(Equal(core.StringPtr("user")))
+				Expect(profileIdentityRequestModel.Accounts).To(Equal([]string{"testString"}))
+				Expect(profileIdentityRequestModel.Description).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				Expect(templateProfileComponentRequestModel).ToNot(BeNil())
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+				Expect(templateProfileComponentRequestModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Rules).To(Equal([]iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}))
+				Expect(templateProfileComponentRequestModel.Identities).To(Equal([]iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}))
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				Expect(policyTemplateReferenceModel).ToNot(BeNil())
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+				Expect(policyTemplateReferenceModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(policyTemplateReferenceModel.Version).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the CreateProfileTemplateVersionOptions model
+				templateID := "testString"
+				createProfileTemplateVersionOptionsModel := iamIdentityService.NewCreateProfileTemplateVersionOptions(templateID)
+				createProfileTemplateVersionOptionsModel.SetTemplateID("testString")
+				createProfileTemplateVersionOptionsModel.SetAccountID("testString")
+				createProfileTemplateVersionOptionsModel.SetName("testString")
+				createProfileTemplateVersionOptionsModel.SetDescription("testString")
+				createProfileTemplateVersionOptionsModel.SetProfile(templateProfileComponentRequestModel)
+				createProfileTemplateVersionOptionsModel.SetPolicyTemplateReferences([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel})
+				createProfileTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createProfileTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(createProfileTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateVersionOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateVersionOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateVersionOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(createProfileTemplateVersionOptionsModel.Profile).To(Equal(templateProfileComponentRequestModel))
+				Expect(createProfileTemplateVersionOptionsModel.PolicyTemplateReferences).To(Equal([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}))
+				Expect(createProfileTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewCreateReportOptions successfully`, func() {
 				// Construct an instance of the CreateReportOptions model
 				accountID := "testString"
@@ -8974,6 +16395,68 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(createServiceIDOptionsModel.Apikey).To(Equal(apiKeyInsideCreateServiceIDRequestModel))
 				Expect(createServiceIDOptionsModel.EntityLock).To(Equal(core.StringPtr("false")))
 				Expect(createServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewCreateTrustedProfileAssignmentOptions successfully`, func() {
+				// Construct an instance of the CreateTrustedProfileAssignmentOptions model
+				createTrustedProfileAssignmentOptionsTemplateID := "testString"
+				createTrustedProfileAssignmentOptionsTemplateVersion := int64(1)
+				createTrustedProfileAssignmentOptionsTargetType := "Account"
+				createTrustedProfileAssignmentOptionsTarget := "testString"
+				createTrustedProfileAssignmentOptionsModel := iamIdentityService.NewCreateTrustedProfileAssignmentOptions(createTrustedProfileAssignmentOptionsTemplateID, createTrustedProfileAssignmentOptionsTemplateVersion, createTrustedProfileAssignmentOptionsTargetType, createTrustedProfileAssignmentOptionsTarget)
+				createTrustedProfileAssignmentOptionsModel.SetTemplateID("testString")
+				createTrustedProfileAssignmentOptionsModel.SetTemplateVersion(int64(1))
+				createTrustedProfileAssignmentOptionsModel.SetTargetType("Account")
+				createTrustedProfileAssignmentOptionsModel.SetTarget("testString")
+				createTrustedProfileAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(createTrustedProfileAssignmentOptionsModel).ToNot(BeNil())
+				Expect(createTrustedProfileAssignmentOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(createTrustedProfileAssignmentOptionsModel.TemplateVersion).To(Equal(core.Int64Ptr(int64(1))))
+				Expect(createTrustedProfileAssignmentOptionsModel.TargetType).To(Equal(core.StringPtr("Account")))
+				Expect(createTrustedProfileAssignmentOptionsModel.Target).To(Equal(core.StringPtr("testString")))
+				Expect(createTrustedProfileAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteAccountSettingsAssignmentOptions successfully`, func() {
+				// Construct an instance of the DeleteAccountSettingsAssignmentOptions model
+				assignmentID := "testString"
+				deleteAccountSettingsAssignmentOptionsModel := iamIdentityService.NewDeleteAccountSettingsAssignmentOptions(assignmentID)
+				deleteAccountSettingsAssignmentOptionsModel.SetAssignmentID("testString")
+				deleteAccountSettingsAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteAccountSettingsAssignmentOptionsModel).ToNot(BeNil())
+				Expect(deleteAccountSettingsAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteAccountSettingsAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteAccountSettingsTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the DeleteAccountSettingsTemplateVersionOptions model
+				templateID := "testString"
+				version := "testString"
+				deleteAccountSettingsTemplateVersionOptionsModel := iamIdentityService.NewDeleteAccountSettingsTemplateVersionOptions(templateID, version)
+				deleteAccountSettingsTemplateVersionOptionsModel.SetTemplateID("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.SetVersion("testString")
+				deleteAccountSettingsTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteAccountSettingsTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(deleteAccountSettingsTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteAccountSettingsTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(deleteAccountSettingsTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteAllVersionsOfAccountSettingsTemplateOptions successfully`, func() {
+				// Construct an instance of the DeleteAllVersionsOfAccountSettingsTemplateOptions model
+				templateID := "testString"
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel := iamIdentityService.NewDeleteAllVersionsOfAccountSettingsTemplateOptions(templateID)
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.SetTemplateID("testString")
+				deleteAllVersionsOfAccountSettingsTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteAllVersionsOfAccountSettingsTemplateOptionsModel).ToNot(BeNil())
+				Expect(deleteAllVersionsOfAccountSettingsTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteAllVersionsOfAccountSettingsTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteAllVersionsOfProfileTemplateOptions successfully`, func() {
+				// Construct an instance of the DeleteAllVersionsOfProfileTemplateOptions model
+				templateID := "testString"
+				deleteAllVersionsOfProfileTemplateOptionsModel := iamIdentityService.NewDeleteAllVersionsOfProfileTemplateOptions(templateID)
+				deleteAllVersionsOfProfileTemplateOptionsModel.SetTemplateID("testString")
+				deleteAllVersionsOfProfileTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteAllVersionsOfProfileTemplateOptionsModel).ToNot(BeNil())
+				Expect(deleteAllVersionsOfProfileTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteAllVersionsOfProfileTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewDeleteAPIKeyOptions successfully`, func() {
 				// Construct an instance of the DeleteAPIKeyOptions model
@@ -9037,6 +16520,19 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(deleteProfileOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewDeleteProfileTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the DeleteProfileTemplateVersionOptions model
+				templateID := "testString"
+				version := "testString"
+				deleteProfileTemplateVersionOptionsModel := iamIdentityService.NewDeleteProfileTemplateVersionOptions(templateID, version)
+				deleteProfileTemplateVersionOptionsModel.SetTemplateID("testString")
+				deleteProfileTemplateVersionOptionsModel.SetVersion("testString")
+				deleteProfileTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteProfileTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(deleteProfileTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteProfileTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(deleteProfileTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewDeleteServiceIDOptions successfully`, func() {
 				// Construct an instance of the DeleteServiceIDOptions model
 				id := "testString"
@@ -9046,6 +16542,28 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(deleteServiceIDOptionsModel).ToNot(BeNil())
 				Expect(deleteServiceIDOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(deleteServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewDeleteTrustedProfileAssignmentOptions successfully`, func() {
+				// Construct an instance of the DeleteTrustedProfileAssignmentOptions model
+				assignmentID := "testString"
+				deleteTrustedProfileAssignmentOptionsModel := iamIdentityService.NewDeleteTrustedProfileAssignmentOptions(assignmentID)
+				deleteTrustedProfileAssignmentOptionsModel.SetAssignmentID("testString")
+				deleteTrustedProfileAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(deleteTrustedProfileAssignmentOptionsModel).ToNot(BeNil())
+				Expect(deleteTrustedProfileAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(deleteTrustedProfileAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetAccountSettingsAssignmentOptions successfully`, func() {
+				// Construct an instance of the GetAccountSettingsAssignmentOptions model
+				assignmentID := "testString"
+				getAccountSettingsAssignmentOptionsModel := iamIdentityService.NewGetAccountSettingsAssignmentOptions(assignmentID)
+				getAccountSettingsAssignmentOptionsModel.SetAssignmentID("testString")
+				getAccountSettingsAssignmentOptionsModel.SetIncludeHistory(false)
+				getAccountSettingsAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getAccountSettingsAssignmentOptionsModel).ToNot(BeNil())
+				Expect(getAccountSettingsAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(getAccountSettingsAssignmentOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getAccountSettingsAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetAccountSettingsOptions successfully`, func() {
 				// Construct an instance of the GetAccountSettingsOptions model
@@ -9058,6 +16576,21 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(getAccountSettingsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
 				Expect(getAccountSettingsOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
 				Expect(getAccountSettingsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetAccountSettingsTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the GetAccountSettingsTemplateVersionOptions model
+				templateID := "testString"
+				version := "testString"
+				getAccountSettingsTemplateVersionOptionsModel := iamIdentityService.NewGetAccountSettingsTemplateVersionOptions(templateID, version)
+				getAccountSettingsTemplateVersionOptionsModel.SetTemplateID("testString")
+				getAccountSettingsTemplateVersionOptionsModel.SetVersion("testString")
+				getAccountSettingsTemplateVersionOptionsModel.SetIncludeHistory(false)
+				getAccountSettingsTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getAccountSettingsTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(getAccountSettingsTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(getAccountSettingsTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(getAccountSettingsTemplateVersionOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getAccountSettingsTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetAPIKeyOptions successfully`, func() {
 				// Construct an instance of the GetAPIKeyOptions model
@@ -9096,6 +16629,30 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(getClaimRuleOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(getClaimRuleOptionsModel.RuleID).To(Equal(core.StringPtr("testString")))
 				Expect(getClaimRuleOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetLatestAccountSettingsTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the GetLatestAccountSettingsTemplateVersionOptions model
+				templateID := "testString"
+				getLatestAccountSettingsTemplateVersionOptionsModel := iamIdentityService.NewGetLatestAccountSettingsTemplateVersionOptions(templateID)
+				getLatestAccountSettingsTemplateVersionOptionsModel.SetTemplateID("testString")
+				getLatestAccountSettingsTemplateVersionOptionsModel.SetIncludeHistory(false)
+				getLatestAccountSettingsTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getLatestAccountSettingsTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(getLatestAccountSettingsTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(getLatestAccountSettingsTemplateVersionOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getLatestAccountSettingsTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetLatestProfileTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the GetLatestProfileTemplateVersionOptions model
+				templateID := "testString"
+				getLatestProfileTemplateVersionOptionsModel := iamIdentityService.NewGetLatestProfileTemplateVersionOptions(templateID)
+				getLatestProfileTemplateVersionOptionsModel.SetTemplateID("testString")
+				getLatestProfileTemplateVersionOptionsModel.SetIncludeHistory(false)
+				getLatestProfileTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getLatestProfileTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(getLatestProfileTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(getLatestProfileTemplateVersionOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getLatestProfileTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewGetLinkOptions successfully`, func() {
 				// Construct an instance of the GetLinkOptions model
@@ -9174,6 +16731,21 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(getProfileOptionsModel.IncludeActivity).To(Equal(core.BoolPtr(false)))
 				Expect(getProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewGetProfileTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the GetProfileTemplateVersionOptions model
+				templateID := "testString"
+				version := "testString"
+				getProfileTemplateVersionOptionsModel := iamIdentityService.NewGetProfileTemplateVersionOptions(templateID, version)
+				getProfileTemplateVersionOptionsModel.SetTemplateID("testString")
+				getProfileTemplateVersionOptionsModel.SetVersion("testString")
+				getProfileTemplateVersionOptionsModel.SetIncludeHistory(false)
+				getProfileTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getProfileTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(getProfileTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(getProfileTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(getProfileTemplateVersionOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getProfileTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewGetReportOptions successfully`, func() {
 				// Construct an instance of the GetReportOptions model
 				accountID := "testString"
@@ -9200,6 +16772,64 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(getServiceIDOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
 				Expect(getServiceIDOptionsModel.IncludeActivity).To(Equal(core.BoolPtr(false)))
 				Expect(getServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewGetTrustedProfileAssignmentOptions successfully`, func() {
+				// Construct an instance of the GetTrustedProfileAssignmentOptions model
+				assignmentID := "testString"
+				getTrustedProfileAssignmentOptionsModel := iamIdentityService.NewGetTrustedProfileAssignmentOptions(assignmentID)
+				getTrustedProfileAssignmentOptionsModel.SetAssignmentID("testString")
+				getTrustedProfileAssignmentOptionsModel.SetIncludeHistory(false)
+				getTrustedProfileAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getTrustedProfileAssignmentOptionsModel).ToNot(BeNil())
+				Expect(getTrustedProfileAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(getTrustedProfileAssignmentOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(getTrustedProfileAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewListAccountSettingsAssignmentsOptions successfully`, func() {
+				// Construct an instance of the ListAccountSettingsAssignmentsOptions model
+				listAccountSettingsAssignmentsOptionsModel := iamIdentityService.NewListAccountSettingsAssignmentsOptions()
+				listAccountSettingsAssignmentsOptionsModel.SetAccountID("testString")
+				listAccountSettingsAssignmentsOptionsModel.SetTemplateID("testString")
+				listAccountSettingsAssignmentsOptionsModel.SetTemplateVersion("testString")
+				listAccountSettingsAssignmentsOptionsModel.SetTarget("testString")
+				listAccountSettingsAssignmentsOptionsModel.SetTargetType("Account")
+				listAccountSettingsAssignmentsOptionsModel.SetLimit(int64(20))
+				listAccountSettingsAssignmentsOptionsModel.SetPagetoken("testString")
+				listAccountSettingsAssignmentsOptionsModel.SetSort("created_at")
+				listAccountSettingsAssignmentsOptionsModel.SetOrder("asc")
+				listAccountSettingsAssignmentsOptionsModel.SetIncludeHistory(false)
+				listAccountSettingsAssignmentsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listAccountSettingsAssignmentsOptionsModel).ToNot(BeNil())
+				Expect(listAccountSettingsAssignmentsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.TemplateVersion).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Target).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.TargetType).To(Equal(core.StringPtr("Account")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(20))))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listAccountSettingsAssignmentsOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(listAccountSettingsAssignmentsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewListAccountSettingsTemplatesOptions successfully`, func() {
+				// Construct an instance of the ListAccountSettingsTemplatesOptions model
+				listAccountSettingsTemplatesOptionsModel := iamIdentityService.NewListAccountSettingsTemplatesOptions()
+				listAccountSettingsTemplatesOptionsModel.SetAccountID("testString")
+				listAccountSettingsTemplatesOptionsModel.SetLimit("20")
+				listAccountSettingsTemplatesOptionsModel.SetPagetoken("testString")
+				listAccountSettingsTemplatesOptionsModel.SetSort("created_at")
+				listAccountSettingsTemplatesOptionsModel.SetOrder("asc")
+				listAccountSettingsTemplatesOptionsModel.SetIncludeHistory("false")
+				listAccountSettingsTemplatesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listAccountSettingsTemplatesOptionsModel).ToNot(BeNil())
+				Expect(listAccountSettingsTemplatesOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsTemplatesOptionsModel.Limit).To(Equal(core.StringPtr("20")))
+				Expect(listAccountSettingsTemplatesOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listAccountSettingsTemplatesOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listAccountSettingsTemplatesOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listAccountSettingsTemplatesOptionsModel.IncludeHistory).To(Equal(core.StringPtr("false")))
+				Expect(listAccountSettingsTemplatesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewListAPIKeysOptions successfully`, func() {
 				// Construct an instance of the ListAPIKeysOptions model
@@ -9246,6 +16876,25 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(listLinksOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(listLinksOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewListProfileTemplatesOptions successfully`, func() {
+				// Construct an instance of the ListProfileTemplatesOptions model
+				listProfileTemplatesOptionsModel := iamIdentityService.NewListProfileTemplatesOptions()
+				listProfileTemplatesOptionsModel.SetAccountID("testString")
+				listProfileTemplatesOptionsModel.SetLimit("20")
+				listProfileTemplatesOptionsModel.SetPagetoken("testString")
+				listProfileTemplatesOptionsModel.SetSort("created_at")
+				listProfileTemplatesOptionsModel.SetOrder("asc")
+				listProfileTemplatesOptionsModel.SetIncludeHistory("false")
+				listProfileTemplatesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listProfileTemplatesOptionsModel).ToNot(BeNil())
+				Expect(listProfileTemplatesOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listProfileTemplatesOptionsModel.Limit).To(Equal(core.StringPtr("20")))
+				Expect(listProfileTemplatesOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listProfileTemplatesOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listProfileTemplatesOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listProfileTemplatesOptionsModel.IncludeHistory).To(Equal(core.StringPtr("false")))
+				Expect(listProfileTemplatesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewListProfilesOptions successfully`, func() {
 				// Construct an instance of the ListProfilesOptions model
 				accountID := "testString"
@@ -9289,6 +16938,73 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(listServiceIdsOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
 				Expect(listServiceIdsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewListTrustedProfileAssignmentsOptions successfully`, func() {
+				// Construct an instance of the ListTrustedProfileAssignmentsOptions model
+				listTrustedProfileAssignmentsOptionsModel := iamIdentityService.NewListTrustedProfileAssignmentsOptions()
+				listTrustedProfileAssignmentsOptionsModel.SetAccountID("testString")
+				listTrustedProfileAssignmentsOptionsModel.SetTemplateID("testString")
+				listTrustedProfileAssignmentsOptionsModel.SetTemplateVersion("testString")
+				listTrustedProfileAssignmentsOptionsModel.SetTarget("testString")
+				listTrustedProfileAssignmentsOptionsModel.SetTargetType("Account")
+				listTrustedProfileAssignmentsOptionsModel.SetLimit(int64(20))
+				listTrustedProfileAssignmentsOptionsModel.SetPagetoken("testString")
+				listTrustedProfileAssignmentsOptionsModel.SetSort("created_at")
+				listTrustedProfileAssignmentsOptionsModel.SetOrder("asc")
+				listTrustedProfileAssignmentsOptionsModel.SetIncludeHistory(false)
+				listTrustedProfileAssignmentsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listTrustedProfileAssignmentsOptionsModel).ToNot(BeNil())
+				Expect(listTrustedProfileAssignmentsOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.TemplateVersion).To(Equal(core.StringPtr("testString")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Target).To(Equal(core.StringPtr("testString")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.TargetType).To(Equal(core.StringPtr("Account")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Limit).To(Equal(core.Int64Ptr(int64(20))))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listTrustedProfileAssignmentsOptionsModel.IncludeHistory).To(Equal(core.BoolPtr(false)))
+				Expect(listTrustedProfileAssignmentsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewListVersionsOfAccountSettingsTemplateOptions successfully`, func() {
+				// Construct an instance of the ListVersionsOfAccountSettingsTemplateOptions model
+				templateID := "testString"
+				listVersionsOfAccountSettingsTemplateOptionsModel := iamIdentityService.NewListVersionsOfAccountSettingsTemplateOptions(templateID)
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetTemplateID("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetLimit("20")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetPagetoken("testString")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetSort("created_at")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetOrder("asc")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetIncludeHistory("false")
+				listVersionsOfAccountSettingsTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel).ToNot(BeNil())
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.Limit).To(Equal(core.StringPtr("20")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.IncludeHistory).To(Equal(core.StringPtr("false")))
+				Expect(listVersionsOfAccountSettingsTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewListVersionsOfProfileTemplateOptions successfully`, func() {
+				// Construct an instance of the ListVersionsOfProfileTemplateOptions model
+				templateID := "testString"
+				listVersionsOfProfileTemplateOptionsModel := iamIdentityService.NewListVersionsOfProfileTemplateOptions(templateID)
+				listVersionsOfProfileTemplateOptionsModel.SetTemplateID("testString")
+				listVersionsOfProfileTemplateOptionsModel.SetLimit("20")
+				listVersionsOfProfileTemplateOptionsModel.SetPagetoken("testString")
+				listVersionsOfProfileTemplateOptionsModel.SetSort("created_at")
+				listVersionsOfProfileTemplateOptionsModel.SetOrder("asc")
+				listVersionsOfProfileTemplateOptionsModel.SetIncludeHistory("false")
+				listVersionsOfProfileTemplateOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(listVersionsOfProfileTemplateOptionsModel).ToNot(BeNil())
+				Expect(listVersionsOfProfileTemplateOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.Limit).To(Equal(core.StringPtr("20")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.Pagetoken).To(Equal(core.StringPtr("testString")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.Sort).To(Equal(core.StringPtr("created_at")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.Order).To(Equal(core.StringPtr("asc")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.IncludeHistory).To(Equal(core.StringPtr("false")))
+				Expect(listVersionsOfProfileTemplateOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewLockAPIKeyOptions successfully`, func() {
 				// Construct an instance of the LockAPIKeyOptions model
 				id := "testString"
@@ -9309,6 +17025,13 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(lockServiceIDOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(lockServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewPolicyTemplateReference successfully`, func() {
+				id := "testString"
+				version := "testString"
+				_model, err := iamIdentityService.NewPolicyTemplateReference(id, version)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
 			It(`Invoke NewProfileClaimRuleConditions successfully`, func() {
 				claim := "testString"
 				operator := "testString"
@@ -9317,27 +17040,25 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
-			It(`Invoke NewProfileIdentity successfully`, func() {
+			It(`Invoke NewProfileIdentityRequest successfully`, func() {
 				identifier := "testString"
 				typeVar := "user"
-				_model, err := iamIdentityService.NewProfileIdentity(identifier, typeVar)
+				_model, err := iamIdentityService.NewProfileIdentityRequest(identifier, typeVar)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewSetProfileIdentitiesOptions successfully`, func() {
-				// Construct an instance of the ProfileIdentity model
-				profileIdentityModel := new(iamidentityv1.ProfileIdentity)
-				Expect(profileIdentityModel).ToNot(BeNil())
-				profileIdentityModel.IamID = core.StringPtr("testString")
-				profileIdentityModel.Identifier = core.StringPtr("testString")
-				profileIdentityModel.Type = core.StringPtr("user")
-				profileIdentityModel.Accounts = []string{"testString"}
-				profileIdentityModel.Description = core.StringPtr("testString")
-				Expect(profileIdentityModel.IamID).To(Equal(core.StringPtr("testString")))
-				Expect(profileIdentityModel.Identifier).To(Equal(core.StringPtr("testString")))
-				Expect(profileIdentityModel.Type).To(Equal(core.StringPtr("user")))
-				Expect(profileIdentityModel.Accounts).To(Equal([]string{"testString"}))
-				Expect(profileIdentityModel.Description).To(Equal(core.StringPtr("testString")))
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				Expect(profileIdentityRequestModel).ToNot(BeNil())
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+				Expect(profileIdentityRequestModel.Identifier).To(Equal(core.StringPtr("testString")))
+				Expect(profileIdentityRequestModel.Type).To(Equal(core.StringPtr("user")))
+				Expect(profileIdentityRequestModel.Accounts).To(Equal([]string{"testString"}))
+				Expect(profileIdentityRequestModel.Description).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the SetProfileIdentitiesOptions model
 				profileID := "testString"
@@ -9345,12 +17066,12 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentitiesOptionsModel := iamIdentityService.NewSetProfileIdentitiesOptions(profileID, ifMatch)
 				setProfileIdentitiesOptionsModel.SetProfileID("testString")
 				setProfileIdentitiesOptionsModel.SetIfMatch("testString")
-				setProfileIdentitiesOptionsModel.SetIdentities([]iamidentityv1.ProfileIdentity{*profileIdentityModel})
+				setProfileIdentitiesOptionsModel.SetIdentities([]iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel})
 				setProfileIdentitiesOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(setProfileIdentitiesOptionsModel).ToNot(BeNil())
 				Expect(setProfileIdentitiesOptionsModel.ProfileID).To(Equal(core.StringPtr("testString")))
 				Expect(setProfileIdentitiesOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
-				Expect(setProfileIdentitiesOptionsModel.Identities).To(Equal([]iamidentityv1.ProfileIdentity{*profileIdentityModel}))
+				Expect(setProfileIdentitiesOptionsModel.Identities).To(Equal([]iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}))
 				Expect(setProfileIdentitiesOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewSetProfileIdentityOptions successfully`, func() {
@@ -9364,7 +17085,6 @@ var _ = Describe(`IamIdentityV1`, func() {
 				setProfileIdentityOptionsModel.SetIdentityType("user")
 				setProfileIdentityOptionsModel.SetIdentifier("testString")
 				setProfileIdentityOptionsModel.SetType("user")
-				setProfileIdentityOptionsModel.SetIamID("testString")
 				setProfileIdentityOptionsModel.SetAccounts([]string{"testString"})
 				setProfileIdentityOptionsModel.SetDescription("testString")
 				setProfileIdentityOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -9373,10 +17093,22 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(setProfileIdentityOptionsModel.IdentityType).To(Equal(core.StringPtr("user")))
 				Expect(setProfileIdentityOptionsModel.Identifier).To(Equal(core.StringPtr("testString")))
 				Expect(setProfileIdentityOptionsModel.Type).To(Equal(core.StringPtr("user")))
-				Expect(setProfileIdentityOptionsModel.IamID).To(Equal(core.StringPtr("testString")))
 				Expect(setProfileIdentityOptionsModel.Accounts).To(Equal([]string{"testString"}))
 				Expect(setProfileIdentityOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(setProfileIdentityOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewTemplateProfileComponentRequest successfully`, func() {
+				name := "testString"
+				_model, err := iamIdentityService.NewTemplateProfileComponentRequest(name)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
+			It(`Invoke NewTrustedProfileTemplateClaimRule successfully`, func() {
+				typeVar := "Profile-SAML"
+				conditions := []iamidentityv1.ProfileClaimRuleConditions{}
+				_model, err := iamIdentityService.NewTrustedProfileTemplateClaimRule(typeVar, conditions)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewUnlockAPIKeyOptions successfully`, func() {
 				// Construct an instance of the UnlockAPIKeyOptions model
@@ -9397,6 +17129,22 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(unlockServiceIDOptionsModel).ToNot(BeNil())
 				Expect(unlockServiceIDOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(unlockServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewUpdateAccountSettingsAssignmentOptions successfully`, func() {
+				// Construct an instance of the UpdateAccountSettingsAssignmentOptions model
+				assignmentID := "testString"
+				ifMatch := "testString"
+				updateAccountSettingsAssignmentOptionsTemplateVersion := int64(1)
+				updateAccountSettingsAssignmentOptionsModel := iamIdentityService.NewUpdateAccountSettingsAssignmentOptions(assignmentID, ifMatch, updateAccountSettingsAssignmentOptionsTemplateVersion)
+				updateAccountSettingsAssignmentOptionsModel.SetAssignmentID("testString")
+				updateAccountSettingsAssignmentOptionsModel.SetIfMatch("testString")
+				updateAccountSettingsAssignmentOptionsModel.SetTemplateVersion(int64(1))
+				updateAccountSettingsAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateAccountSettingsAssignmentOptionsModel).ToNot(BeNil())
+				Expect(updateAccountSettingsAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsAssignmentOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsAssignmentOptionsModel.TemplateVersion).To(Equal(core.Int64Ptr(int64(1))))
+				Expect(updateAccountSettingsAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewUpdateAccountSettingsOptions successfully`, func() {
 				// Construct an instance of the AccountSettingsUserMfa model
@@ -9438,6 +17186,62 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(updateAccountSettingsOptionsModel.SystemAccessTokenExpirationInSeconds).To(Equal(core.StringPtr("3600")))
 				Expect(updateAccountSettingsOptionsModel.SystemRefreshTokenExpirationInSeconds).To(Equal(core.StringPtr("259200")))
 				Expect(updateAccountSettingsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewUpdateAccountSettingsTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the AccountSettingsUserMfa model
+				accountSettingsUserMfaModel := new(iamidentityv1.AccountSettingsUserMfa)
+				Expect(accountSettingsUserMfaModel).ToNot(BeNil())
+				accountSettingsUserMfaModel.IamID = core.StringPtr("testString")
+				accountSettingsUserMfaModel.Mfa = core.StringPtr("NONE")
+				Expect(accountSettingsUserMfaModel.IamID).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsUserMfaModel.Mfa).To(Equal(core.StringPtr("NONE")))
+
+				// Construct an instance of the AccountSettingsComponent model
+				accountSettingsComponentModel := new(iamidentityv1.AccountSettingsComponent)
+				Expect(accountSettingsComponentModel).ToNot(BeNil())
+				accountSettingsComponentModel.RestrictCreateServiceID = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.RestrictCreatePlatformApikey = core.StringPtr("NOT_SET")
+				accountSettingsComponentModel.AllowedIPAddresses = core.StringPtr("testString")
+				accountSettingsComponentModel.Mfa = core.StringPtr("NONE")
+				accountSettingsComponentModel.UserMfa = []iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}
+				accountSettingsComponentModel.SessionExpirationInSeconds = core.StringPtr("86400")
+				accountSettingsComponentModel.SessionInvalidationInSeconds = core.StringPtr("7200")
+				accountSettingsComponentModel.MaxSessionsPerIdentity = core.StringPtr("testString")
+				accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds = core.StringPtr("3600")
+				accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds = core.StringPtr("259200")
+				Expect(accountSettingsComponentModel.RestrictCreateServiceID).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.RestrictCreatePlatformApikey).To(Equal(core.StringPtr("NOT_SET")))
+				Expect(accountSettingsComponentModel.AllowedIPAddresses).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.Mfa).To(Equal(core.StringPtr("NONE")))
+				Expect(accountSettingsComponentModel.UserMfa).To(Equal([]iamidentityv1.AccountSettingsUserMfa{*accountSettingsUserMfaModel}))
+				Expect(accountSettingsComponentModel.SessionExpirationInSeconds).To(Equal(core.StringPtr("86400")))
+				Expect(accountSettingsComponentModel.SessionInvalidationInSeconds).To(Equal(core.StringPtr("7200")))
+				Expect(accountSettingsComponentModel.MaxSessionsPerIdentity).To(Equal(core.StringPtr("testString")))
+				Expect(accountSettingsComponentModel.SystemAccessTokenExpirationInSeconds).To(Equal(core.StringPtr("3600")))
+				Expect(accountSettingsComponentModel.SystemRefreshTokenExpirationInSeconds).To(Equal(core.StringPtr("259200")))
+
+				// Construct an instance of the UpdateAccountSettingsTemplateVersionOptions model
+				ifMatch := "testString"
+				templateID := "testString"
+				version := "testString"
+				updateAccountSettingsTemplateVersionOptionsModel := iamIdentityService.NewUpdateAccountSettingsTemplateVersionOptions(ifMatch, templateID, version)
+				updateAccountSettingsTemplateVersionOptionsModel.SetIfMatch("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetTemplateID("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetVersion("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetAccountID("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetName("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetDescription("testString")
+				updateAccountSettingsTemplateVersionOptionsModel.SetAccountSettings(accountSettingsComponentModel)
+				updateAccountSettingsTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateAccountSettingsTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.AccountSettings).To(Equal(accountSettingsComponentModel))
+				Expect(updateAccountSettingsTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewUpdateAPIKeyOptions successfully`, func() {
 				// Construct an instance of the UpdateAPIKeyOptions model
@@ -9541,6 +17345,88 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(updateProfileOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(updateProfileOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewUpdateProfileTemplateVersionOptions successfully`, func() {
+				// Construct an instance of the ProfileClaimRuleConditions model
+				profileClaimRuleConditionsModel := new(iamidentityv1.ProfileClaimRuleConditions)
+				Expect(profileClaimRuleConditionsModel).ToNot(BeNil())
+				profileClaimRuleConditionsModel.Claim = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Operator = core.StringPtr("testString")
+				profileClaimRuleConditionsModel.Value = core.StringPtr("testString")
+				Expect(profileClaimRuleConditionsModel.Claim).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Operator).To(Equal(core.StringPtr("testString")))
+				Expect(profileClaimRuleConditionsModel.Value).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TrustedProfileTemplateClaimRule model
+				trustedProfileTemplateClaimRuleModel := new(iamidentityv1.TrustedProfileTemplateClaimRule)
+				Expect(trustedProfileTemplateClaimRuleModel).ToNot(BeNil())
+				trustedProfileTemplateClaimRuleModel.Name = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Type = core.StringPtr("Profile-SAML")
+				trustedProfileTemplateClaimRuleModel.RealmName = core.StringPtr("testString")
+				trustedProfileTemplateClaimRuleModel.Expiration = core.Int64Ptr(int64(38))
+				trustedProfileTemplateClaimRuleModel.Conditions = []iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}
+				Expect(trustedProfileTemplateClaimRuleModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Type).To(Equal(core.StringPtr("Profile-SAML")))
+				Expect(trustedProfileTemplateClaimRuleModel.RealmName).To(Equal(core.StringPtr("testString")))
+				Expect(trustedProfileTemplateClaimRuleModel.Expiration).To(Equal(core.Int64Ptr(int64(38))))
+				Expect(trustedProfileTemplateClaimRuleModel.Conditions).To(Equal([]iamidentityv1.ProfileClaimRuleConditions{*profileClaimRuleConditionsModel}))
+
+				// Construct an instance of the ProfileIdentityRequest model
+				profileIdentityRequestModel := new(iamidentityv1.ProfileIdentityRequest)
+				Expect(profileIdentityRequestModel).ToNot(BeNil())
+				profileIdentityRequestModel.Identifier = core.StringPtr("testString")
+				profileIdentityRequestModel.Type = core.StringPtr("user")
+				profileIdentityRequestModel.Accounts = []string{"testString"}
+				profileIdentityRequestModel.Description = core.StringPtr("testString")
+				Expect(profileIdentityRequestModel.Identifier).To(Equal(core.StringPtr("testString")))
+				Expect(profileIdentityRequestModel.Type).To(Equal(core.StringPtr("user")))
+				Expect(profileIdentityRequestModel.Accounts).To(Equal([]string{"testString"}))
+				Expect(profileIdentityRequestModel.Description).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the TemplateProfileComponentRequest model
+				templateProfileComponentRequestModel := new(iamidentityv1.TemplateProfileComponentRequest)
+				Expect(templateProfileComponentRequestModel).ToNot(BeNil())
+				templateProfileComponentRequestModel.Name = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Description = core.StringPtr("testString")
+				templateProfileComponentRequestModel.Rules = []iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}
+				templateProfileComponentRequestModel.Identities = []iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}
+				Expect(templateProfileComponentRequestModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(templateProfileComponentRequestModel.Rules).To(Equal([]iamidentityv1.TrustedProfileTemplateClaimRule{*trustedProfileTemplateClaimRuleModel}))
+				Expect(templateProfileComponentRequestModel.Identities).To(Equal([]iamidentityv1.ProfileIdentityRequest{*profileIdentityRequestModel}))
+
+				// Construct an instance of the PolicyTemplateReference model
+				policyTemplateReferenceModel := new(iamidentityv1.PolicyTemplateReference)
+				Expect(policyTemplateReferenceModel).ToNot(BeNil())
+				policyTemplateReferenceModel.ID = core.StringPtr("testString")
+				policyTemplateReferenceModel.Version = core.StringPtr("testString")
+				Expect(policyTemplateReferenceModel.ID).To(Equal(core.StringPtr("testString")))
+				Expect(policyTemplateReferenceModel.Version).To(Equal(core.StringPtr("testString")))
+
+				// Construct an instance of the UpdateProfileTemplateVersionOptions model
+				ifMatch := "testString"
+				templateID := "testString"
+				version := "testString"
+				updateProfileTemplateVersionOptionsModel := iamIdentityService.NewUpdateProfileTemplateVersionOptions(ifMatch, templateID, version)
+				updateProfileTemplateVersionOptionsModel.SetIfMatch("testString")
+				updateProfileTemplateVersionOptionsModel.SetTemplateID("testString")
+				updateProfileTemplateVersionOptionsModel.SetVersion("testString")
+				updateProfileTemplateVersionOptionsModel.SetAccountID("testString")
+				updateProfileTemplateVersionOptionsModel.SetName("testString")
+				updateProfileTemplateVersionOptionsModel.SetDescription("testString")
+				updateProfileTemplateVersionOptionsModel.SetProfile(templateProfileComponentRequestModel)
+				updateProfileTemplateVersionOptionsModel.SetPolicyTemplateReferences([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel})
+				updateProfileTemplateVersionOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateProfileTemplateVersionOptionsModel).ToNot(BeNil())
+				Expect(updateProfileTemplateVersionOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.TemplateID).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.Version).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.AccountID).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.Name).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.Description).To(Equal(core.StringPtr("testString")))
+				Expect(updateProfileTemplateVersionOptionsModel.Profile).To(Equal(templateProfileComponentRequestModel))
+				Expect(updateProfileTemplateVersionOptionsModel.PolicyTemplateReferences).To(Equal([]iamidentityv1.PolicyTemplateReference{*policyTemplateReferenceModel}))
+				Expect(updateProfileTemplateVersionOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewUpdateServiceIDOptions successfully`, func() {
 				// Construct an instance of the UpdateServiceIDOptions model
 				id := "testString"
@@ -9559,6 +17445,22 @@ var _ = Describe(`IamIdentityV1`, func() {
 				Expect(updateServiceIDOptionsModel.Description).To(Equal(core.StringPtr("testString")))
 				Expect(updateServiceIDOptionsModel.UniqueInstanceCrns).To(Equal([]string{"testString"}))
 				Expect(updateServiceIDOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
+			It(`Invoke NewUpdateTrustedProfileAssignmentOptions successfully`, func() {
+				// Construct an instance of the UpdateTrustedProfileAssignmentOptions model
+				assignmentID := "testString"
+				ifMatch := "testString"
+				updateTrustedProfileAssignmentOptionsTemplateVersion := int64(1)
+				updateTrustedProfileAssignmentOptionsModel := iamIdentityService.NewUpdateTrustedProfileAssignmentOptions(assignmentID, ifMatch, updateTrustedProfileAssignmentOptionsTemplateVersion)
+				updateTrustedProfileAssignmentOptionsModel.SetAssignmentID("testString")
+				updateTrustedProfileAssignmentOptionsModel.SetIfMatch("testString")
+				updateTrustedProfileAssignmentOptionsModel.SetTemplateVersion(int64(1))
+				updateTrustedProfileAssignmentOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateTrustedProfileAssignmentOptionsModel).ToNot(BeNil())
+				Expect(updateTrustedProfileAssignmentOptionsModel.AssignmentID).To(Equal(core.StringPtr("testString")))
+				Expect(updateTrustedProfileAssignmentOptionsModel.IfMatch).To(Equal(core.StringPtr("testString")))
+				Expect(updateTrustedProfileAssignmentOptionsModel.TemplateVersion).To(Equal(core.Int64Ptr(int64(1))))
+				Expect(updateTrustedProfileAssignmentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 		})
 	})


### PR DESCRIPTION
## PR summary
Added support for IAM enterprise feature. Enterprise admins can create templates for account settings and trusted profiles and assign them to accounts and account groups in the enterprise.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
SDK adopters will be able to work with IAM enterprise feature.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information
API definition: [Staging](https://test.cloud.ibm.com/apidocs/iam-identity-token-api#list-profile-templates)

Test information:

Integration Tests:
```
Ran 490 of 490 Specs in 814.586 seconds
SUCCESS! -- 490 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/IBM/platform-services-go-sdk/iamidentityv1   817.700s
```

Examples:
```
Ran 473 of 473 Specs in 759.903 seconds
SUCCESS! -- 473 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/IBM/platform-services-go-sdk/iamidentityv1   763.477s
```