### PR TITLE
build: increase timeout for linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-int-cov:
 	${GO} test `${GO} list ./...` -tags=integration ${COVERAGE}
 
 lint:
-	${LINT} run --build-tags=integration,examples
+	${LINT} run --build-tags=integration,examples --timeout 120s
 
 scan-gosec:
 	${GOSEC} ./...


### PR DESCRIPTION
## PR summary
This PR simply adds the `--timeout 120s` option to the linter command in Makefile.


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->