### PR TITLE
fix(IAM Policy Management): Added nest conditions to rule.conditions

### DIFF
--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -277,9 +277,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListPoliciesWithContext(ctx co
 // their support of authorization policies. To create an authorization policy, use **`"type": "authorization"`** in the
 // body. The subject attributes must match the supported authorization subjects of the resource. Multiple subject
 // attributes might be provided. The following attributes are supported:
-//
-//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
-//
+//   serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
 // supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
@@ -397,9 +395,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyWithContext(ctx co
 // To update an authorization policy, use **`"type": "authorization"`** in the body. The subject attributes must match
 // the supported authorization subjects of the resource. Multiple subject attributes might be provided. The following
 // attributes are supported:
-//
-//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
-//
+//   serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
 // supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
@@ -1146,31 +1142,27 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
 // example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
 // ```json
-//
-//	"rule": {
-//	  "operator": "and",
-//	  "conditions": [{
-//	    "key": "{{environment.attributes.day_of_week}}",
-//	    "operator": "dayOfWeekAnyOf",
-//	    "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
-//	  },
-//	    "key": "{{environment.attributes.current_time}}",
-//	    "operator": "timeGreaterThanOrEquals",
-//	    "value": "09:00:00+00:00"
-//	  },
-//	    "key": "{{environment.attributes.current_time}}",
-//	    "operator": "timeLessThanOrEquals",
-//	    "value": "17:00:00+00:00"
-//	  }]
-//	}
-//
+//   "rule": {
+//     "operator": "and",
+//     "conditions": [{
+//       "key": "{{environment.attributes.day_of_week}}",
+//       "operator": "dayOfWeekAnyOf",
+//       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeGreaterThanOrEquals",
+//       "value": "09:00:00+00:00"
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeLessThanOrEquals",
+//       "value": "17:00:00+00:00"
+//     }]
+//   }
 // ``` You can use the following operators in the **`key`** and **`value`** pair:
 // ```
-//
-//	'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-//	'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//	'dayOfWeekEquals', 'dayOfWeekAnyOf',
-//
+//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
 // ```
 //
 // The pattern field that matches the rule is required when rule is provided. For the business hour rule example above,
@@ -1187,9 +1179,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // their support of authorization policies. To create an authorization policy, use **`"type": "authorization"`** in the
 // body. The subject attributes must match the supported authorization subjects of the resource. Multiple subject
 // attributes might be provided. The following attributes are supported:
-//
-//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
-//
+//   serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
 // supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
@@ -1311,31 +1301,27 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 // specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
 // example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
 // ```json
-//
-//	"rule": {
-//	  "operator": "and",
-//	  "conditions": [{
-//	    "key": "{{environment.attributes.day_of_week}}",
-//	    "operator": "dayOfWeekAnyOf",
-//	    "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
-//	  },
-//	    "key": "{{environment.attributes.current_time}}",
-//	    "operator": "timeGreaterThanOrEquals",
-//	    "value": "09:00:00+00:00"
-//	  },
-//	    "key": "{{environment.attributes.current_time}}",
-//	    "operator": "timeLessThanOrEquals",
-//	    "value": "17:00:00+00:00"
-//	  }]
-//	}
-//
+//   "rule": {
+//     "operator": "and",
+//     "conditions": [{
+//       "key": "{{environment.attributes.day_of_week}}",
+//       "operator": "dayOfWeekAnyOf",
+//       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeGreaterThanOrEquals",
+//       "value": "09:00:00+00:00"
+//     },
+//       "key": "{{environment.attributes.current_time}}",
+//       "operator": "timeLessThanOrEquals",
+//       "value": "17:00:00+00:00"
+//     }]
+//   }
 // ``` You can use the following operators in the **`key`**, **`value`** pair:
 // ```
-//
-//	'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-//	'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//	'dayOfWeekEquals', 'dayOfWeekAnyOf',
-//
+//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
 // ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
 // above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
 // operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
@@ -1348,9 +1334,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 // To update an authorization policy, use **`"type": "authorization"`** in the body. The subject attributes must match
 // the supported authorization subjects of the resource. Multiple subject attributes might be provided. The following
 // attributes are supported:
-//
-//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
-//
+//   serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
 // supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
@@ -1986,7 +1970,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) ReplacePolicyTemplateWithConte
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *replacePolicyTemplateOptions.PolicyTemplateID,
-		"version":            *replacePolicyTemplateOptions.Version,
+		"version": *replacePolicyTemplateOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
@@ -2071,7 +2055,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) DeletePolicyTemplateVersionWit
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *deletePolicyTemplateVersionOptions.PolicyTemplateID,
-		"version":            *deletePolicyTemplateVersionOptions.Version,
+		"version": *deletePolicyTemplateVersionOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -2120,7 +2104,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) GetPolicyTemplateVersionWithCo
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *getPolicyTemplateVersionOptions.PolicyTemplateID,
-		"version":            *getPolicyTemplateVersionOptions.Version,
+		"version": *getPolicyTemplateVersionOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2182,7 +2166,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CommitPolicyTemplateWithContex
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *commitPolicyTemplateOptions.PolicyTemplateID,
-		"version":            *commitPolicyTemplateOptions.Version,
+		"version": *commitPolicyTemplateOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
@@ -2376,7 +2360,7 @@ type CommitPolicyTemplateOptions struct {
 func (*IamPolicyManagementV1) NewCommitPolicyTemplateOptions(policyTemplateID string, version string) *CommitPolicyTemplateOptions {
 	return &CommitPolicyTemplateOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version:          core.StringPtr(version),
+		Version: core.StringPtr(version),
 	}
 }
 
@@ -2463,7 +2447,6 @@ type ControlResponse struct {
 	// Permission granted by the policy.
 	Grant *Grant `json:"grant,omitempty"`
 }
-
 func (*ControlResponse) isaControlResponse() bool {
 	return true
 }
@@ -2521,9 +2504,9 @@ type CreatePolicyOptions struct {
 // NewCreatePolicyOptions : Instantiate CreatePolicyOptions
 func (*IamPolicyManagementV1) NewCreatePolicyOptions(typeVar string, subjects []PolicySubject, roles []PolicyRole, resources []PolicyResource) *CreatePolicyOptions {
 	return &CreatePolicyOptions{
-		Type:      core.StringPtr(typeVar),
-		Subjects:  subjects,
-		Roles:     roles,
+		Type: core.StringPtr(typeVar),
+		Subjects: subjects,
+		Roles: roles,
 		Resources: resources,
 	}
 }
@@ -2610,9 +2593,9 @@ type CreatePolicyTemplateOptions struct {
 // NewCreatePolicyTemplateOptions : Instantiate CreatePolicyTemplateOptions
 func (*IamPolicyManagementV1) NewCreatePolicyTemplateOptions(name string, accountID string, policy *TemplatePolicy) *CreatePolicyTemplateOptions {
 	return &CreatePolicyTemplateOptions{
-		Name:      core.StringPtr(name),
+		Name: core.StringPtr(name),
 		AccountID: core.StringPtr(accountID),
-		Policy:    policy,
+		Policy: policy,
 	}
 }
 
@@ -2685,7 +2668,7 @@ type CreatePolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewCreatePolicyTemplateVersionOptions(policyTemplateID string, policy *TemplatePolicy) *CreatePolicyTemplateVersionOptions {
 	return &CreatePolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Policy:           policy,
+		Policy: policy,
 	}
 }
 
@@ -2768,9 +2751,9 @@ type CreateRoleOptions struct {
 func (*IamPolicyManagementV1) NewCreateRoleOptions(displayName string, actions []string, name string, accountID string, serviceName string) *CreateRoleOptions {
 	return &CreateRoleOptions{
 		DisplayName: core.StringPtr(displayName),
-		Actions:     actions,
-		Name:        core.StringPtr(name),
-		AccountID:   core.StringPtr(accountID),
+		Actions: actions,
+		Name: core.StringPtr(name),
+		AccountID: core.StringPtr(accountID),
 		ServiceName: core.StringPtr(serviceName),
 	}
 }
@@ -2868,7 +2851,7 @@ type CreateV2PolicyOptions struct {
 // Constants associated with the CreateV2PolicyOptions.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	CreateV2PolicyOptionsTypeAccessConst        = "access"
+	CreateV2PolicyOptionsTypeAccessConst = "access"
 	CreateV2PolicyOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -2876,7 +2859,7 @@ const (
 func (*IamPolicyManagementV1) NewCreateV2PolicyOptions(control *Control, typeVar string) *CreateV2PolicyOptions {
 	return &CreateV2PolicyOptions{
 		Control: control,
-		Type:    core.StringPtr(typeVar),
+		Type: core.StringPtr(typeVar),
 	}
 }
 
@@ -3109,7 +3092,7 @@ type DeletePolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewDeletePolicyTemplateVersionOptions(policyTemplateID string, version string) *DeletePolicyTemplateVersionOptions {
 	return &DeletePolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version:          core.StringPtr(version),
+		Version: core.StringPtr(version),
 	}
 }
 
@@ -3262,23 +3245,23 @@ type ErrorObject struct {
 // Constants associated with the ErrorObject.Code property.
 // The API error code for the error.
 const (
-	ErrorObjectCodeInsufficentPermissionsConst        = "insufficent_permissions"
-	ErrorObjectCodeInvalidBodyConst                   = "invalid_body"
-	ErrorObjectCodeInvalidTokenConst                  = "invalid_token"
+	ErrorObjectCodeInsufficentPermissionsConst = "insufficent_permissions"
+	ErrorObjectCodeInvalidBodyConst = "invalid_body"
+	ErrorObjectCodeInvalidTokenConst = "invalid_token"
 	ErrorObjectCodeMissingRequiredQueryParameterConst = "missing_required_query_parameter"
-	ErrorObjectCodeNotFoundConst                      = "not_found"
+	ErrorObjectCodeNotFoundConst = "not_found"
 	ErrorObjectCodePolicyAssignmentConflictErrorConst = "policy_assignment_conflict_error"
-	ErrorObjectCodePolicyAssignmentNotFoundConst      = "policy_assignment_not_found"
-	ErrorObjectCodePolicyConflictErrorConst           = "policy_conflict_error"
-	ErrorObjectCodePolicyNotFoundConst                = "policy_not_found"
-	ErrorObjectCodePolicyTemplateConflictErrorConst   = "policy_template_conflict_error"
-	ErrorObjectCodePolicyTemplateNotFoundConst        = "policy_template_not_found"
-	ErrorObjectCodeRequestNotProcessedConst           = "request_not_processed"
-	ErrorObjectCodeRoleConflictErrorConst             = "role_conflict_error"
-	ErrorObjectCodeRoleNotFoundConst                  = "role_not_found"
-	ErrorObjectCodeTooManyRequestsConst               = "too_many_requests"
-	ErrorObjectCodeUnableToProcessConst               = "unable_to_process"
-	ErrorObjectCodeUnsupportedContentTypeConst        = "unsupported_content_type"
+	ErrorObjectCodePolicyAssignmentNotFoundConst = "policy_assignment_not_found"
+	ErrorObjectCodePolicyConflictErrorConst = "policy_conflict_error"
+	ErrorObjectCodePolicyNotFoundConst = "policy_not_found"
+	ErrorObjectCodePolicyTemplateConflictErrorConst = "policy_template_conflict_error"
+	ErrorObjectCodePolicyTemplateNotFoundConst = "policy_template_not_found"
+	ErrorObjectCodeRequestNotProcessedConst = "request_not_processed"
+	ErrorObjectCodeRoleConflictErrorConst = "role_conflict_error"
+	ErrorObjectCodeRoleNotFoundConst = "role_not_found"
+	ErrorObjectCodeTooManyRequestsConst = "too_many_requests"
+	ErrorObjectCodeUnableToProcessConst = "unable_to_process"
+	ErrorObjectCodeUnsupportedContentTypeConst = "unsupported_content_type"
 )
 
 // UnmarshalErrorObject unmarshals an instance of ErrorObject from the specified map of raw messages.
@@ -3435,7 +3418,7 @@ type GetPolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewGetPolicyTemplateVersionOptions(policyTemplateID string, version string) *GetPolicyTemplateVersionOptions {
 	return &GetPolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version:          core.StringPtr(version),
+		Version: core.StringPtr(version),
 	}
 }
 
@@ -3508,7 +3491,7 @@ type GetV2PolicyOptions struct {
 // * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
 // fields.
 const (
-	GetV2PolicyOptionsFormatDisplayConst           = "display"
+	GetV2PolicyOptionsFormatDisplayConst = "display"
 	GetV2PolicyOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -3663,7 +3646,7 @@ type ListPoliciesOptions struct {
 // Constants associated with the ListPoliciesOptions.Type property.
 // Optional type of policy.
 const (
-	ListPoliciesOptionsTypeAccessConst        = "access"
+	ListPoliciesOptionsTypeAccessConst = "access"
 	ListPoliciesOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -3671,21 +3654,21 @@ const (
 // Optional type of service.
 const (
 	ListPoliciesOptionsServiceTypePlatformServiceConst = "platform_service"
-	ListPoliciesOptionsServiceTypeServiceConst         = "service"
+	ListPoliciesOptionsServiceTypeServiceConst = "service"
 )
 
 // Constants associated with the ListPoliciesOptions.Sort property.
 // Optional top level policy field to sort results. Ascending sort is default. Descending sort available by prepending
 // '-' to field. Example '-last_modified_at'.
 const (
-	ListPoliciesOptionsSortCreatedAtConst        = "created_at"
-	ListPoliciesOptionsSortCreatedByIDConst      = "created_by_id"
-	ListPoliciesOptionsSortHrefConst             = "href"
-	ListPoliciesOptionsSortIDConst               = "id"
-	ListPoliciesOptionsSortLastModifiedAtConst   = "last_modified_at"
+	ListPoliciesOptionsSortCreatedAtConst = "created_at"
+	ListPoliciesOptionsSortCreatedByIDConst = "created_by_id"
+	ListPoliciesOptionsSortHrefConst = "href"
+	ListPoliciesOptionsSortIDConst = "id"
+	ListPoliciesOptionsSortLastModifiedAtConst = "last_modified_at"
 	ListPoliciesOptionsSortLastModifiedByIDConst = "last_modified_by_id"
-	ListPoliciesOptionsSortStateConst            = "state"
-	ListPoliciesOptionsSortTypeConst             = "type"
+	ListPoliciesOptionsSortStateConst = "state"
+	ListPoliciesOptionsSortTypeConst = "type"
 )
 
 // Constants associated with the ListPoliciesOptions.Format property.
@@ -3694,7 +3677,7 @@ const (
 // it has done so
 // * `display` - returns the list of all actions included in each of the policy roles.
 const (
-	ListPoliciesOptionsFormatDisplayConst           = "display"
+	ListPoliciesOptionsFormatDisplayConst = "display"
 	ListPoliciesOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -3703,7 +3686,7 @@ const (
 // * `active` - returns active policies
 // * `deleted` - returns non-active policies.
 const (
-	ListPoliciesOptionsStateActiveConst  = "active"
+	ListPoliciesOptionsStateActiveConst = "active"
 	ListPoliciesOptionsStateDeletedConst = "deleted"
 )
 
@@ -4082,7 +4065,7 @@ type ListV2PoliciesOptions struct {
 // Constants associated with the ListV2PoliciesOptions.Type property.
 // Optional type of policy.
 const (
-	ListV2PoliciesOptionsTypeAccessConst        = "access"
+	ListV2PoliciesOptionsTypeAccessConst = "access"
 	ListV2PoliciesOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -4090,7 +4073,7 @@ const (
 // Optional type of service.
 const (
 	ListV2PoliciesOptionsServiceTypePlatformServiceConst = "platform_service"
-	ListV2PoliciesOptionsServiceTypeServiceConst         = "service"
+	ListV2PoliciesOptionsServiceTypeServiceConst = "service"
 )
 
 // Constants associated with the ListV2PoliciesOptions.Format property.
@@ -4100,7 +4083,7 @@ const (
 // * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
 // fields.
 const (
-	ListV2PoliciesOptionsFormatDisplayConst           = "display"
+	ListV2PoliciesOptionsFormatDisplayConst = "display"
 	ListV2PoliciesOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -4109,7 +4092,7 @@ const (
 // * `active` - returns active policies
 // * `deleted` - returns non-active policies.
 const (
-	ListV2PoliciesOptionsStateActiveConst  = "active"
+	ListV2PoliciesOptionsStateActiveConst = "active"
 	ListV2PoliciesOptionsStateDeletedConst = "deleted"
 )
 
@@ -4234,7 +4217,7 @@ type Policy struct {
 // Constants associated with the Policy.State property.
 // The policy state.
 const (
-	PolicyStateActiveConst  = "active"
+	PolicyStateActiveConst = "active"
 	PolicyStateDeletedConst = "deleted"
 )
 
@@ -4350,10 +4333,10 @@ const (
 // Constants associated with the PolicyAssignment.Status property.
 // The policy assignment status.
 const (
-	PolicyAssignmentStatusFailedConst            = "failed"
-	PolicyAssignmentStatusInProgressConst        = "in_progress"
+	PolicyAssignmentStatusFailedConst = "failed"
+	PolicyAssignmentStatusInProgressConst = "in_progress"
 	PolicyAssignmentStatusSucceedWithErrorsConst = "succeed_with_errors"
-	PolicyAssignmentStatusSucceededConst         = "succeeded"
+	PolicyAssignmentStatusSucceededConst = "succeeded"
 )
 
 // UnmarshalPolicyAssignment unmarshals an instance of PolicyAssignment from the specified map of raw messages.
@@ -4445,7 +4428,7 @@ type PolicyAssignmentOptions struct {
 // The policy subject type; either 'iam_id' or 'access_group_id'.
 const (
 	PolicyAssignmentOptionsSubjectTypeAccessGroupIDConst = "access_group_id"
-	PolicyAssignmentOptionsSubjectTypeIamIDConst         = "iam_id"
+	PolicyAssignmentOptionsSubjectTypeIamIDConst = "iam_id"
 )
 
 // UnmarshalPolicyAssignmentOptions unmarshals an instance of PolicyAssignmentOptions from the specified map of raw messages.
@@ -4907,7 +4890,7 @@ type PolicyTemplateMetaData struct {
 // Constants associated with the PolicyTemplateMetaData.State property.
 // The policy state.
 const (
-	PolicyTemplateMetaDataStateActiveConst  = "active"
+	PolicyTemplateMetaDataStateActiveConst = "active"
 	PolicyTemplateMetaDataStateDeletedConst = "deleted"
 )
 
@@ -5018,11 +5001,11 @@ type ReplacePolicyOptions struct {
 // NewReplacePolicyOptions : Instantiate ReplacePolicyOptions
 func (*IamPolicyManagementV1) NewReplacePolicyOptions(policyID string, ifMatch string, typeVar string, subjects []PolicySubject, roles []PolicyRole, resources []PolicyResource) *ReplacePolicyOptions {
 	return &ReplacePolicyOptions{
-		PolicyID:  core.StringPtr(policyID),
-		IfMatch:   core.StringPtr(ifMatch),
-		Type:      core.StringPtr(typeVar),
-		Subjects:  subjects,
-		Roles:     roles,
+		PolicyID: core.StringPtr(policyID),
+		IfMatch: core.StringPtr(ifMatch),
+		Type: core.StringPtr(typeVar),
+		Subjects: subjects,
+		Roles: roles,
 		Resources: resources,
 	}
 }
@@ -5110,9 +5093,9 @@ type ReplacePolicyTemplateOptions struct {
 func (*IamPolicyManagementV1) NewReplacePolicyTemplateOptions(policyTemplateID string, version string, ifMatch string, policy *TemplatePolicy) *ReplacePolicyTemplateOptions {
 	return &ReplacePolicyTemplateOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version:          core.StringPtr(version),
-		IfMatch:          core.StringPtr(ifMatch),
-		Policy:           policy,
+		Version: core.StringPtr(version),
+		IfMatch: core.StringPtr(ifMatch),
+		Policy: policy,
 	}
 }
 
@@ -5190,10 +5173,10 @@ type ReplaceRoleOptions struct {
 // NewReplaceRoleOptions : Instantiate ReplaceRoleOptions
 func (*IamPolicyManagementV1) NewReplaceRoleOptions(roleID string, ifMatch string, displayName string, actions []string) *ReplaceRoleOptions {
 	return &ReplaceRoleOptions{
-		RoleID:      core.StringPtr(roleID),
-		IfMatch:     core.StringPtr(ifMatch),
+		RoleID: core.StringPtr(roleID),
+		IfMatch: core.StringPtr(ifMatch),
 		DisplayName: core.StringPtr(displayName),
-		Actions:     actions,
+		Actions: actions,
 	}
 }
 
@@ -5271,17 +5254,17 @@ type ReplaceV2PolicyOptions struct {
 // Constants associated with the ReplaceV2PolicyOptions.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	ReplaceV2PolicyOptionsTypeAccessConst        = "access"
+	ReplaceV2PolicyOptionsTypeAccessConst = "access"
 	ReplaceV2PolicyOptionsTypeAuthorizationConst = "authorization"
 )
 
 // NewReplaceV2PolicyOptions : Instantiate ReplaceV2PolicyOptions
 func (*IamPolicyManagementV1) NewReplaceV2PolicyOptions(id string, ifMatch string, control *Control, typeVar string) *ReplaceV2PolicyOptions {
 	return &ReplaceV2PolicyOptions{
-		ID:      core.StringPtr(id),
+		ID: core.StringPtr(id),
 		IfMatch: core.StringPtr(ifMatch),
 		Control: control,
-		Type:    core.StringPtr(typeVar),
+		Type: core.StringPtr(typeVar),
 	}
 }
 
@@ -5360,7 +5343,7 @@ type ResourceAttribute struct {
 // NewResourceAttribute : Instantiate ResourceAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewResourceAttribute(name string, value string) (_model *ResourceAttribute, err error) {
 	_model = &ResourceAttribute{
-		Name:  core.StringPtr(name),
+		Name: core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5401,7 +5384,7 @@ type ResourceTag struct {
 // NewResourceTag : Instantiate ResourceTag (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewResourceTag(name string, value string) (_model *ResourceTag, err error) {
 	_model = &ResourceTag{
-		Name:  core.StringPtr(name),
+		Name: core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5448,7 +5431,7 @@ type Role struct {
 func (*IamPolicyManagementV1) NewRole(displayName string, actions []string) (_model *Role, err error) {
 	_model = &Role{
 		DisplayName: core.StringPtr(displayName),
-		Actions:     actions,
+		Actions: actions,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5581,24 +5564,24 @@ type RuleAttribute struct {
 // Constants associated with the RuleAttribute.Operator property.
 // The operator of an attribute.
 const (
-	RuleAttributeOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
+	RuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	RuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	RuleAttributeOperatorDatetimelessthanConst            = "dateTimeLessThan"
-	RuleAttributeOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
-	RuleAttributeOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
-	RuleAttributeOperatorDayofweekequalsConst             = "dayOfWeekEquals"
-	RuleAttributeOperatorTimegreaterthanConst             = "timeGreaterThan"
-	RuleAttributeOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
-	RuleAttributeOperatorTimelessthanConst                = "timeLessThan"
-	RuleAttributeOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
+	RuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
+	RuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
+	RuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
+	RuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	RuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
+	RuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
+	RuleAttributeOperatorTimelessthanConst = "timeLessThan"
+	RuleAttributeOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
 )
 
 // NewRuleAttribute : Instantiate RuleAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewRuleAttribute(key string, operator string, value interface{}) (_model *RuleAttribute, err error) {
 	_model = &RuleAttribute{
-		Key:      core.StringPtr(key),
+		Key: core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value:    value,
+		Value: value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5623,17 +5606,17 @@ func UnmarshalRuleAttribute(m map[string]json.RawMessage, result interface{}) (e
 	return
 }
 
-// RuleAttributeWithConditions : Rule that specifies additional access granted (e.g., time-based condition).
+// RuleAttributeWithConditions : Rule that specifies additional conditions.
 type RuleAttributeWithConditions struct {
 	// The name of an attribute.
-	Key *string `json:"key" validate:"required"`
+	Key *string `json:"key,omitempty"`
 
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
 	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
 	// array of strings (e.g., array of days to permit access) for rule attribute.
-	Value interface{} `json:"value" validate:"required"`
+	Value interface{} `json:"value,omitempty"`
 
 	// List of additional conditions associated with a policy, e.g., time-based conditions that grant access over a certain
 	// time period.
@@ -5643,24 +5626,24 @@ type RuleAttributeWithConditions struct {
 // Constants associated with the RuleAttributeWithConditions.Operator property.
 // The operator of an attribute.
 const (
-	RuleAttributeWithConditionsOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
+	RuleAttributeWithConditionsOperatorAndConst = "and"
+	RuleAttributeWithConditionsOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	RuleAttributeWithConditionsOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	RuleAttributeWithConditionsOperatorDatetimelessthanConst            = "dateTimeLessThan"
-	RuleAttributeWithConditionsOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
-	RuleAttributeWithConditionsOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
-	RuleAttributeWithConditionsOperatorDayofweekequalsConst             = "dayOfWeekEquals"
-	RuleAttributeWithConditionsOperatorTimegreaterthanConst             = "timeGreaterThan"
-	RuleAttributeWithConditionsOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
-	RuleAttributeWithConditionsOperatorTimelessthanConst                = "timeLessThan"
-	RuleAttributeWithConditionsOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
+	RuleAttributeWithConditionsOperatorDatetimelessthanConst = "dateTimeLessThan"
+	RuleAttributeWithConditionsOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
+	RuleAttributeWithConditionsOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
+	RuleAttributeWithConditionsOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	RuleAttributeWithConditionsOperatorOrConst = "or"
+	RuleAttributeWithConditionsOperatorTimegreaterthanConst = "timeGreaterThan"
+	RuleAttributeWithConditionsOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
+	RuleAttributeWithConditionsOperatorTimelessthanConst = "timeLessThan"
+	RuleAttributeWithConditionsOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
 )
 
 // NewRuleAttributeWithConditions : Instantiate RuleAttributeWithConditions (Generic Model Constructor)
-func (*IamPolicyManagementV1) NewRuleAttributeWithConditions(key string, operator string, value interface{}) (_model *RuleAttributeWithConditions, err error) {
+func (*IamPolicyManagementV1) NewRuleAttributeWithConditions(operator string) (_model *RuleAttributeWithConditions, err error) {
 	_model = &RuleAttributeWithConditions{
-		Key:      core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value:    value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5701,7 +5684,7 @@ type SubjectAttribute struct {
 // NewSubjectAttribute : Instantiate SubjectAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewSubjectAttribute(name string, value string) (_model *SubjectAttribute, err error) {
 	_model = &SubjectAttribute{
-		Name:  core.StringPtr(name),
+		Name: core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5819,14 +5802,14 @@ type TemplatePolicy struct {
 // Constants associated with the TemplatePolicy.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	TemplatePolicyTypeAccessConst        = "access"
+	TemplatePolicyTypeAccessConst = "access"
 	TemplatePolicyTypeAuthorizationConst = "authorization"
 )
 
 // NewTemplatePolicy : Instantiate TemplatePolicy (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewTemplatePolicy(typeVar string, control *Control) (_model *TemplatePolicy, err error) {
 	_model = &TemplatePolicy{
-		Type:    core.StringPtr(typeVar),
+		Type: core.StringPtr(typeVar),
 		Control: control,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5883,7 +5866,7 @@ type UpdatePolicyStateOptions struct {
 // Constants associated with the UpdatePolicyStateOptions.State property.
 // The policy state.
 const (
-	UpdatePolicyStateOptionsStateActiveConst  = "active"
+	UpdatePolicyStateOptionsStateActiveConst = "active"
 	UpdatePolicyStateOptionsStateDeletedConst = "deleted"
 )
 
@@ -5891,7 +5874,7 @@ const (
 func (*IamPolicyManagementV1) NewUpdatePolicyStateOptions(policyID string, ifMatch string) *UpdatePolicyStateOptions {
 	return &UpdatePolicyStateOptions{
 		PolicyID: core.StringPtr(policyID),
-		IfMatch:  core.StringPtr(ifMatch),
+		IfMatch: core.StringPtr(ifMatch),
 	}
 }
 
@@ -5974,14 +5957,14 @@ type V2Policy struct {
 // Constants associated with the V2Policy.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	V2PolicyTypeAccessConst        = "access"
+	V2PolicyTypeAccessConst = "access"
 	V2PolicyTypeAuthorizationConst = "authorization"
 )
 
 // Constants associated with the V2Policy.State property.
 // The policy state, either 'deleted' or 'active'.
 const (
-	V2PolicyStateActiveConst  = "active"
+	V2PolicyStateActiveConst = "active"
 	V2PolicyStateDeletedConst = "deleted"
 )
 
@@ -6124,15 +6107,15 @@ type V2PolicyResourceAttribute struct {
 const (
 	V2PolicyResourceAttributeOperatorStringequalsConst = "stringEquals"
 	V2PolicyResourceAttributeOperatorStringexistsConst = "stringExists"
-	V2PolicyResourceAttributeOperatorStringmatchConst  = "stringMatch"
+	V2PolicyResourceAttributeOperatorStringmatchConst = "stringMatch"
 )
 
 // NewV2PolicyResourceAttribute : Instantiate V2PolicyResourceAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyResourceAttribute(key string, operator string, value interface{}) (_model *V2PolicyResourceAttribute, err error) {
 	_model = &V2PolicyResourceAttribute{
-		Key:      core.StringPtr(key),
+		Key: core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value:    value,
+		Value: value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -6173,14 +6156,14 @@ type V2PolicyResourceTag struct {
 // The operator of an access management tag.
 const (
 	V2PolicyResourceTagOperatorStringequalsConst = "stringEquals"
-	V2PolicyResourceTagOperatorStringmatchConst  = "stringMatch"
+	V2PolicyResourceTagOperatorStringmatchConst = "stringMatch"
 )
 
 // NewV2PolicyResourceTag : Instantiate V2PolicyResourceTag (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyResourceTag(key string, value string, operator string) (_model *V2PolicyResourceTag, err error) {
 	_model = &V2PolicyResourceTag{
-		Key:      core.StringPtr(key),
-		Value:    core.StringPtr(value),
+		Key: core.StringPtr(key),
+		Value: core.StringPtr(value),
 		Operator: core.StringPtr(operator),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -6229,18 +6212,17 @@ type V2PolicyRule struct {
 // Constants associated with the V2PolicyRule.Operator property.
 // The operator of an attribute.
 const (
-	V2PolicyRuleOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
+	V2PolicyRuleOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	V2PolicyRuleOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	V2PolicyRuleOperatorDatetimelessthanConst            = "dateTimeLessThan"
-	V2PolicyRuleOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
-	V2PolicyRuleOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
-	V2PolicyRuleOperatorDayofweekequalsConst             = "dayOfWeekEquals"
-	V2PolicyRuleOperatorTimegreaterthanConst             = "timeGreaterThan"
-	V2PolicyRuleOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
-	V2PolicyRuleOperatorTimelessthanConst                = "timeLessThan"
-	V2PolicyRuleOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
+	V2PolicyRuleOperatorDatetimelessthanConst = "dateTimeLessThan"
+	V2PolicyRuleOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
+	V2PolicyRuleOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
+	V2PolicyRuleOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	V2PolicyRuleOperatorTimegreaterthanConst = "timeGreaterThan"
+	V2PolicyRuleOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
+	V2PolicyRuleOperatorTimelessthanConst = "timeLessThan"
+	V2PolicyRuleOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
 )
-
 func (*V2PolicyRule) isaV2PolicyRule() bool {
 	return true
 }
@@ -6319,9 +6301,9 @@ const (
 // NewV2PolicySubjectAttribute : Instantiate V2PolicySubjectAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicySubjectAttribute(key string, operator string, value string) (_model *V2PolicySubjectAttribute, err error) {
 	_model = &V2PolicySubjectAttribute{
-		Key:      core.StringPtr(key),
+		Key: core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value:    core.StringPtr(value),
+		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -6405,14 +6387,14 @@ type V2PolicyTemplateMetaData struct {
 // Constants associated with the V2PolicyTemplateMetaData.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	V2PolicyTemplateMetaDataTypeAccessConst        = "access"
+	V2PolicyTemplateMetaDataTypeAccessConst = "access"
 	V2PolicyTemplateMetaDataTypeAuthorizationConst = "authorization"
 )
 
 // Constants associated with the V2PolicyTemplateMetaData.State property.
 // The policy state, either 'deleted' or 'active'.
 const (
-	V2PolicyTemplateMetaDataStateActiveConst  = "active"
+	V2PolicyTemplateMetaDataStateActiveConst = "active"
 	V2PolicyTemplateMetaDataStateDeletedConst = "deleted"
 )
 
@@ -6552,24 +6534,24 @@ type V2PolicyRuleRuleAttribute struct {
 // Constants associated with the V2PolicyRuleRuleAttribute.Operator property.
 // The operator of an attribute.
 const (
-	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
+	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorDatetimelessthanConst            = "dateTimeLessThan"
-	V2PolicyRuleRuleAttributeOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
-	V2PolicyRuleRuleAttributeOperatorDayofweekequalsConst             = "dayOfWeekEquals"
-	V2PolicyRuleRuleAttributeOperatorTimegreaterthanConst             = "timeGreaterThan"
-	V2PolicyRuleRuleAttributeOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorTimelessthanConst                = "timeLessThan"
-	V2PolicyRuleRuleAttributeOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
+	V2PolicyRuleRuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
+	V2PolicyRuleRuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	V2PolicyRuleRuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
+	V2PolicyRuleRuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorTimelessthanConst = "timeLessThan"
+	V2PolicyRuleRuleAttributeOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
 )
 
 // NewV2PolicyRuleRuleAttribute : Instantiate V2PolicyRuleRuleAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyRuleRuleAttribute(key string, operator string, value interface{}) (_model *V2PolicyRuleRuleAttribute, err error) {
 	_model = &V2PolicyRuleRuleAttribute{
-		Key:      core.StringPtr(key),
+		Key: core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value:    value,
+		Value: value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -6613,13 +6595,13 @@ type V2PolicyRuleRuleWithConditions struct {
 // Operator to evaluate conditions.
 const (
 	V2PolicyRuleRuleWithConditionsOperatorAndConst = "and"
-	V2PolicyRuleRuleWithConditionsOperatorOrConst  = "or"
+	V2PolicyRuleRuleWithConditionsOperatorOrConst = "or"
 )
 
 // NewV2PolicyRuleRuleWithConditions : Instantiate V2PolicyRuleRuleWithConditions (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyRuleRuleWithConditions(operator string, conditions []RuleAttributeWithConditions) (_model *V2PolicyRuleRuleWithConditions, err error) {
 	_model = &V2PolicyRuleRuleWithConditions{
-		Operator:   core.StringPtr(operator),
+		Operator: core.StringPtr(operator),
 		Conditions: conditions,
 	}
 	err = core.ValidateStruct(_model, "required parameters")

--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.78.0-67aec9b7-20230818-174940
+ * IBM OpenAPI SDK Code Generator Version: 3.65.0-79fc0b8f-20230209-215651
  */
 
 // Package iampolicymanagementv1 : Operations and models for the IamPolicyManagementV1 service
@@ -277,12 +277,15 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListPoliciesWithContext(ctx co
 // their support of authorization policies. To create an authorization policy, use **`"type": "authorization"`** in the
 // body. The subject attributes must match the supported authorization subjects of the resource. Multiple subject
 // attributes might be provided. The following attributes are supported:
-//   serviceName, serviceInstance, region, resourceType, resource, accountId Assign roles that are supported by the
-// service or platform roles. For more information, see [IAM roles and
+//
+//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
+//
+// supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
 // To view a service's or the platform's supported attributes, check the [documentation](/docs?tab=all-docs). Both the
-// policy subject and the policy resource must include the **`serviceName`** and **`accountId`** attributes.
+// policy subject and the policy resource must include the **`accountId`** attributes. The policy subject must include
+// either **`serviceName`** or **`resourceGroupId`** (or both) attributes.
 //
 // ### Attribute Operators
 //
@@ -394,12 +397,15 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyWithContext(ctx co
 // To update an authorization policy, use **`"type": "authorization"`** in the body. The subject attributes must match
 // the supported authorization subjects of the resource. Multiple subject attributes might be provided. The following
 // attributes are supported:
-//   serviceName, serviceInstance, region, resourceType, resource, accountId Assign roles that are supported by the
-// service or platform roles. For more information, see [IAM roles and
+//
+//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
+//
+// supported by the service or platform roles. For more information, see [IAM roles and
 // actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
 // greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
 // To view a service's or the platform's supported attributes, check the [documentation](/docs?tab=all-docs). Both the
-// policy subject and the policy resource must include the **`serviceName`** and **`accountId`** attributes.
+// policy subject and the policy resource must include the **`accountId`** attributes. The policy subject must include
+// either **`serviceName`** or **`resourceGroupId`** (or both) attributes.
 //
 // ### Attribute Operators
 //
@@ -1140,27 +1146,31 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
 // example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
 // ```json
-//   "rule": {
-//     "operator": "and",
-//     "conditions": [{
-//       "key": "{{environment.attributes.day_of_week}}",
-//       "operator": "dayOfWeekAnyOf",
-//       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeGreaterThanOrEquals",
-//       "value": "09:00:00+00:00"
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeLessThanOrEquals",
-//       "value": "17:00:00+00:00"
-//     }]
-//   }
+//
+//	"rule": {
+//	  "operator": "and",
+//	  "conditions": [{
+//	    "key": "{{environment.attributes.day_of_week}}",
+//	    "operator": "dayOfWeekAnyOf",
+//	    "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
+//	  },
+//	    "key": "{{environment.attributes.current_time}}",
+//	    "operator": "timeGreaterThanOrEquals",
+//	    "value": "09:00:00+00:00"
+//	  },
+//	    "key": "{{environment.attributes.current_time}}",
+//	    "operator": "timeLessThanOrEquals",
+//	    "value": "17:00:00+00:00"
+//	  }]
+//	}
+//
 // ``` You can use the following operators in the **`key`** and **`value`** pair:
 // ```
-//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//
+//	'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//	'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//	'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//
 // ```
 //
 // The pattern field that matches the rule is required when rule is provided. For the business hour rule example above,
@@ -1170,6 +1180,22 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // [Limiting access with time-based
 // conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui). If the subject is a locked
 // service-id, the request will fail.
+//
+// ### Authorization
+//
+// Authorization policies are supported by services on a case by case basis. Refer to service documentation to verify
+// their support of authorization policies. To create an authorization policy, use **`"type": "authorization"`** in the
+// body. The subject attributes must match the supported authorization subjects of the resource. Multiple subject
+// attributes might be provided. The following attributes are supported:
+//
+//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
+//
+// supported by the service or platform roles. For more information, see [IAM roles and
+// actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
+// greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
+// To view a service's or the platform's supported attributes, check the [documentation](/docs?tab=all-docs). Both the
+// policy subject and the policy resource must include the **`accountId`** attributes. The policy subject must include
+// either **`serviceName`** or **`resourceGroupId`** (or both) attributes.
 //
 // ### Attribute Operators
 //
@@ -1272,7 +1298,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 //
 // ### Access
 //
-// To create an access policy, use **`"type": "access"`** in the body. The supported subject attributes are **`iam_id`**
+// To update an access policy, use **`"type": "access"`** in the body. The supported subject attributes are **`iam_id`**
 // and **`access_group_id`**. Use the **`iam_id`** subject attribute to assign access to a user or service-id. Use the
 // **`access_group_id`** subject attribute to assign access to an access group. Assign roles that are supported by the
 // service or platform roles. For more information, see [IAM roles and
@@ -1285,33 +1311,53 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 // specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
 // example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
 // ```json
-//   "rule": {
-//     "operator": "and",
-//     "conditions": [{
-//       "key": "{{environment.attributes.day_of_week}}",
-//       "operator": "dayOfWeekAnyOf",
-//       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeGreaterThanOrEquals",
-//       "value": "09:00:00+00:00"
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeLessThanOrEquals",
-//       "value": "17:00:00+00:00"
-//     }]
-//   }
+//
+//	"rule": {
+//	  "operator": "and",
+//	  "conditions": [{
+//	    "key": "{{environment.attributes.day_of_week}}",
+//	    "operator": "dayOfWeekAnyOf",
+//	    "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
+//	  },
+//	    "key": "{{environment.attributes.current_time}}",
+//	    "operator": "timeGreaterThanOrEquals",
+//	    "value": "09:00:00+00:00"
+//	  },
+//	    "key": "{{environment.attributes.current_time}}",
+//	    "operator": "timeLessThanOrEquals",
+//	    "value": "17:00:00+00:00"
+//	  }]
+//	}
+//
 // ``` You can use the following operators in the **`key`**, **`value`** pair:
 // ```
-//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//
+//	'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//	'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
+//	'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//
 // ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
 // above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
 // operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
 // and
 // [Limiting access with time-based
 // conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui).
+//
+// ### Authorization
+//
+// To update an authorization policy, use **`"type": "authorization"`** in the body. The subject attributes must match
+// the supported authorization subjects of the resource. Multiple subject attributes might be provided. The following
+// attributes are supported:
+//
+//	serviceName, serviceInstance, region, resourceType, resource, accountId, resourceGroupId Assign roles that are
+//
+// supported by the service or platform roles. For more information, see [IAM roles and
+// actions](/docs/account?topic=account-iam-service-roles-actions). The user must also have the same level of access or
+// greater to the target resource in order to grant the role. Use only the resource attributes supported by the service.
+// To view a service's or the platform's supported attributes, check the [documentation](/docs?tab=all-docs). Both the
+// policy subject and the policy resource must include the **`accountId`** attributes. The policy subject must include
+// either **`serviceName`** or **`resourceGroupId`** (or both) attributes.
+//
 // ### Attribute Operators
 //
 // Currently, only the `stringEquals`, `stringMatch`, and `stringEquals` operators are available. For more information,
@@ -1592,12 +1638,12 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListPolicyTemplatesWithContext
 // CreatePolicyTemplate : Create a policy template
 // Create a policy template. Policy templates define a policy without requiring a subject, and you can use them to grant
 // access to multiple subjects.
-func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplate(createPolicyTemplateOptions *CreatePolicyTemplateOptions) (result *PolicyTemplate, response *core.DetailedResponse, err error) {
+func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplate(createPolicyTemplateOptions *CreatePolicyTemplateOptions) (result *PolicyTemplateLimitData, response *core.DetailedResponse, err error) {
 	return iamPolicyManagement.CreatePolicyTemplateWithContext(context.Background(), createPolicyTemplateOptions)
 }
 
 // CreatePolicyTemplateWithContext is an alternate form of the CreatePolicyTemplate method which supports a Context parameter
-func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateWithContext(ctx context.Context, createPolicyTemplateOptions *CreatePolicyTemplateOptions) (result *PolicyTemplate, response *core.DetailedResponse, err error) {
+func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateWithContext(ctx context.Context, createPolicyTemplateOptions *CreatePolicyTemplateOptions) (result *PolicyTemplateLimitData, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(createPolicyTemplateOptions, "createPolicyTemplateOptions cannot be nil")
 	if err != nil {
 		return
@@ -1661,7 +1707,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateWithContex
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPolicyTemplate)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPolicyTemplateLimitData)
 		if err != nil {
 			return
 		}
@@ -1784,12 +1830,12 @@ func (iamPolicyManagement *IamPolicyManagementV1) DeletePolicyTemplateWithContex
 // CreatePolicyTemplateVersion : Create a new policy template version
 // Create a new version of a policy template. Use this if you need to make updates to a policy template that is
 // committed.
-func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateVersion(createPolicyTemplateVersionOptions *CreatePolicyTemplateVersionOptions) (result *PolicyTemplate, response *core.DetailedResponse, err error) {
+func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateVersion(createPolicyTemplateVersionOptions *CreatePolicyTemplateVersionOptions) (result *PolicyTemplateLimitData, response *core.DetailedResponse, err error) {
 	return iamPolicyManagement.CreatePolicyTemplateVersionWithContext(context.Background(), createPolicyTemplateVersionOptions)
 }
 
 // CreatePolicyTemplateVersionWithContext is an alternate form of the CreatePolicyTemplateVersion method which supports a Context parameter
-func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateVersionWithContext(ctx context.Context, createPolicyTemplateVersionOptions *CreatePolicyTemplateVersionOptions) (result *PolicyTemplate, response *core.DetailedResponse, err error) {
+func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateVersionWithContext(ctx context.Context, createPolicyTemplateVersionOptions *CreatePolicyTemplateVersionOptions) (result *PolicyTemplateLimitData, response *core.DetailedResponse, err error) {
 	err = core.ValidateNotNil(createPolicyTemplateVersionOptions, "createPolicyTemplateVersionOptions cannot be nil")
 	if err != nil {
 		return
@@ -1851,7 +1897,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyTemplateVersionWit
 		return
 	}
 	if rawResponse != nil {
-		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPolicyTemplate)
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalPolicyTemplateLimitData)
 		if err != nil {
 			return
 		}
@@ -1940,7 +1986,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) ReplacePolicyTemplateWithConte
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *replacePolicyTemplateOptions.PolicyTemplateID,
-		"version": *replacePolicyTemplateOptions.Version,
+		"version":            *replacePolicyTemplateOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.PUT)
@@ -2025,7 +2071,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) DeletePolicyTemplateVersionWit
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *deletePolicyTemplateVersionOptions.PolicyTemplateID,
-		"version": *deletePolicyTemplateVersionOptions.Version,
+		"version":            *deletePolicyTemplateVersionOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.DELETE)
@@ -2074,7 +2120,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) GetPolicyTemplateVersionWithCo
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *getPolicyTemplateVersionOptions.PolicyTemplateID,
-		"version": *getPolicyTemplateVersionOptions.Version,
+		"version":            *getPolicyTemplateVersionOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.GET)
@@ -2136,7 +2182,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CommitPolicyTemplateWithContex
 
 	pathParamsMap := map[string]string{
 		"policy_template_id": *commitPolicyTemplateOptions.PolicyTemplateID,
-		"version": *commitPolicyTemplateOptions.Version,
+		"version":            *commitPolicyTemplateOptions.Version,
 	}
 
 	builder := core.NewRequestBuilder(core.POST)
@@ -2330,7 +2376,7 @@ type CommitPolicyTemplateOptions struct {
 func (*IamPolicyManagementV1) NewCommitPolicyTemplateOptions(policyTemplateID string, version string) *CommitPolicyTemplateOptions {
 	return &CommitPolicyTemplateOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version: core.StringPtr(version),
+		Version:          core.StringPtr(version),
 	}
 }
 
@@ -2417,6 +2463,7 @@ type ControlResponse struct {
 	// Permission granted by the policy.
 	Grant *Grant `json:"grant,omitempty"`
 }
+
 func (*ControlResponse) isaControlResponse() bool {
 	return true
 }
@@ -2474,9 +2521,9 @@ type CreatePolicyOptions struct {
 // NewCreatePolicyOptions : Instantiate CreatePolicyOptions
 func (*IamPolicyManagementV1) NewCreatePolicyOptions(typeVar string, subjects []PolicySubject, roles []PolicyRole, resources []PolicyResource) *CreatePolicyOptions {
 	return &CreatePolicyOptions{
-		Type: core.StringPtr(typeVar),
-		Subjects: subjects,
-		Roles: roles,
+		Type:      core.StringPtr(typeVar),
+		Subjects:  subjects,
+		Roles:     roles,
 		Resources: resources,
 	}
 }
@@ -2563,9 +2610,9 @@ type CreatePolicyTemplateOptions struct {
 // NewCreatePolicyTemplateOptions : Instantiate CreatePolicyTemplateOptions
 func (*IamPolicyManagementV1) NewCreatePolicyTemplateOptions(name string, accountID string, policy *TemplatePolicy) *CreatePolicyTemplateOptions {
 	return &CreatePolicyTemplateOptions{
-		Name: core.StringPtr(name),
+		Name:      core.StringPtr(name),
 		AccountID: core.StringPtr(accountID),
-		Policy: policy,
+		Policy:    policy,
 	}
 }
 
@@ -2638,7 +2685,7 @@ type CreatePolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewCreatePolicyTemplateVersionOptions(policyTemplateID string, policy *TemplatePolicy) *CreatePolicyTemplateVersionOptions {
 	return &CreatePolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Policy: policy,
+		Policy:           policy,
 	}
 }
 
@@ -2721,9 +2768,9 @@ type CreateRoleOptions struct {
 func (*IamPolicyManagementV1) NewCreateRoleOptions(displayName string, actions []string, name string, accountID string, serviceName string) *CreateRoleOptions {
 	return &CreateRoleOptions{
 		DisplayName: core.StringPtr(displayName),
-		Actions: actions,
-		Name: core.StringPtr(name),
-		AccountID: core.StringPtr(accountID),
+		Actions:     actions,
+		Name:        core.StringPtr(name),
+		AccountID:   core.StringPtr(accountID),
 		ServiceName: core.StringPtr(serviceName),
 	}
 }
@@ -2821,7 +2868,7 @@ type CreateV2PolicyOptions struct {
 // Constants associated with the CreateV2PolicyOptions.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	CreateV2PolicyOptionsTypeAccessConst = "access"
+	CreateV2PolicyOptionsTypeAccessConst        = "access"
 	CreateV2PolicyOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -2829,7 +2876,7 @@ const (
 func (*IamPolicyManagementV1) NewCreateV2PolicyOptions(control *Control, typeVar string) *CreateV2PolicyOptions {
 	return &CreateV2PolicyOptions{
 		Control: control,
-		Type: core.StringPtr(typeVar),
+		Type:    core.StringPtr(typeVar),
 	}
 }
 
@@ -3062,7 +3109,7 @@ type DeletePolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewDeletePolicyTemplateVersionOptions(policyTemplateID string, version string) *DeletePolicyTemplateVersionOptions {
 	return &DeletePolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version: core.StringPtr(version),
+		Version:          core.StringPtr(version),
 	}
 }
 
@@ -3215,23 +3262,23 @@ type ErrorObject struct {
 // Constants associated with the ErrorObject.Code property.
 // The API error code for the error.
 const (
-	ErrorObjectCodeInsufficentPermissionsConst = "insufficent_permissions"
-	ErrorObjectCodeInvalidBodyConst = "invalid_body"
-	ErrorObjectCodeInvalidTokenConst = "invalid_token"
+	ErrorObjectCodeInsufficentPermissionsConst        = "insufficent_permissions"
+	ErrorObjectCodeInvalidBodyConst                   = "invalid_body"
+	ErrorObjectCodeInvalidTokenConst                  = "invalid_token"
 	ErrorObjectCodeMissingRequiredQueryParameterConst = "missing_required_query_parameter"
-	ErrorObjectCodeNotFoundConst = "not_found"
+	ErrorObjectCodeNotFoundConst                      = "not_found"
 	ErrorObjectCodePolicyAssignmentConflictErrorConst = "policy_assignment_conflict_error"
-	ErrorObjectCodePolicyAssignmentNotFoundConst = "policy_assignment_not_found"
-	ErrorObjectCodePolicyConflictErrorConst = "policy_conflict_error"
-	ErrorObjectCodePolicyNotFoundConst = "policy_not_found"
-	ErrorObjectCodePolicyTemplateConflictErrorConst = "policy_template_conflict_error"
-	ErrorObjectCodePolicyTemplateNotFoundConst = "policy_template_not_found"
-	ErrorObjectCodeRequestNotProcessedConst = "request_not_processed"
-	ErrorObjectCodeRoleConflictErrorConst = "role_conflict_error"
-	ErrorObjectCodeRoleNotFoundConst = "role_not_found"
-	ErrorObjectCodeTooManyRequestsConst = "too_many_requests"
-	ErrorObjectCodeUnableToProcessConst = "unable_to_process"
-	ErrorObjectCodeUnsupportedContentTypeConst = "unsupported_content_type"
+	ErrorObjectCodePolicyAssignmentNotFoundConst      = "policy_assignment_not_found"
+	ErrorObjectCodePolicyConflictErrorConst           = "policy_conflict_error"
+	ErrorObjectCodePolicyNotFoundConst                = "policy_not_found"
+	ErrorObjectCodePolicyTemplateConflictErrorConst   = "policy_template_conflict_error"
+	ErrorObjectCodePolicyTemplateNotFoundConst        = "policy_template_not_found"
+	ErrorObjectCodeRequestNotProcessedConst           = "request_not_processed"
+	ErrorObjectCodeRoleConflictErrorConst             = "role_conflict_error"
+	ErrorObjectCodeRoleNotFoundConst                  = "role_not_found"
+	ErrorObjectCodeTooManyRequestsConst               = "too_many_requests"
+	ErrorObjectCodeUnableToProcessConst               = "unable_to_process"
+	ErrorObjectCodeUnsupportedContentTypeConst        = "unsupported_content_type"
 )
 
 // UnmarshalErrorObject unmarshals an instance of ErrorObject from the specified map of raw messages.
@@ -3388,7 +3435,7 @@ type GetPolicyTemplateVersionOptions struct {
 func (*IamPolicyManagementV1) NewGetPolicyTemplateVersionOptions(policyTemplateID string, version string) *GetPolicyTemplateVersionOptions {
 	return &GetPolicyTemplateVersionOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version: core.StringPtr(version),
+		Version:          core.StringPtr(version),
 	}
 }
 
@@ -3461,7 +3508,7 @@ type GetV2PolicyOptions struct {
 // * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
 // fields.
 const (
-	GetV2PolicyOptionsFormatDisplayConst = "display"
+	GetV2PolicyOptionsFormatDisplayConst           = "display"
 	GetV2PolicyOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -3533,6 +3580,30 @@ func UnmarshalGrantWithEnrichedRoles(m map[string]json.RawMessage, result interf
 	return
 }
 
+// LimitData : policy template current and limit details with in an account.
+type LimitData struct {
+	// policy template current count.
+	Current *int64 `json:"current,omitempty"`
+
+	// policy template limit count.
+	Limit *int64 `json:"limit,omitempty"`
+}
+
+// UnmarshalLimitData unmarshals an instance of LimitData from the specified map of raw messages.
+func UnmarshalLimitData(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LimitData)
+	err = core.UnmarshalPrimitive(m, "current", &obj.Current)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "limit", &obj.Limit)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // ListPoliciesOptions : The ListPolicies options.
 type ListPoliciesOptions struct {
 	// The account GUID that the policies belong to.
@@ -3592,7 +3663,7 @@ type ListPoliciesOptions struct {
 // Constants associated with the ListPoliciesOptions.Type property.
 // Optional type of policy.
 const (
-	ListPoliciesOptionsTypeAccessConst = "access"
+	ListPoliciesOptionsTypeAccessConst        = "access"
 	ListPoliciesOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -3600,21 +3671,21 @@ const (
 // Optional type of service.
 const (
 	ListPoliciesOptionsServiceTypePlatformServiceConst = "platform_service"
-	ListPoliciesOptionsServiceTypeServiceConst = "service"
+	ListPoliciesOptionsServiceTypeServiceConst         = "service"
 )
 
 // Constants associated with the ListPoliciesOptions.Sort property.
 // Optional top level policy field to sort results. Ascending sort is default. Descending sort available by prepending
 // '-' to field. Example '-last_modified_at'.
 const (
-	ListPoliciesOptionsSortCreatedAtConst = "created_at"
-	ListPoliciesOptionsSortCreatedByIDConst = "created_by_id"
-	ListPoliciesOptionsSortHrefConst = "href"
-	ListPoliciesOptionsSortIDConst = "id"
-	ListPoliciesOptionsSortLastModifiedAtConst = "last_modified_at"
+	ListPoliciesOptionsSortCreatedAtConst        = "created_at"
+	ListPoliciesOptionsSortCreatedByIDConst      = "created_by_id"
+	ListPoliciesOptionsSortHrefConst             = "href"
+	ListPoliciesOptionsSortIDConst               = "id"
+	ListPoliciesOptionsSortLastModifiedAtConst   = "last_modified_at"
 	ListPoliciesOptionsSortLastModifiedByIDConst = "last_modified_by_id"
-	ListPoliciesOptionsSortStateConst = "state"
-	ListPoliciesOptionsSortTypeConst = "type"
+	ListPoliciesOptionsSortStateConst            = "state"
+	ListPoliciesOptionsSortTypeConst             = "type"
 )
 
 // Constants associated with the ListPoliciesOptions.Format property.
@@ -3623,7 +3694,7 @@ const (
 // it has done so
 // * `display` - returns the list of all actions included in each of the policy roles.
 const (
-	ListPoliciesOptionsFormatDisplayConst = "display"
+	ListPoliciesOptionsFormatDisplayConst           = "display"
 	ListPoliciesOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -3632,7 +3703,7 @@ const (
 // * `active` - returns active policies
 // * `deleted` - returns non-active policies.
 const (
-	ListPoliciesOptionsStateActiveConst = "active"
+	ListPoliciesOptionsStateActiveConst  = "active"
 	ListPoliciesOptionsStateDeletedConst = "deleted"
 )
 
@@ -4011,7 +4082,7 @@ type ListV2PoliciesOptions struct {
 // Constants associated with the ListV2PoliciesOptions.Type property.
 // Optional type of policy.
 const (
-	ListV2PoliciesOptionsTypeAccessConst = "access"
+	ListV2PoliciesOptionsTypeAccessConst        = "access"
 	ListV2PoliciesOptionsTypeAuthorizationConst = "authorization"
 )
 
@@ -4019,7 +4090,7 @@ const (
 // Optional type of service.
 const (
 	ListV2PoliciesOptionsServiceTypePlatformServiceConst = "platform_service"
-	ListV2PoliciesOptionsServiceTypeServiceConst = "service"
+	ListV2PoliciesOptionsServiceTypeServiceConst         = "service"
 )
 
 // Constants associated with the ListV2PoliciesOptions.Format property.
@@ -4029,7 +4100,7 @@ const (
 // * `display` - returns the list of all actions included in each of the policy roles and translations for all relevant
 // fields.
 const (
-	ListV2PoliciesOptionsFormatDisplayConst = "display"
+	ListV2PoliciesOptionsFormatDisplayConst           = "display"
 	ListV2PoliciesOptionsFormatIncludeLastPermitConst = "include_last_permit"
 )
 
@@ -4038,7 +4109,7 @@ const (
 // * `active` - returns active policies
 // * `deleted` - returns non-active policies.
 const (
-	ListV2PoliciesOptionsStateActiveConst = "active"
+	ListV2PoliciesOptionsStateActiveConst  = "active"
 	ListV2PoliciesOptionsStateDeletedConst = "deleted"
 )
 
@@ -4163,7 +4234,7 @@ type Policy struct {
 // Constants associated with the Policy.State property.
 // The policy state.
 const (
-	PolicyStateActiveConst = "active"
+	PolicyStateActiveConst  = "active"
 	PolicyStateDeletedConst = "deleted"
 )
 
@@ -4279,10 +4350,10 @@ const (
 // Constants associated with the PolicyAssignment.Status property.
 // The policy assignment status.
 const (
-	PolicyAssignmentStatusFailedConst = "failed"
-	PolicyAssignmentStatusInProgressConst = "in_progress"
+	PolicyAssignmentStatusFailedConst            = "failed"
+	PolicyAssignmentStatusInProgressConst        = "in_progress"
 	PolicyAssignmentStatusSucceedWithErrorsConst = "succeed_with_errors"
-	PolicyAssignmentStatusSucceededConst = "succeeded"
+	PolicyAssignmentStatusSucceededConst         = "succeeded"
 )
 
 // UnmarshalPolicyAssignment unmarshals an instance of PolicyAssignment from the specified map of raw messages.
@@ -4374,7 +4445,7 @@ type PolicyAssignmentOptions struct {
 // The policy subject type; either 'iam_id' or 'access_group_id'.
 const (
 	PolicyAssignmentOptionsSubjectTypeAccessGroupIDConst = "access_group_id"
-	PolicyAssignmentOptionsSubjectTypeIamIDConst = "iam_id"
+	PolicyAssignmentOptionsSubjectTypeIamIDConst         = "iam_id"
 )
 
 // UnmarshalPolicyAssignmentOptions unmarshals an instance of PolicyAssignmentOptions from the specified map of raw messages.
@@ -4687,6 +4758,109 @@ func UnmarshalPolicyTemplateCollection(m map[string]json.RawMessage, result inte
 	return
 }
 
+// PolicyTemplateLimitData : The core set of properties associated with the policy template.
+type PolicyTemplateLimitData struct {
+	// Required field when creating a new template. Otherwise this field is optional. If the field is included it will
+	// change the name value for all existing versions of the template.
+	Name *string `json:"name" validate:"required"`
+
+	// Description of the policy template. This is shown to users in the enterprise account. Use this to describe the
+	// purpose or context of the policy for enterprise users managing IAM templates.
+	Description *string `json:"description,omitempty"`
+
+	// Enterprise account ID where this template will be created.
+	AccountID *string `json:"account_id" validate:"required"`
+
+	// Template version.
+	Version *string `json:"version" validate:"required"`
+
+	// Committed status of the template version.
+	Committed *bool `json:"committed,omitempty"`
+
+	// The core set of properties associated with the template's policy objet.
+	Policy *TemplatePolicy `json:"policy" validate:"required"`
+
+	// The policy template ID.
+	ID *string `json:"id,omitempty"`
+
+	// The href URL that links to the policy templates API by policy template ID.
+	Href *string `json:"href,omitempty"`
+
+	// The UTC timestamp when the policy template was created.
+	CreatedAt *strfmt.DateTime `json:"created_at,omitempty"`
+
+	// The iam ID of the entity that created the policy template.
+	CreatedByID *string `json:"created_by_id,omitempty"`
+
+	// The UTC timestamp when the policy template was last modified.
+	LastModifiedAt *strfmt.DateTime `json:"last_modified_at,omitempty"`
+
+	// The iam ID of the entity that last modified the policy template.
+	LastModifiedByID *string `json:"last_modified_by_id,omitempty"`
+
+	// policy template count details.
+	Counts *TemplateCountData `json:"counts,omitempty"`
+}
+
+// UnmarshalPolicyTemplateLimitData unmarshals an instance of PolicyTemplateLimitData from the specified map of raw messages.
+func UnmarshalPolicyTemplateLimitData(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(PolicyTemplateLimitData)
+	err = core.UnmarshalPrimitive(m, "name", &obj.Name)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "description", &obj.Description)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "version", &obj.Version)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "committed", &obj.Committed)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "policy", &obj.Policy, UnmarshalTemplatePolicy)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_at", &obj.CreatedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "created_by_id", &obj.CreatedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_at", &obj.LastModifiedAt)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "last_modified_by_id", &obj.LastModifiedByID)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "counts", &obj.Counts, UnmarshalTemplateCountData)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // PolicyTemplateMetaData : The core set of properties associated with a policy.
 type PolicyTemplateMetaData struct {
 	// The policy ID.
@@ -4733,7 +4907,7 @@ type PolicyTemplateMetaData struct {
 // Constants associated with the PolicyTemplateMetaData.State property.
 // The policy state.
 const (
-	PolicyTemplateMetaDataStateActiveConst = "active"
+	PolicyTemplateMetaDataStateActiveConst  = "active"
 	PolicyTemplateMetaDataStateDeletedConst = "deleted"
 )
 
@@ -4844,11 +5018,11 @@ type ReplacePolicyOptions struct {
 // NewReplacePolicyOptions : Instantiate ReplacePolicyOptions
 func (*IamPolicyManagementV1) NewReplacePolicyOptions(policyID string, ifMatch string, typeVar string, subjects []PolicySubject, roles []PolicyRole, resources []PolicyResource) *ReplacePolicyOptions {
 	return &ReplacePolicyOptions{
-		PolicyID: core.StringPtr(policyID),
-		IfMatch: core.StringPtr(ifMatch),
-		Type: core.StringPtr(typeVar),
-		Subjects: subjects,
-		Roles: roles,
+		PolicyID:  core.StringPtr(policyID),
+		IfMatch:   core.StringPtr(ifMatch),
+		Type:      core.StringPtr(typeVar),
+		Subjects:  subjects,
+		Roles:     roles,
 		Resources: resources,
 	}
 }
@@ -4936,9 +5110,9 @@ type ReplacePolicyTemplateOptions struct {
 func (*IamPolicyManagementV1) NewReplacePolicyTemplateOptions(policyTemplateID string, version string, ifMatch string, policy *TemplatePolicy) *ReplacePolicyTemplateOptions {
 	return &ReplacePolicyTemplateOptions{
 		PolicyTemplateID: core.StringPtr(policyTemplateID),
-		Version: core.StringPtr(version),
-		IfMatch: core.StringPtr(ifMatch),
-		Policy: policy,
+		Version:          core.StringPtr(version),
+		IfMatch:          core.StringPtr(ifMatch),
+		Policy:           policy,
 	}
 }
 
@@ -5016,10 +5190,10 @@ type ReplaceRoleOptions struct {
 // NewReplaceRoleOptions : Instantiate ReplaceRoleOptions
 func (*IamPolicyManagementV1) NewReplaceRoleOptions(roleID string, ifMatch string, displayName string, actions []string) *ReplaceRoleOptions {
 	return &ReplaceRoleOptions{
-		RoleID: core.StringPtr(roleID),
-		IfMatch: core.StringPtr(ifMatch),
+		RoleID:      core.StringPtr(roleID),
+		IfMatch:     core.StringPtr(ifMatch),
 		DisplayName: core.StringPtr(displayName),
-		Actions: actions,
+		Actions:     actions,
 	}
 }
 
@@ -5097,17 +5271,17 @@ type ReplaceV2PolicyOptions struct {
 // Constants associated with the ReplaceV2PolicyOptions.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	ReplaceV2PolicyOptionsTypeAccessConst = "access"
+	ReplaceV2PolicyOptionsTypeAccessConst        = "access"
 	ReplaceV2PolicyOptionsTypeAuthorizationConst = "authorization"
 )
 
 // NewReplaceV2PolicyOptions : Instantiate ReplaceV2PolicyOptions
 func (*IamPolicyManagementV1) NewReplaceV2PolicyOptions(id string, ifMatch string, control *Control, typeVar string) *ReplaceV2PolicyOptions {
 	return &ReplaceV2PolicyOptions{
-		ID: core.StringPtr(id),
+		ID:      core.StringPtr(id),
 		IfMatch: core.StringPtr(ifMatch),
 		Control: control,
-		Type: core.StringPtr(typeVar),
+		Type:    core.StringPtr(typeVar),
 	}
 }
 
@@ -5186,7 +5360,7 @@ type ResourceAttribute struct {
 // NewResourceAttribute : Instantiate ResourceAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewResourceAttribute(name string, value string) (_model *ResourceAttribute, err error) {
 	_model = &ResourceAttribute{
-		Name: core.StringPtr(name),
+		Name:  core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5227,7 +5401,7 @@ type ResourceTag struct {
 // NewResourceTag : Instantiate ResourceTag (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewResourceTag(name string, value string) (_model *ResourceTag, err error) {
 	_model = &ResourceTag{
-		Name: core.StringPtr(name),
+		Name:  core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5274,7 +5448,7 @@ type Role struct {
 func (*IamPolicyManagementV1) NewRole(displayName string, actions []string) (_model *Role, err error) {
 	_model = &Role{
 		DisplayName: core.StringPtr(displayName),
-		Actions: actions,
+		Actions:     actions,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5407,24 +5581,24 @@ type RuleAttribute struct {
 // Constants associated with the RuleAttribute.Operator property.
 // The operator of an attribute.
 const (
-	RuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
+	RuleAttributeOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
 	RuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	RuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
-	RuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
-	RuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
-	RuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
-	RuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
-	RuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
-	RuleAttributeOperatorTimelessthanConst = "timeLessThan"
-	RuleAttributeOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
+	RuleAttributeOperatorDatetimelessthanConst            = "dateTimeLessThan"
+	RuleAttributeOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
+	RuleAttributeOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
+	RuleAttributeOperatorDayofweekequalsConst             = "dayOfWeekEquals"
+	RuleAttributeOperatorTimegreaterthanConst             = "timeGreaterThan"
+	RuleAttributeOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
+	RuleAttributeOperatorTimelessthanConst                = "timeLessThan"
+	RuleAttributeOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
 )
 
 // NewRuleAttribute : Instantiate RuleAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewRuleAttribute(key string, operator string, value interface{}) (_model *RuleAttribute, err error) {
 	_model = &RuleAttribute{
-		Key: core.StringPtr(key),
+		Key:      core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value: value,
+		Value:    value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5449,6 +5623,72 @@ func UnmarshalRuleAttribute(m map[string]json.RawMessage, result interface{}) (e
 	return
 }
 
+// RuleAttributeWithConditions : Rule that specifies additional access granted (e.g., time-based condition).
+type RuleAttributeWithConditions struct {
+	// The name of an attribute.
+	Key *string `json:"key" validate:"required"`
+
+	// The operator of an attribute.
+	Operator *string `json:"operator" validate:"required"`
+
+	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
+	// array of strings (e.g., array of days to permit access) for rule attribute.
+	Value interface{} `json:"value" validate:"required"`
+
+	// List of additional conditions associated with a policy, e.g., time-based conditions that grant access over a certain
+	// time period.
+	Conditions []RuleAttribute `json:"conditions,omitempty"`
+}
+
+// Constants associated with the RuleAttributeWithConditions.Operator property.
+// The operator of an attribute.
+const (
+	RuleAttributeWithConditionsOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
+	RuleAttributeWithConditionsOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
+	RuleAttributeWithConditionsOperatorDatetimelessthanConst            = "dateTimeLessThan"
+	RuleAttributeWithConditionsOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
+	RuleAttributeWithConditionsOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
+	RuleAttributeWithConditionsOperatorDayofweekequalsConst             = "dayOfWeekEquals"
+	RuleAttributeWithConditionsOperatorTimegreaterthanConst             = "timeGreaterThan"
+	RuleAttributeWithConditionsOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
+	RuleAttributeWithConditionsOperatorTimelessthanConst                = "timeLessThan"
+	RuleAttributeWithConditionsOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
+)
+
+// NewRuleAttributeWithConditions : Instantiate RuleAttributeWithConditions (Generic Model Constructor)
+func (*IamPolicyManagementV1) NewRuleAttributeWithConditions(key string, operator string, value interface{}) (_model *RuleAttributeWithConditions, err error) {
+	_model = &RuleAttributeWithConditions{
+		Key:      core.StringPtr(key),
+		Operator: core.StringPtr(operator),
+		Value:    value,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalRuleAttributeWithConditions unmarshals an instance of RuleAttributeWithConditions from the specified map of raw messages.
+func UnmarshalRuleAttributeWithConditions(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(RuleAttributeWithConditions)
+	err = core.UnmarshalPrimitive(m, "key", &obj.Key)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "operator", &obj.Operator)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalRuleAttribute)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // SubjectAttribute : An attribute associated with a subject.
 type SubjectAttribute struct {
 	// The name of an attribute.
@@ -5461,7 +5701,7 @@ type SubjectAttribute struct {
 // NewSubjectAttribute : Instantiate SubjectAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewSubjectAttribute(name string, value string) (_model *SubjectAttribute, err error) {
 	_model = &SubjectAttribute{
-		Name: core.StringPtr(name),
+		Name:  core.StringPtr(name),
 		Value: core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5476,6 +5716,30 @@ func UnmarshalSubjectAttribute(m map[string]json.RawMessage, result interface{})
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "value", &obj.Value)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// TemplateCountData : policy template count details.
+type TemplateCountData struct {
+	// policy template current and limit details with in an account.
+	Template *LimitData `json:"template,omitempty"`
+
+	// policy template current and limit details with in an account.
+	Version *LimitData `json:"version,omitempty"`
+}
+
+// UnmarshalTemplateCountData unmarshals an instance of TemplateCountData from the specified map of raw messages.
+func UnmarshalTemplateCountData(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(TemplateCountData)
+	err = core.UnmarshalModel(m, "template", &obj.Template, UnmarshalLimitData)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "version", &obj.Version, UnmarshalLimitData)
 	if err != nil {
 		return
 	}
@@ -5555,14 +5819,14 @@ type TemplatePolicy struct {
 // Constants associated with the TemplatePolicy.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	TemplatePolicyTypeAccessConst = "access"
+	TemplatePolicyTypeAccessConst        = "access"
 	TemplatePolicyTypeAuthorizationConst = "authorization"
 )
 
 // NewTemplatePolicy : Instantiate TemplatePolicy (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewTemplatePolicy(typeVar string, control *Control) (_model *TemplatePolicy, err error) {
 	_model = &TemplatePolicy{
-		Type: core.StringPtr(typeVar),
+		Type:    core.StringPtr(typeVar),
 		Control: control,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5619,7 +5883,7 @@ type UpdatePolicyStateOptions struct {
 // Constants associated with the UpdatePolicyStateOptions.State property.
 // The policy state.
 const (
-	UpdatePolicyStateOptionsStateActiveConst = "active"
+	UpdatePolicyStateOptionsStateActiveConst  = "active"
 	UpdatePolicyStateOptionsStateDeletedConst = "deleted"
 )
 
@@ -5627,7 +5891,7 @@ const (
 func (*IamPolicyManagementV1) NewUpdatePolicyStateOptions(policyID string, ifMatch string) *UpdatePolicyStateOptions {
 	return &UpdatePolicyStateOptions{
 		PolicyID: core.StringPtr(policyID),
-		IfMatch: core.StringPtr(ifMatch),
+		IfMatch:  core.StringPtr(ifMatch),
 	}
 }
 
@@ -5710,14 +5974,14 @@ type V2Policy struct {
 // Constants associated with the V2Policy.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	V2PolicyTypeAccessConst = "access"
+	V2PolicyTypeAccessConst        = "access"
 	V2PolicyTypeAuthorizationConst = "authorization"
 )
 
 // Constants associated with the V2Policy.State property.
 // The policy state, either 'deleted' or 'active'.
 const (
-	V2PolicyStateActiveConst = "active"
+	V2PolicyStateActiveConst  = "active"
 	V2PolicyStateDeletedConst = "deleted"
 )
 
@@ -5860,15 +6124,15 @@ type V2PolicyResourceAttribute struct {
 const (
 	V2PolicyResourceAttributeOperatorStringequalsConst = "stringEquals"
 	V2PolicyResourceAttributeOperatorStringexistsConst = "stringExists"
-	V2PolicyResourceAttributeOperatorStringmatchConst = "stringMatch"
+	V2PolicyResourceAttributeOperatorStringmatchConst  = "stringMatch"
 )
 
 // NewV2PolicyResourceAttribute : Instantiate V2PolicyResourceAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyResourceAttribute(key string, operator string, value interface{}) (_model *V2PolicyResourceAttribute, err error) {
 	_model = &V2PolicyResourceAttribute{
-		Key: core.StringPtr(key),
+		Key:      core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value: value,
+		Value:    value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -5909,14 +6173,14 @@ type V2PolicyResourceTag struct {
 // The operator of an access management tag.
 const (
 	V2PolicyResourceTagOperatorStringequalsConst = "stringEquals"
-	V2PolicyResourceTagOperatorStringmatchConst = "stringMatch"
+	V2PolicyResourceTagOperatorStringmatchConst  = "stringMatch"
 )
 
 // NewV2PolicyResourceTag : Instantiate V2PolicyResourceTag (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyResourceTag(key string, value string, operator string) (_model *V2PolicyResourceTag, err error) {
 	_model = &V2PolicyResourceTag{
-		Key: core.StringPtr(key),
-		Value: core.StringPtr(value),
+		Key:      core.StringPtr(key),
+		Value:    core.StringPtr(value),
 		Operator: core.StringPtr(operator),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -5959,23 +6223,24 @@ type V2PolicyRule struct {
 
 	// List of conditions associated with a policy, e.g., time-based conditions that grant access over a certain time
 	// period.
-	Conditions []RuleAttribute `json:"conditions,omitempty"`
+	Conditions []RuleAttributeWithConditions `json:"conditions,omitempty"`
 }
 
 // Constants associated with the V2PolicyRule.Operator property.
 // The operator of an attribute.
 const (
-	V2PolicyRuleOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
+	V2PolicyRuleOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
 	V2PolicyRuleOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	V2PolicyRuleOperatorDatetimelessthanConst = "dateTimeLessThan"
-	V2PolicyRuleOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
-	V2PolicyRuleOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
-	V2PolicyRuleOperatorDayofweekequalsConst = "dayOfWeekEquals"
-	V2PolicyRuleOperatorTimegreaterthanConst = "timeGreaterThan"
-	V2PolicyRuleOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
-	V2PolicyRuleOperatorTimelessthanConst = "timeLessThan"
-	V2PolicyRuleOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
+	V2PolicyRuleOperatorDatetimelessthanConst            = "dateTimeLessThan"
+	V2PolicyRuleOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
+	V2PolicyRuleOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
+	V2PolicyRuleOperatorDayofweekequalsConst             = "dayOfWeekEquals"
+	V2PolicyRuleOperatorTimegreaterthanConst             = "timeGreaterThan"
+	V2PolicyRuleOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
+	V2PolicyRuleOperatorTimelessthanConst                = "timeLessThan"
+	V2PolicyRuleOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
 )
+
 func (*V2PolicyRule) isaV2PolicyRule() bool {
 	return true
 }
@@ -5999,7 +6264,7 @@ func UnmarshalV2PolicyRule(m map[string]json.RawMessage, result interface{}) (er
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalRuleAttribute)
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalRuleAttributeWithConditions)
 	if err != nil {
 		return
 	}
@@ -6054,9 +6319,9 @@ const (
 // NewV2PolicySubjectAttribute : Instantiate V2PolicySubjectAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicySubjectAttribute(key string, operator string, value string) (_model *V2PolicySubjectAttribute, err error) {
 	_model = &V2PolicySubjectAttribute{
-		Key: core.StringPtr(key),
+		Key:      core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value: core.StringPtr(value),
+		Value:    core.StringPtr(value),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -6140,14 +6405,14 @@ type V2PolicyTemplateMetaData struct {
 // Constants associated with the V2PolicyTemplateMetaData.Type property.
 // The policy type; either 'access' or 'authorization'.
 const (
-	V2PolicyTemplateMetaDataTypeAccessConst = "access"
+	V2PolicyTemplateMetaDataTypeAccessConst        = "access"
 	V2PolicyTemplateMetaDataTypeAuthorizationConst = "authorization"
 )
 
 // Constants associated with the V2PolicyTemplateMetaData.State property.
 // The policy state, either 'deleted' or 'active'.
 const (
-	V2PolicyTemplateMetaDataStateActiveConst = "active"
+	V2PolicyTemplateMetaDataStateActiveConst  = "active"
 	V2PolicyTemplateMetaDataStateDeletedConst = "deleted"
 )
 
@@ -6287,24 +6552,24 @@ type V2PolicyRuleRuleAttribute struct {
 // Constants associated with the V2PolicyRuleRuleAttribute.Operator property.
 // The operator of an attribute.
 const (
-	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
+	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanConst         = "dateTimeGreaterThan"
 	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
-	V2PolicyRuleRuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
-	V2PolicyRuleRuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
-	V2PolicyRuleRuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
-	V2PolicyRuleRuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
-	V2PolicyRuleRuleAttributeOperatorTimelessthanConst = "timeLessThan"
-	V2PolicyRuleRuleAttributeOperatorTimelessthanorequalsConst = "timeLessThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorDatetimelessthanConst            = "dateTimeLessThan"
+	V2PolicyRuleRuleAttributeOperatorDatetimelessthanorequalsConst    = "dateTimeLessThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorDayofweekanyofConst              = "dayOfWeekAnyOf"
+	V2PolicyRuleRuleAttributeOperatorDayofweekequalsConst             = "dayOfWeekEquals"
+	V2PolicyRuleRuleAttributeOperatorTimegreaterthanConst             = "timeGreaterThan"
+	V2PolicyRuleRuleAttributeOperatorTimegreaterthanorequalsConst     = "timeGreaterThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorTimelessthanConst                = "timeLessThan"
+	V2PolicyRuleRuleAttributeOperatorTimelessthanorequalsConst        = "timeLessThanOrEquals"
 )
 
 // NewV2PolicyRuleRuleAttribute : Instantiate V2PolicyRuleRuleAttribute (Generic Model Constructor)
 func (*IamPolicyManagementV1) NewV2PolicyRuleRuleAttribute(key string, operator string, value interface{}) (_model *V2PolicyRuleRuleAttribute, err error) {
 	_model = &V2PolicyRuleRuleAttribute{
-		Key: core.StringPtr(key),
+		Key:      core.StringPtr(key),
 		Operator: core.StringPtr(operator),
-		Value: value,
+		Value:    value,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -6341,20 +6606,20 @@ type V2PolicyRuleRuleWithConditions struct {
 
 	// List of conditions associated with a policy, e.g., time-based conditions that grant access over a certain time
 	// period.
-	Conditions []RuleAttribute `json:"conditions" validate:"required"`
+	Conditions []RuleAttributeWithConditions `json:"conditions" validate:"required"`
 }
 
 // Constants associated with the V2PolicyRuleRuleWithConditions.Operator property.
 // Operator to evaluate conditions.
 const (
 	V2PolicyRuleRuleWithConditionsOperatorAndConst = "and"
-	V2PolicyRuleRuleWithConditionsOperatorOrConst = "or"
+	V2PolicyRuleRuleWithConditionsOperatorOrConst  = "or"
 )
 
 // NewV2PolicyRuleRuleWithConditions : Instantiate V2PolicyRuleRuleWithConditions (Generic Model Constructor)
-func (*IamPolicyManagementV1) NewV2PolicyRuleRuleWithConditions(operator string, conditions []RuleAttribute) (_model *V2PolicyRuleRuleWithConditions, err error) {
+func (*IamPolicyManagementV1) NewV2PolicyRuleRuleWithConditions(operator string, conditions []RuleAttributeWithConditions) (_model *V2PolicyRuleRuleWithConditions, err error) {
 	_model = &V2PolicyRuleRuleWithConditions{
-		Operator: core.StringPtr(operator),
+		Operator:   core.StringPtr(operator),
 		Conditions: conditions,
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -6372,7 +6637,7 @@ func UnmarshalV2PolicyRuleRuleWithConditions(m map[string]json.RawMessage, resul
 	if err != nil {
 		return
 	}
-	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalRuleAttribute)
+	err = core.UnmarshalModel(m, "conditions", &obj.Conditions, UnmarshalRuleAttributeWithConditions)
 	if err != nil {
 		return
 	}

--- a/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_examples_test.go
@@ -371,24 +371,24 @@ var _ = Describe(`IamPolicyManagementV1 Examples Tests`, func() {
 					*accountIDResourceAttribute, *serviceNameResourceAttribute},
 				Tags: []iampolicymanagementv1.V2PolicyResourceTag{*policyResourceTag},
 			}
-			weeklyConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			weeklyConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.day_of_week}}"),
 				Operator: core.StringPtr("dayOfWeekAnyOf"),
 				Value:    []string{"1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"},
 			}
-			startConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			startConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
 				Operator: core.StringPtr("timeGreaterThanOrEquals"),
 				Value:    core.StringPtr("09:00:00+00:00"),
 			}
-			endConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			endConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
 				Operator: core.StringPtr("timeLessThanOrEquals"),
 				Value:    core.StringPtr("17:00:00+00:00"),
 			}
 			policyRule := &iampolicymanagementv1.V2PolicyRule{
 				Operator: core.StringPtr("and"),
-				Conditions: []iampolicymanagementv1.RuleAttribute{
+				Conditions: []iampolicymanagementv1.RuleAttributeWithConditions{
 					*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute},
 			}
 
@@ -481,24 +481,24 @@ var _ = Describe(`IamPolicyManagementV1 Examples Tests`, func() {
 				v2PolicyControl,
 				"access",
 			)
-			weeklyConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			weeklyConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.day_of_week}}"),
 				Operator: core.StringPtr("dayOfWeekAnyOf"),
 				Value:    []string{"1+00:00", "2+00:00", "3+00:00", "4+00:00"},
 			}
-			startConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			startConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
 				Operator: core.StringPtr("timeGreaterThanOrEquals"),
 				Value:    core.StringPtr("09:00:00+00:00"),
 			}
-			endConditionAttribute := &iampolicymanagementv1.RuleAttribute{
+			endConditionAttribute := &iampolicymanagementv1.RuleAttributeWithConditions{
 				Key:      core.StringPtr("{{environment.attributes.current_time}}"),
 				Operator: core.StringPtr("timeLessThanOrEquals"),
 				Value:    core.StringPtr("17:00:00+00:00"),
 			}
 			policyRule := &iampolicymanagementv1.V2PolicyRule{
 				Operator: core.StringPtr("and"),
-				Conditions: []iampolicymanagementv1.RuleAttribute{
+				Conditions: []iampolicymanagementv1.RuleAttributeWithConditions{
 					*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute},
 			}
 			options.SetRule(policyRule)
@@ -1058,8 +1058,6 @@ var _ = Describe(`IamPolicyManagementV1 Examples Tests`, func() {
 			Expect(policy.Template.ID).ToNot(BeNil())
 			Expect(policy.Template.Version).ToNot(BeNil())
 			Expect(policy.Template.AssignmentID).ToNot(BeNil())
-			Expect(policy.Template.RootID).ToNot(BeNil())
-			Expect(policy.Template.RootVersion).ToNot(BeNil())
 		})
 
 		It(`DeletePolicyTemplateVersion request example`, func() {

--- a/iampolicymanagementv1/iam_policy_management_v1_integration_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_integration_test.go
@@ -348,24 +348,24 @@ var _ = Describe("IAM Policy Management - Integration Tests", func() {
 			control.Grant = grant
 
 			// Construct an instance of Policy Rule Attribute
-			weeklyConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			weeklyConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			weeklyConditionAttribute.Key = core.StringPtr("{{environment.attributes.day_of_week}}")
 			weeklyConditionAttribute.Operator = core.StringPtr("dayOfWeekAnyOf")
 			weeklyConditionAttribute.Value = []string{"1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"}
 
-			startConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			startConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			startConditionAttribute.Key = core.StringPtr("{{environment.attributes.current_time}}")
 			startConditionAttribute.Operator = core.StringPtr("timeGreaterThanOrEquals")
 			startConditionAttribute.Value = core.StringPtr("09:00:00+00:00")
 
-			endConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			endConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			endConditionAttribute.Key = core.StringPtr("{{environment.attributes.current_time}}")
 			endConditionAttribute.Operator = core.StringPtr("timeLessThanOrEquals")
 			endConditionAttribute.Value = core.StringPtr("17:00:00+00:00")
 
 			policyRule := new(iampolicymanagementv1.V2PolicyRule)
 			policyRule.Operator = core.StringPtr("and")
-			policyRule.Conditions = []iampolicymanagementv1.RuleAttribute{*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute}
+			policyRule.Conditions = []iampolicymanagementv1.RuleAttributeWithConditions{*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute}
 
 			// Construct an instance of the CreateV2PolicyOptions model
 			options := new(iampolicymanagementv1.CreateV2PolicyOptions)
@@ -454,24 +454,24 @@ var _ = Describe("IAM Policy Management - Integration Tests", func() {
 			control.Grant = grant
 
 			// Construct an instance of Policy Rule Attribute
-			weeklyConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			weeklyConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			weeklyConditionAttribute.Key = core.StringPtr("{{environment.attributes.day_of_week}}")
 			weeklyConditionAttribute.Operator = core.StringPtr("dayOfWeekAnyOf")
 			weeklyConditionAttribute.Value = []string{"1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"}
 
-			startConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			startConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			startConditionAttribute.Key = core.StringPtr("{{environment.attributes.current_time}}")
 			startConditionAttribute.Operator = core.StringPtr("timeGreaterThanOrEquals")
 			startConditionAttribute.Value = core.StringPtr("09:00:00+00:00")
 
-			endConditionAttribute := new(iampolicymanagementv1.RuleAttribute)
+			endConditionAttribute := new(iampolicymanagementv1.RuleAttributeWithConditions)
 			endConditionAttribute.Key = core.StringPtr("{{environment.attributes.current_time}}")
 			endConditionAttribute.Operator = core.StringPtr("timeLessThanOrEquals")
 			endConditionAttribute.Value = core.StringPtr("17:00:00+00:00")
 
 			policyRule := new(iampolicymanagementv1.V2PolicyRule)
 			policyRule.Operator = core.StringPtr("and")
-			policyRule.Conditions = []iampolicymanagementv1.RuleAttribute{*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute}
+			policyRule.Conditions = []iampolicymanagementv1.RuleAttributeWithConditions{*weeklyConditionAttribute, *startConditionAttribute, *endConditionAttribute}
 
 			// Construct an instance of the ReplaceV2PolicyOptions model
 			options := new(iampolicymanagementv1.ReplaceV2PolicyOptions)
@@ -992,8 +992,6 @@ var _ = Describe("IAM Policy Management - Integration Tests", func() {
 			Expect(policy.Template.ID).ToNot(BeNil())
 			Expect(policy.Template.Version).ToNot(BeNil())
 			Expect(policy.Template.AssignmentID).ToNot(BeNil())
-			Expect(policy.Template.RootID).ToNot(BeNil())
-			Expect(policy.Template.RootVersion).ToNot(BeNil())
 		})
 	})
 

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -66,14 +66,13 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_URL": "https://iampolicymanagementv1/api",
+				"IAM_POLICY_MANAGEMENT_URL":       "https://iampolicymanagementv1/api",
 				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
-				})
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
 				Expect(iamPolicyManagementService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -102,8 +101,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
-				})
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
 				err := iamPolicyManagementService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(iamPolicyManagementService).ToNot(BeNil())
@@ -121,13 +119,12 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_URL": "https://iampolicymanagementv1/api",
+				"IAM_POLICY_MANAGEMENT_URL":       "https://iampolicymanagementv1/api",
 				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
-			})
+			iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(iamPolicyManagementService).To(BeNil())
@@ -138,7 +135,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_AUTH_TYPE":   "NOAuth",
+				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -4905,7 +4902,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplate successfully with retries`, func() {
@@ -5026,7 +5023,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplate successfully`, func() {
@@ -5675,7 +5672,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplateVersion successfully with retries`, func() {
@@ -5793,7 +5790,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplateVersion successfully`, func() {
@@ -8535,6 +8532,14 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
+			It(`Invoke NewRuleAttributeWithConditions successfully`, func() {
+				key := "testString"
+				operator := "timeLessThan"
+				value := core.StringPtr("testString")
+				_model, err := iamPolicyManagementService.NewRuleAttributeWithConditions(key, operator, value)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
 			It(`Invoke NewSubjectAttribute successfully`, func() {
 				name := "testString"
 				value := "testString"
@@ -8609,7 +8614,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Invoke NewV2PolicyRuleRuleWithConditions successfully`, func() {
 				operator := "and"
-				conditions := []iampolicymanagementv1.RuleAttribute{}
+				conditions := []iampolicymanagementv1.RuleAttributeWithConditions{}
 				_model, err := iamPolicyManagementService.NewV2PolicyRuleRuleWithConditions(operator, conditions)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -66,13 +66,14 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_URL":       "https://iampolicymanagementv1/api",
+				"IAM_POLICY_MANAGEMENT_URL": "https://iampolicymanagementv1/api",
 				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
+				})
 				Expect(iamPolicyManagementService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -101,7 +102,8 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
+				iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
+				})
 				err := iamPolicyManagementService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(iamPolicyManagementService).ToNot(BeNil())
@@ -119,12 +121,13 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_URL":       "https://iampolicymanagementv1/api",
+				"IAM_POLICY_MANAGEMENT_URL": "https://iampolicymanagementv1/api",
 				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{})
+			iamPolicyManagementService, serviceErr := iampolicymanagementv1.NewIamPolicyManagementV1UsingExternalConfig(&iampolicymanagementv1.IamPolicyManagementV1Options{
+			})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(iamPolicyManagementService).To(BeNil())
@@ -135,7 +138,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"IAM_POLICY_MANAGEMENT_AUTH_TYPE": "NOAuth",
+				"IAM_POLICY_MANAGEMENT_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -8533,10 +8536,8 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				Expect(err).To(BeNil())
 			})
 			It(`Invoke NewRuleAttributeWithConditions successfully`, func() {
-				key := "testString"
 				operator := "timeLessThan"
-				value := core.StringPtr("testString")
-				_model, err := iamPolicyManagementService.NewRuleAttributeWithConditions(key, operator, value)
+				_model, err := iamPolicyManagementService.NewRuleAttributeWithConditions(operator)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
Updated based on API definition fix to allow for `conditions` under `rule.conditions`.
Tests:

Examples:
```sh
go test -tags=examples
Ran 213 of 213 Specs in 13.890 seconds
SUCCESS! -- 213 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/IBM/platform-services-go-sdk/iampolicymanagementv1	14.331s
```

Integration:
```sh
go test -tags=integration
Ran 211 of 211 Specs in 21.518 seconds
SUCCESS! -- 211 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/IBM/platform-services-go-sdk/iampolicymanagementv1	22.384s
```

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->
Updates Rule to allow for properties that are already allowed for in API.

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->
issue: https://github.ibm.com/IAM/AM-issues/issues/1908