### PR TITLE
fix(IAM Policy Management): regenerate based on minor API update to operator enum

### DIFF
--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.84.1-55f6d880-20240110-194020
+ * IBM OpenAPI SDK Code Generator Version: 3.84.2-a032c73d-20240125-175315
  */
 
 // Package iampolicymanagementv1 : Operations and models for the IamPolicyManagementV1 service
@@ -388,87 +388,7 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreatePolicyWithContext(ctx co
 // actions](/docs/account?topic=account-iam-service-roles-actions). Use only the resource attributes supported by the
 // service. To view a service's or the platform's supported attributes, check the [documentation](/docs?tab=all-docs).
 // The policy resource must include either the **`serviceType`**, **`serviceName`**,  or **`resourceGroupId`** attribute
-// and the **`accountId`** attribute.`
-//
-// In the rule field, you can specify a single condition by using **`key`**, **`value`**, and condition **`operator`**,
-// or a set of **`conditions`** with a combination **`operator`**. The possible combination operators are **`and`** and
-// **`or`**.
-//
-// Currently, we support two types of patterns:
-//
-// 1. `time-based`: Used to specify a time-based restriction
-//
-// Combine conditions to specify a time-based restriction (e.g., access only during business hours, during the
-// Monday-Friday work week). For example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following
-// rule:
-// ```json
-//   "rule": {
-//     "operator": "and",
-//     "conditions": [{
-//       "key": "{{environment.attributes.day_of_week}}",
-//       "operator": "dayOfWeekAnyOf",
-//       "value": ["1+00:00", "2+00:00", "3+00:00", "4+00:00", "5+00:00"]
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeGreaterThanOrEquals",
-//       "value": "09:00:00+00:00"
-//     },
-//       "key": "{{environment.attributes.current_time}}",
-//       "operator": "timeLessThanOrEquals",
-//       "value": "17:00:00+00:00"
-//     }]
-//   }
-// ``` You can use the following operators in the **`key`** and **`value`** pair:
-// ```
-//   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
-//   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
-// ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
-// above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
-// operators](/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties) and
-// [Limiting access with time-based conditions](/docs/account?topic=account-iam-time-based&interface=ui). If the subject
-// is a locked service-id, the request will fail.
-//
-// 2. `attribute-based`: Used to specify a combination of OR/AND based conditions applied on resource attributes.
-//
-// Combine conditions to specify an attribute-based condition using AN/OR-based operators.
-//
-// For example, a policy can grant access based on multiple conditions applied on the resource attributes below:
-// ```json
-//   "pattern": "attribute-based-condition:resource:literal-and-wildcard"
-//   "rule": {
-//       "operator": "or",
-//       "conditions": [
-//         {
-//           "operator": "and",
-//           "conditions": [
-//             {
-//               "key": "{{resource.attributes.prefix}}",
-//               "operator": "stringEquals",
-//               "value": "home/test"
-//             },
-//             {
-//               "key": "{{environment.attributes.delimiter}}",
-//               "operator": "stringEquals",
-//               "value": "/"
-//             }
-//           ]
-//         },
-//         {
-//           "key": "{{resource.attributes.path}}",
-//           "operator": "stringMatch",
-//           "value": "home/David/_*"
-//         }
-//       ]
-//   }
-// ```
-//
-// In addition to satisfying the `resources` section, the policy grants permission only if either the `path` begins with
-// `home/David/` **OR**  the `prefix` is `home/test` and the `delimiter` is `/`. This mechanism helps you consolidate
-// multiple policies in to a single policy,  making policies easier to administer and stay within the policy limit for
-// an account. View the list of operators that can be used in the condition
-// [here](/docs/account?topic=account-wildcard#string-comparisons).
-//
+// and the **`accountId`** attribute.` If the subject is a locked service-id, the request will fail.
 //
 // ### Authorization
 //
@@ -1218,9 +1138,15 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // The policy resource must include either the **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
 // **`service_group_id`** attribute and the **`accountId`** attribute. In the rule field, you can specify a single
 // condition by using **`key`**, **`value`**, and condition **`operator`**, or a set of **`conditions`** with a
-// combination **`operator`**. The possible combination operators are **`and`** and **`or`**. Combine conditions to
-// specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
-// example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+// combination **`operator`**. The possible combination operators are **`and`** and **`or`**.
+//
+// Currently, we support two types of patterns:
+//
+// 1. `time-based`: Used to specify a time-based restriction
+//
+// Combine conditions to specify a time-based restriction (e.g., access only during business hours, during the
+// Monday-Friday work week). For example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following
+// rule:
 // ```json
 //   "rule": {
 //     "operator": "and",
@@ -1241,17 +1167,54 @@ func (iamPolicyManagement *IamPolicyManagementV1) ListV2PoliciesWithContext(ctx 
 // ``` You can use the following operators in the **`key`** and **`value`** pair:
 // ```
 //   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
 //   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf'
+// ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
+// above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
+// operators](/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties) and
+// [Limiting access with time-based conditions](/docs/account?topic=account-iam-time-based&interface=ui). If the subject
+// is a locked service-id, the request will fail.
+//
+// 2. `attribute-based`: Used to specify a combination of OR/AND based conditions applied on resource attributes.
+//
+// Combine conditions to specify an attribute-based condition using AND/OR-based operators.
+//
+// For example, a policy can grant access based on multiple conditions applied on the resource attributes below:
+// ```json
+//   "pattern": "attribute-based-condition:resource:literal-and-wildcard"
+//   "rule": {
+//       "operator": "or",
+//       "conditions": [
+//         {
+//           "operator": "and",
+//           "conditions": [
+//             {
+//               "key": "{{resource.attributes.prefix}}",
+//               "operator": "stringEquals",
+//               "value": "home/test"
+//             },
+//             {
+//               "key": "{{environment.attributes.delimiter}}",
+//               "operator": "stringEquals",
+//               "value": "/"
+//             }
+//           ]
+//         },
+//         {
+//           "key": "{{resource.attributes.path}}",
+//           "operator": "stringMatch",
+//           "value": "home/David/_*"
+//         }
+//       ]
+//   }
 // ```
 //
-// The pattern field that matches the rule is required when rule is provided. For the business hour rule example above,
-// the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
-// operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
-// and
-// [Limiting access with time-based
-// conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui). If the subject is a locked
-// service-id, the request will fail.
+// In addition to satisfying the `resources` section, the policy grants permission only if either the `path` begins with
+// `home/David/` **OR**  the `prefix` is `home/test` and the `delimiter` is `/`. This mechanism helps you consolidate
+// multiple policies in to a single policy,  making policies easier to administer and stay within the policy limit for
+// an account. View the list of operators that can be used in the condition
+// [here](/docs/account?topic=account-wildcard#string-comparisons).
 //
 // ### Authorization
 //
@@ -1377,9 +1340,15 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 // The policy resource must include either the **`serviceType`**, **`serviceName`**, **`resourceGroupId`** or
 // **`service_group_id`** attribute and the **`accountId`** attribute. In the rule field, you can specify a single
 // condition by using **`key`**, **`value`**, and condition **`operator`**, or a set of **`conditions`** with a
-// combination **`operator`**. The possible combination operators are **`and`** and **`or`**. Combine conditions to
-// specify a time-based restriction (e.g., access only during business hours, during the Monday-Friday work week). For
-// example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following rule:
+// combination **`operator`**. The possible combination operators are **`and`** and **`or`**.
+//
+// Currently, we support two types of patterns:
+//
+// 1. `time-based`: Used to specify a time-based restriction
+//
+// Combine conditions to specify a time-based restriction (e.g., access only during business hours, during the
+// Monday-Friday work week). For example, a policy can grant access Monday-Friday, 9:00am-5:00pm using the following
+// rule:
 // ```json
 //   "rule": {
 //     "operator": "and",
@@ -1397,17 +1366,57 @@ func (iamPolicyManagement *IamPolicyManagementV1) CreateV2PolicyWithContext(ctx 
 //       "value": "17:00:00+00:00"
 //     }]
 //   }
-// ``` You can use the following operators in the **`key`**, **`value`** pair:
+// ``` You can use the following operators in the **`key`** and **`value`** pair:
 // ```
 //   'timeLessThan', 'timeLessThanOrEquals', 'timeGreaterThan', 'timeGreaterThanOrEquals',
+//   'dateLessThan', 'dateLessThanOrEquals', 'dateGreaterThan', 'dateGreaterThanOrEquals',
 //   'dateTimeLessThan', 'dateTimeLessThanOrEquals', 'dateTimeGreaterThan', 'dateTimeGreaterThanOrEquals',
-//   'dayOfWeekEquals', 'dayOfWeekAnyOf',
+//   'dayOfWeekEquals', 'dayOfWeekAnyOf'
 // ``` The pattern field that matches the rule is required when rule is provided. For the business hour rule example
 // above, the **`pattern`** is **`"time-based-conditions:weekly"`**. For more information, see [Time-based conditions
-// operators](https://cloud.ibm.com/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties)
-// and
-// [Limiting access with time-based
-// conditions](https://cloud.ibm.com/docs/account?topic=account-iam-time-based&interface=ui).
+// operators](/docs/account?topic=account-iam-condition-properties&interface=ui#policy-condition-properties) and
+// [Limiting access with time-based conditions](/docs/account?topic=account-iam-time-based&interface=ui). If the subject
+// is a locked service-id, the request will fail.
+//
+// 2. `attribute-based`: Used to specify a combination of OR/AND based conditions applied on resource attributes.
+//
+// Combine conditions to specify an attribute-based condition using AND/OR-based operators.
+//
+// For example, a policy can grant access based on multiple conditions applied on the resource attributes below:
+// ```json
+//   "pattern": "attribute-based-condition:resource:literal-and-wildcard"
+//   "rule": {
+//       "operator": "or",
+//       "conditions": [
+//         {
+//           "operator": "and",
+//           "conditions": [
+//             {
+//               "key": "{{resource.attributes.prefix}}",
+//               "operator": "stringEquals",
+//               "value": "home/test"
+//             },
+//             {
+//               "key": "{{environment.attributes.delimiter}}",
+//               "operator": "stringEquals",
+//               "value": "/"
+//             }
+//           ]
+//         },
+//         {
+//           "key": "{{resource.attributes.path}}",
+//           "operator": "stringMatch",
+//           "value": "home/David/_*"
+//         }
+//       ]
+//   }
+// ```
+//
+// In addition to satisfying the `resources` section, the policy grants permission only if either the `path` begins with
+// `home/David/` **OR**  the `prefix` is `home/test` and the `delimiter` is `/`. This mechanism helps you consolidate
+// multiple policies in to a single policy,  making policies easier to administer and stay within the policy limit for
+// an account. View the list of operators that can be used in the condition
+// [here](/docs/account?topic=account-wildcard#string-comparisons).
 //
 // ### Authorization
 //
@@ -4325,8 +4334,8 @@ type NestedCondition struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator,omitempty"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value,omitempty"`
 
 	// List of conditions associated with a policy, e.g., time-based conditions that grant access over a certain time
@@ -4337,12 +4346,21 @@ type NestedCondition struct {
 // Constants associated with the NestedCondition.Operator property.
 // The operator of an attribute.
 const (
+	NestedConditionOperatorDategreaterthanConst = "dateGreaterThan"
+	NestedConditionOperatorDategreaterthanorequalsConst = "dateGreaterThanOrEquals"
+	NestedConditionOperatorDatelessthanConst = "dateLessThan"
+	NestedConditionOperatorDatelessthanorequalsConst = "dateLessThanOrEquals"
 	NestedConditionOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	NestedConditionOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
 	NestedConditionOperatorDatetimelessthanConst = "dateTimeLessThan"
 	NestedConditionOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
 	NestedConditionOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
 	NestedConditionOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	NestedConditionOperatorStringequalsConst = "stringEquals"
+	NestedConditionOperatorStringequalsanyofConst = "stringEqualsAnyOf"
+	NestedConditionOperatorStringexistsConst = "stringExists"
+	NestedConditionOperatorStringmatchConst = "stringMatch"
+	NestedConditionOperatorStringmatchanyofConst = "stringMatchAnyOf"
 	NestedConditionOperatorTimegreaterthanConst = "timeGreaterThan"
 	NestedConditionOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
 	NestedConditionOperatorTimelessthanConst = "timeLessThan"
@@ -5788,20 +5806,29 @@ type RuleAttribute struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value" validate:"required"`
 }
 
 // Constants associated with the RuleAttribute.Operator property.
 // The operator of an attribute.
 const (
+	RuleAttributeOperatorDategreaterthanConst = "dateGreaterThan"
+	RuleAttributeOperatorDategreaterthanorequalsConst = "dateGreaterThanOrEquals"
+	RuleAttributeOperatorDatelessthanConst = "dateLessThan"
+	RuleAttributeOperatorDatelessthanorequalsConst = "dateLessThanOrEquals"
 	RuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	RuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
 	RuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
 	RuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
 	RuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
 	RuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	RuleAttributeOperatorStringequalsConst = "stringEquals"
+	RuleAttributeOperatorStringequalsanyofConst = "stringEqualsAnyOf"
+	RuleAttributeOperatorStringexistsConst = "stringExists"
+	RuleAttributeOperatorStringmatchConst = "stringMatch"
+	RuleAttributeOperatorStringmatchanyofConst = "stringMatchAnyOf"
 	RuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
 	RuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
 	RuleAttributeOperatorTimelessthanConst = "timeLessThan"
@@ -6263,8 +6290,8 @@ type V2PolicyResourceAttribute struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value" validate:"required"`
 }
 
@@ -6272,8 +6299,10 @@ type V2PolicyResourceAttribute struct {
 // The operator of an attribute.
 const (
 	V2PolicyResourceAttributeOperatorStringequalsConst = "stringEquals"
+	V2PolicyResourceAttributeOperatorStringequalsanyofConst = "stringEqualsAnyOf"
 	V2PolicyResourceAttributeOperatorStringexistsConst = "stringExists"
 	V2PolicyResourceAttributeOperatorStringmatchConst = "stringMatch"
+	V2PolicyResourceAttributeOperatorStringmatchanyofConst = "stringMatchAnyOf"
 )
 
 // NewV2PolicyResourceAttribute : Instantiate V2PolicyResourceAttribute (Generic Model Constructor)
@@ -6366,8 +6395,8 @@ type V2PolicyRule struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator,omitempty"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value,omitempty"`
 
 	// List of conditions associated with a policy, e.g., time-based conditions that grant access over a certain time
@@ -6378,12 +6407,21 @@ type V2PolicyRule struct {
 // Constants associated with the V2PolicyRule.Operator property.
 // The operator of an attribute.
 const (
+	V2PolicyRuleOperatorDategreaterthanConst = "dateGreaterThan"
+	V2PolicyRuleOperatorDategreaterthanorequalsConst = "dateGreaterThanOrEquals"
+	V2PolicyRuleOperatorDatelessthanConst = "dateLessThan"
+	V2PolicyRuleOperatorDatelessthanorequalsConst = "dateLessThanOrEquals"
 	V2PolicyRuleOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	V2PolicyRuleOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
 	V2PolicyRuleOperatorDatetimelessthanConst = "dateTimeLessThan"
 	V2PolicyRuleOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
 	V2PolicyRuleOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
 	V2PolicyRuleOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	V2PolicyRuleOperatorStringequalsConst = "stringEquals"
+	V2PolicyRuleOperatorStringequalsanyofConst = "stringEqualsAnyOf"
+	V2PolicyRuleOperatorStringexistsConst = "stringExists"
+	V2PolicyRuleOperatorStringmatchConst = "stringMatch"
+	V2PolicyRuleOperatorStringmatchanyofConst = "stringMatchAnyOf"
 	V2PolicyRuleOperatorTimegreaterthanConst = "timeGreaterThan"
 	V2PolicyRuleOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
 	V2PolicyRuleOperatorTimelessthanConst = "timeLessThan"
@@ -6454,8 +6492,8 @@ type V2PolicySubjectAttribute struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value" validate:"required"`
 }
 
@@ -6463,6 +6501,7 @@ type V2PolicySubjectAttribute struct {
 // The operator of an attribute.
 const (
 	V2PolicySubjectAttributeOperatorStringequalsConst = "stringEquals"
+	V2PolicySubjectAttributeOperatorStringexistsConst = "stringExists"
 )
 
 // NewV2PolicySubjectAttribute : Instantiate V2PolicySubjectAttribute (Generic Model Constructor)
@@ -6693,20 +6732,29 @@ type NestedConditionRuleAttribute struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value" validate:"required"`
 }
 
 // Constants associated with the NestedConditionRuleAttribute.Operator property.
 // The operator of an attribute.
 const (
+	NestedConditionRuleAttributeOperatorDategreaterthanConst = "dateGreaterThan"
+	NestedConditionRuleAttributeOperatorDategreaterthanorequalsConst = "dateGreaterThanOrEquals"
+	NestedConditionRuleAttributeOperatorDatelessthanConst = "dateLessThan"
+	NestedConditionRuleAttributeOperatorDatelessthanorequalsConst = "dateLessThanOrEquals"
 	NestedConditionRuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	NestedConditionRuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
 	NestedConditionRuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
 	NestedConditionRuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
 	NestedConditionRuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
 	NestedConditionRuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	NestedConditionRuleAttributeOperatorStringequalsConst = "stringEquals"
+	NestedConditionRuleAttributeOperatorStringequalsanyofConst = "stringEqualsAnyOf"
+	NestedConditionRuleAttributeOperatorStringexistsConst = "stringExists"
+	NestedConditionRuleAttributeOperatorStringmatchConst = "stringMatch"
+	NestedConditionRuleAttributeOperatorStringmatchanyofConst = "stringMatchAnyOf"
 	NestedConditionRuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
 	NestedConditionRuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
 	NestedConditionRuleAttributeOperatorTimelessthanConst = "timeLessThan"
@@ -6803,20 +6851,29 @@ type V2PolicyRuleRuleAttribute struct {
 	// The operator of an attribute.
 	Operator *string `json:"operator" validate:"required"`
 
-	// The value of a rule or resource attribute; can be boolean or string for resource attribute. Can be string or an
-	// array of strings (e.g., array of days to permit access) for rule attribute.
+	// The value of a rule, resource, or subject attribute; can be boolean or string for resource and subject attribute.
+	// Can be string or an array of strings (e.g., array of days to permit access) for rule attribute.
 	Value interface{} `json:"value" validate:"required"`
 }
 
 // Constants associated with the V2PolicyRuleRuleAttribute.Operator property.
 // The operator of an attribute.
 const (
+	V2PolicyRuleRuleAttributeOperatorDategreaterthanConst = "dateGreaterThan"
+	V2PolicyRuleRuleAttributeOperatorDategreaterthanorequalsConst = "dateGreaterThanOrEquals"
+	V2PolicyRuleRuleAttributeOperatorDatelessthanConst = "dateLessThan"
+	V2PolicyRuleRuleAttributeOperatorDatelessthanorequalsConst = "dateLessThanOrEquals"
 	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanConst = "dateTimeGreaterThan"
 	V2PolicyRuleRuleAttributeOperatorDatetimegreaterthanorequalsConst = "dateTimeGreaterThanOrEquals"
 	V2PolicyRuleRuleAttributeOperatorDatetimelessthanConst = "dateTimeLessThan"
 	V2PolicyRuleRuleAttributeOperatorDatetimelessthanorequalsConst = "dateTimeLessThanOrEquals"
 	V2PolicyRuleRuleAttributeOperatorDayofweekanyofConst = "dayOfWeekAnyOf"
 	V2PolicyRuleRuleAttributeOperatorDayofweekequalsConst = "dayOfWeekEquals"
+	V2PolicyRuleRuleAttributeOperatorStringequalsConst = "stringEquals"
+	V2PolicyRuleRuleAttributeOperatorStringequalsanyofConst = "stringEqualsAnyOf"
+	V2PolicyRuleRuleAttributeOperatorStringexistsConst = "stringExists"
+	V2PolicyRuleRuleAttributeOperatorStringmatchConst = "stringMatch"
+	V2PolicyRuleRuleAttributeOperatorStringmatchanyofConst = "stringMatchAnyOf"
 	V2PolicyRuleRuleAttributeOperatorTimegreaterthanConst = "timeGreaterThan"
 	V2PolicyRuleRuleAttributeOperatorTimegreaterthanorequalsConst = "timeGreaterThanOrEquals"
 	V2PolicyRuleRuleAttributeOperatorTimelessthanConst = "timeLessThan"

--- a/iampolicymanagementv1/iam_policy_management_v1.go
+++ b/iampolicymanagementv1/iam_policy_management_v1.go
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.84.2-a032c73d-20240125-175315
+ * IBM OpenAPI SDK Code Generator Version: 3.85.0-75c38f8f-20240206-210220
  */
 
 // Package iampolicymanagementv1 : Operations and models for the IamPolicyManagementV1 service

--- a/iampolicymanagementv1/iam_policy_management_v1_test.go
+++ b/iampolicymanagementv1/iam_policy_management_v1_test.go
@@ -3033,7 +3033,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policies": [{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}]}`)
+					fmt.Fprintf(res, "%s", `{"policies": [{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}]}`)
 				}))
 			})
 			It(`Invoke ListV2Policies successfully with retries`, func() {
@@ -3109,7 +3109,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policies": [{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}]}`)
+					fmt.Fprintf(res, "%s", `{"policies": [{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}]}`)
 				}))
 			})
 			It(`Invoke ListV2Policies successfully`, func() {
@@ -3302,7 +3302,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -3369,7 +3369,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
 				}))
 			})
 			It(`Invoke CreateV2Policy successfully with retries`, func() {
@@ -3423,7 +3423,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -3493,7 +3493,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
 				}))
 			})
 			It(`Invoke CreateV2Policy successfully`, func() {
@@ -3552,7 +3552,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -3624,7 +3624,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -3717,7 +3717,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -3812,7 +3812,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -3880,7 +3880,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
 				}))
 			})
 			It(`Invoke ReplaceV2Policy successfully with retries`, func() {
@@ -3934,7 +3934,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -4005,7 +4005,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19}`)
 				}))
 			})
 			It(`Invoke ReplaceV2Policy successfully`, func() {
@@ -4064,7 +4064,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -4137,7 +4137,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -4231,7 +4231,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -4325,7 +4325,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}`)
 				}))
 			})
 			It(`Invoke GetV2Policy successfully with retries`, func() {
@@ -4381,7 +4381,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}`)
+					fmt.Fprintf(res, "%s", `{"type": "access", "description": "Description", "subject": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}]}, "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "id": "ID", "href": "Href", "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}, "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "state": "active", "last_permit_at": "LastPermitAt", "last_permit_frequency": 19, "template": {"id": "ID", "version": "Version", "assignment_id": "AssignmentID", "root_id": "RootID", "root_version": "RootVersion"}}`)
 				}))
 			})
 			It(`Invoke GetV2Policy successfully`, func() {
@@ -4620,7 +4620,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policy_templates": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
+					fmt.Fprintf(res, "%s", `{"policy_templates": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
 				}))
 			})
 			It(`Invoke ListPolicyTemplates successfully with retries`, func() {
@@ -4680,7 +4680,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policy_templates": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
+					fmt.Fprintf(res, "%s", `{"policy_templates": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
 				}))
 			})
 			It(`Invoke ListPolicyTemplates successfully`, func() {
@@ -4827,7 +4827,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -4913,7 +4913,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplate successfully with retries`, func() {
@@ -4945,7 +4945,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5034,7 +5034,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplate successfully`, func() {
@@ -5071,7 +5071,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5140,7 +5140,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5230,7 +5230,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5342,7 +5342,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke GetPolicyTemplate successfully with retries`, func() {
@@ -5398,7 +5398,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke GetPolicyTemplate successfully`, func() {
@@ -5608,7 +5608,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5691,7 +5691,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplateVersion successfully with retries`, func() {
@@ -5723,7 +5723,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5809,7 +5809,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID", "counts": {"template": {"current": 7, "limit": 5}, "version": {"current": 7, "limit": 5}}}`)
 				}))
 			})
 			It(`Invoke CreatePolicyTemplateVersion successfully`, func() {
@@ -5846,7 +5846,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -5914,7 +5914,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6003,7 +6003,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6114,7 +6114,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"versions": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
+					fmt.Fprintf(res, "%s", `{"versions": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
 				}))
 			})
 			It(`Invoke ListPolicyTemplateVersions successfully with retries`, func() {
@@ -6170,7 +6170,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"versions": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
+					fmt.Fprintf(res, "%s", `{"versions": [{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}]}`)
 				}))
 			})
 			It(`Invoke ListPolicyTemplateVersions successfully`, func() {
@@ -6314,7 +6314,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6401,7 +6401,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke ReplacePolicyTemplate successfully with retries`, func() {
@@ -6433,7 +6433,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6523,7 +6523,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke ReplacePolicyTemplate successfully`, func() {
@@ -6560,7 +6560,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6630,7 +6630,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6721,7 +6721,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				// Construct an instance of the V2PolicyRuleRuleAttribute model
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 
 				// Construct an instance of the Roles model
@@ -6902,7 +6902,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke GetPolicyTemplateVersion successfully with retries`, func() {
@@ -6957,7 +6957,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "timeLessThan", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
+					fmt.Fprintf(res, "%s", `{"name": "Name", "description": "Description", "account_id": "AccountID", "version": "Version", "committed": false, "policy": {"type": "access", "description": "Description", "resource": {"attributes": [{"key": "Key", "operator": "stringEquals", "value": "anyValue"}], "tags": [{"key": "Key", "value": "Value", "operator": "stringEquals"}]}, "pattern": "Pattern", "rule": {"key": "Key", "operator": "stringEquals", "value": "anyValue"}, "control": {"grant": {"roles": [{"role_id": "RoleID"}]}}}, "state": "active", "id": "ID", "href": "Href", "created_at": "2019-01-01T12:00:00.000Z", "created_by_id": "CreatedByID", "last_modified_at": "2019-01-01T12:00:00.000Z", "last_modified_by_id": "LastModifiedByID"}`)
 				}))
 			})
 			It(`Invoke GetPolicyTemplateVersion successfully`, func() {
@@ -7708,10 +7708,10 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				Expect(v2PolicyRuleModel).ToNot(BeNil())
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 				Expect(v2PolicyRuleModel.Key).To(Equal(core.StringPtr("testString")))
-				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("timeLessThan")))
+				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("stringEquals")))
 				Expect(v2PolicyRuleModel.Value).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the Roles model
@@ -7802,10 +7802,10 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				Expect(v2PolicyRuleModel).ToNot(BeNil())
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 				Expect(v2PolicyRuleModel.Key).To(Equal(core.StringPtr("testString")))
-				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("timeLessThan")))
+				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("stringEquals")))
 				Expect(v2PolicyRuleModel.Value).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the Roles model
@@ -7953,10 +7953,10 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				Expect(v2PolicyRuleModel).ToNot(BeNil())
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 				Expect(v2PolicyRuleModel.Key).To(Equal(core.StringPtr("testString")))
-				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("timeLessThan")))
+				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("stringEquals")))
 				Expect(v2PolicyRuleModel.Value).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the CreateV2PolicyOptions model
@@ -8344,10 +8344,10 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				Expect(v2PolicyRuleModel).ToNot(BeNil())
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 				Expect(v2PolicyRuleModel.Key).To(Equal(core.StringPtr("testString")))
-				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("timeLessThan")))
+				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("stringEquals")))
 				Expect(v2PolicyRuleModel.Value).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the Roles model
@@ -8496,10 +8496,10 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 				v2PolicyRuleModel := new(iampolicymanagementv1.V2PolicyRuleRuleAttribute)
 				Expect(v2PolicyRuleModel).ToNot(BeNil())
 				v2PolicyRuleModel.Key = core.StringPtr("testString")
-				v2PolicyRuleModel.Operator = core.StringPtr("timeLessThan")
+				v2PolicyRuleModel.Operator = core.StringPtr("stringEquals")
 				v2PolicyRuleModel.Value = core.StringPtr("testString")
 				Expect(v2PolicyRuleModel.Key).To(Equal(core.StringPtr("testString")))
-				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("timeLessThan")))
+				Expect(v2PolicyRuleModel.Operator).To(Equal(core.StringPtr("stringEquals")))
 				Expect(v2PolicyRuleModel.Value).To(Equal(core.StringPtr("testString")))
 
 				// Construct an instance of the ReplaceV2PolicyOptions model
@@ -8559,7 +8559,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Invoke NewRuleAttribute successfully`, func() {
 				key := "testString"
-				operator := "timeLessThan"
+				operator := "stringEquals"
 				value := core.StringPtr("testString")
 				_model, err := iamPolicyManagementService.NewRuleAttribute(key, operator, value)
 				Expect(_model).ToNot(BeNil())
@@ -8631,7 +8631,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Invoke NewNestedConditionRuleAttribute successfully`, func() {
 				key := "testString"
-				operator := "timeLessThan"
+				operator := "stringEquals"
 				value := core.StringPtr("testString")
 				_model, err := iamPolicyManagementService.NewNestedConditionRuleAttribute(key, operator, value)
 				Expect(_model).ToNot(BeNil())
@@ -8646,7 +8646,7 @@ var _ = Describe(`IamPolicyManagementV1`, func() {
 			})
 			It(`Invoke NewV2PolicyRuleRuleAttribute successfully`, func() {
 				key := "testString"
-				operator := "timeLessThan"
+				operator := "stringEquals"
 				value := core.StringPtr("testString")
 				_model, err := iamPolicyManagementService.NewV2PolicyRuleRuleAttribute(key, operator, value)
 				Expect(_model).ToNot(BeNil())


### PR DESCRIPTION
## PR summary
<!-- please include a brief summary of the changes in this PR -->
This is a minor regeneration based on update to enum for operators in v2/policies.
Issue: https://github.ibm.com/IAM/AM-issues/issues/2212

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->

Tests:
```sh
go test -tags=examples
...
Ran 214 of 214 Specs in 19.609 seconds
SUCCESS! -- 214 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/IBM/platform-services-go-sdk/iampolicymanagementv1	20.361s
```

```sh
go test -tags=integration
...
Ran 212 of 212 Specs in 16.369 seconds
SUCCESS! -- 212 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```