### PR TITLE
fix(ATracker): add new regions br-sao, ca-tor, jp-osa, jp-tok and in-che

### DIFF
--- a/atrackerv2/atracker_v2.go
+++ b/atrackerv2/atracker_v2.go
@@ -127,16 +127,16 @@ func GetServiceURLForRegion(region string) (string, error) {
 		"private.eu-fr2":   "https://private.eu-fr2.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the eu-fr2 region.
 		"au-syd":           "https://au-syd.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the au-syd region.
 		"private.au-syd":   "https://private.au-syd.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the au-syd region.
-		"ca-tor":           "https://us-east.atracker.cloud.ibm.com",          // The server for IBM Cloud Activity Tracker Service for ca-tor points to the us-east region.
-		"private.ca-tor":   "https://private.us-east.atracker.cloud.ibm.com",  // The server for IBM Cloud Activity Tracker Service for ca-tor points to the us-east region.
-		"br-sao":           "https://us-south.atracker.cloud.ibm.com",         // The server for IBM Cloud Activity Tracker Service for br-sao points to the us-south region.
-		"private.br-sao":   "https://private.us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for br-sao points to the us-south region.
-		"jp-tok":           "https://eu-de.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service for jp-tok points to the eu-de region.
-		"private.jp-tok":   "https://private.eu-de.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service for jp-tok points to the eu-de region.
-		"jp-osa":           "https://eu-de.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service for jp-osa points to the eu-de region.
-		"private.jp-osa":   "https://private.eu-de.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service for jp-osa points to the eu-de region.
-		"in-che":           "https://eu-de.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service for in-che points to the eu-de region.
-		"private.in-che":   "https://private.eu-de.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service for in-che points to the eu-de region.
+		"ca-tor":           "https://ca-tor.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the ca-tor region.
+		"private.ca-tor":   "https://private.ca-tor.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the ca-tor region.
+		"br-sao":           "https://br-sao.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the br-sao region.
+		"private.br-sao":   "https://private.br-sao.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the br-sao region.
+		"jp-tok":           "https://jp-tok.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the jp-tok region.
+		"private.jp-tok":   "https://private.jp-tok.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the jp-tok region.
+		"jp-osa":           "https://jp-osa.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the jp-osa region.
+		"private.jp-osa":   "https://private.jp-osa.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the jp-osa region.
+		"in-che":           "https://in-che.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the in-che region.
+		"private.in-che":   "https://private.in-che.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the in-che region.
 	}
 
 	if url, ok := endpoints[region]; ok {

--- a/atrackerv2/atracker_v2_test.go
+++ b/atrackerv2/atracker_v2_test.go
@@ -211,43 +211,43 @@ var _ = Describe(`AtrackerV2`, func() {
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("ca-tor")
-			Expect(url).To(Equal("https://us-east.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://ca-tor.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.ca-tor")
-			Expect(url).To(Equal("https://private.us-east.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.ca-tor.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("br-sao")
-			Expect(url).To(Equal("https://us-south.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://br-sao.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.br-sao")
-			Expect(url).To(Equal("https://private.us-south.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.br-sao.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("jp-tok")
-			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://jp-tok.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.jp-tok")
-			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.jp-tok.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("jp-osa")
-			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://jp-osa.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.jp-osa")
-			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.jp-osa.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("in-che")
-			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://in-che.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.in-che")
-			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.in-che.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("INVALID_REGION")


### PR DESCRIPTION
## PR summary
Added new regions Sao Paulo(br-sao), Toronto(ca-tor), Osaka(jp-tok), Tokyo(jp-tok) and Chennai(in-che) to ATracker


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
Added new region. No change in old code

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

## Other information