### PR TITLE
fix(Metrics Router): add new regions br-sao, ca-tor, jp-osa and jp-tok

### DIFF
--- a/metricsrouterv3/metrics_router_v3.go
+++ b/metricsrouterv3/metrics_router_v3.go
@@ -114,6 +114,10 @@ func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
 		"au-syd":           "https://au-syd.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the au-syd region.
 		"private.au-syd":   "https://private.au-syd.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the au-syd region.
+		"br-sao":           "https://br-sao.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the br-sao region.
+		"private.br-sao":   "https://private.br-sao.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the br-sao region.
+		"ca-tor":           "https://ca-tor.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the ca-tor region.
+		"private.ca-tor":   "https://private.ca-tor.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the ca-tor region.
 		"eu-de":            "https://eu-de.metrics-router.cloud.ibm.com/api/v3",            // The server for IBM Cloud Metrics Routing Service in the eu-de region.
 		"private.eu-de":    "https://private.eu-de.metrics-router.cloud.ibm.com/api/v3",    // The server for IBM Cloud Metrics Routing Service in the eu-de region.
 		"eu-gb":            "https://eu-gb.metrics-router.cloud.ibm.com/api/v3",            // The server for IBM Cloud Metrics Routing Service in the eu-gb region.
@@ -122,6 +126,10 @@ func GetServiceURLForRegion(region string) (string, error) {
 		"private.eu-es":    "https://private.eu-es.metrics-router.cloud.ibm.com/api/v3",    // The server for IBM Cloud Metrics Routing Service in the eu-es region.
 		"eu-fr2":           "https://eu-fr2.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the eu-fr2 region.
 		"private.eu-fr2":   "https://private.eu-fr2.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the eu-fr2 region.
+		"jp-osa":           "https://jp-osa.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the jp-osa region.
+		"private.jp-osa":   "https://private.jp-osa.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the jp-osa region.
+		"jp-tok":           "https://jp-tok.metrics-router.cloud.ibm.com/api/v3",           // The server for IBM Cloud Metrics Routing Service in the jp-tok region.
+		"private.jp-tok":   "https://private.jp-tok.metrics-router.cloud.ibm.com/api/v3",   // The server for IBM Cloud Metrics Routing Service in the jp-tok region.
 		"us-east":          "https://us-east.metrics-router.cloud.ibm.com/api/v3",          // The server for IBM Cloud Metrics Routing Service in the us-east region.
 		"private.us-east":  "https://private.us-east.metrics-router.cloud.ibm.com/api/v3",  // The server for IBM Cloud Metrics Routing Service in the us-east region.
 		"us-south":         "https://us-south.metrics-router.cloud.ibm.com/api/v3",         // The server for IBM Cloud Metrics Routing Service in the us-south region.

--- a/metricsrouterv3/metrics_router_v3_test.go
+++ b/metricsrouterv3/metrics_router_v3_test.go
@@ -162,6 +162,22 @@ var _ = Describe(`MetricsRouterV3`, func() {
 			Expect(url).To(Equal("https://private.au-syd.metrics-router.cloud.ibm.com/api/v3"))
 			Expect(err).To(BeNil())
 
+			url, err = metricsrouterv3.GetServiceURLForRegion("br-sao")
+			Expect(url).To(Equal("https://br-sao.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("private.br-sao")
+			Expect(url).To(Equal("https://private.br-sao.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("ca-tor")
+			Expect(url).To(Equal("https://ca-tor.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("private.ca-tor")
+			Expect(url).To(Equal("https://private.ca-tor.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
 			url, err = metricsrouterv3.GetServiceURLForRegion("eu-de")
 			Expect(url).To(Equal("https://eu-de.metrics-router.cloud.ibm.com/api/v3"))
 			Expect(err).To(BeNil())
@@ -192,6 +208,22 @@ var _ = Describe(`MetricsRouterV3`, func() {
 
 			url, err = metricsrouterv3.GetServiceURLForRegion("private.eu-fr2")
 			Expect(url).To(Equal("https://private.eu-fr2.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("jp-osa")
+			Expect(url).To(Equal("https://jp-osa.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("private.jp-osa")
+			Expect(url).To(Equal("https://private.jp-osa.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("jp-tok")
+			Expect(url).To(Equal("https://jp-tok.metrics-router.cloud.ibm.com/api/v3"))
+			Expect(err).To(BeNil())
+
+			url, err = metricsrouterv3.GetServiceURLForRegion("private.jp-tok")
+			Expect(url).To(Equal("https://private.jp-tok.metrics-router.cloud.ibm.com/api/v3"))
 			Expect(err).To(BeNil())
 
 			url, err = metricsrouterv3.GetServiceURLForRegion("us-east")


### PR DESCRIPTION
## PR summary
Added new regions Sao Paulo(br-sao), Toronto(ca-tor), Osaka(jp-tok) and Tokyo(jp-tok) to metrics-router


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Added new region. No change in old code

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information