### PR TITLE
fix (ATracker): add support for Cloud Logs target type

### DIFF
--- a/atrackerv2/atracker_v2.go
+++ b/atrackerv2/atracker_v2.go
@@ -113,30 +113,30 @@ func NewAtrackerV2(options *AtrackerV2Options) (service *AtrackerV2, err error) 
 // GetServiceURLForRegion returns the service URL to be used for the specified region
 func GetServiceURLForRegion(region string) (string, error) {
 	var endpoints = map[string]string{
-		"us-south":         "https://us-south.atracker.cloud.ibm.com",         // The server for IBM Cloud Activity Tracker Service in the us-south region.
+		"us-south": "https://us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the us-south region.
 		"private.us-south": "https://private.us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the us-south region.
-		"us-east":          "https://us-east.atracker.cloud.ibm.com",          // The server for IBM Cloud Activity Tracker Service in the us-east region.
-		"private.us-east":  "https://private.us-east.atracker.cloud.ibm.com",  // The server for IBM Cloud Activity Tracker Service in the us-east region.
-		"eu-de":            "https://eu-de.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service in the eu-de region.
-		"private.eu-de":    "https://private.eu-de.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service in the eu-de region.
-		"eu-gb":            "https://eu-gb.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service in the eu-gb region.
-		"private.eu-gb":    "https://private.eu-gb.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service in the eu-gb region.
-		"eu-es":            "https://eu-es.atracker.cloud.ibm.com",            // The server for IBM Cloud Activity Tracker Service in the eu-es region.
-		"private.eu-es":    "https://private.eu-es.atracker.cloud.ibm.com",    // The server for IBM Cloud Activity Tracker Service in the eu-es region.
-		"eu-fr2":           "https://eu-fr2.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the eu-fr2 region.
-		"private.eu-fr2":   "https://private.eu-fr2.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the eu-fr2 region.
-		"au-syd":           "https://au-syd.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the au-syd region.
-		"private.au-syd":   "https://private.au-syd.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the au-syd region.
-		"ca-tor":           "https://ca-tor.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the ca-tor region.
-		"private.ca-tor":   "https://private.ca-tor.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the ca-tor region.
-		"br-sao":           "https://br-sao.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the br-sao region.
-		"private.br-sao":   "https://private.br-sao.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the br-sao region.
-		"jp-tok":           "https://jp-tok.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the jp-tok region.
-		"private.jp-tok":   "https://private.jp-tok.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the jp-tok region.
-		"jp-osa":           "https://jp-osa.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the jp-osa region.
-		"private.jp-osa":   "https://private.jp-osa.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the jp-osa region.
-		"in-che":           "https://in-che.atracker.cloud.ibm.com",           // The server for IBM Cloud Activity Tracker Service in the in-che region.
-		"private.in-che":   "https://private.in-che.atracker.cloud.ibm.com",   // The server for IBM Cloud Activity Tracker Service in the in-che region.
+		"us-east": "https://us-east.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the us-east region.
+		"private.us-east": "https://private.us-east.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the us-east region.
+		"eu-de": "https://eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-de region.
+		"private.eu-de": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-de region.
+		"eu-gb": "https://eu-gb.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-gb region.
+		"private.eu-gb": "https://private.eu-gb.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-gb region.
+		"eu-es": "https://eu-es.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-es region.
+		"private.eu-es": "https://private.eu-es.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the eu-es region.
+		"au-syd": "https://au-syd.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the au-syd region.
+		"private.au-syd": "https://private.au-syd.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service in the au-syd region.
+		"ca-tor": "https://us-east.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for ca-tor points to the us-east region.
+		"private.ca-tor": "https://private.us-east.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for ca-tor points to the us-east region.
+		"br-sao": "https://us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for br-sao points to the us-south region.
+		"private.br-sao": "https://private.us-south.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for br-sao points to the us-south region.
+		"eu-fr2": "https://eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for eu-fr2 points to the eu-de region.
+		"private.eu-fr2": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for eu-fr2 points to the eu-de region.
+		"jp-tok": "https://eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for jp-tok points to the eu-de region.
+		"private.jp-tok": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for jp-tok points to the eu-de region.
+		"jp-osa": "https://eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for jp-osa points to the eu-de region.
+		"private.jp-osa": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for jp-osa points to the eu-de region.
+		"in-che": "https://eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for in-che points to the eu-de region.
+		"private.in-che": "https://private.eu-de.atracker.cloud.ibm.com", // The server for IBM Cloud Activity Tracker Service for in-che points to the eu-de region.
 	}
 
 	if url, ok := endpoints[region]; ok {
@@ -244,6 +244,9 @@ func (atracker *AtrackerV2) CreateTargetWithContext(ctx context.Context, createT
 	}
 	if createTargetOptions.EventstreamsEndpoint != nil {
 		body["eventstreams_endpoint"] = createTargetOptions.EventstreamsEndpoint
+	}
+	if createTargetOptions.CloudlogsEndpoint != nil {
+		body["cloudlogs_endpoint"] = createTargetOptions.CloudlogsEndpoint
 	}
 	if createTargetOptions.Region != nil {
 		body["region"] = createTargetOptions.Region
@@ -442,6 +445,9 @@ func (atracker *AtrackerV2) ReplaceTargetWithContext(ctx context.Context, replac
 	}
 	if replaceTargetOptions.EventstreamsEndpoint != nil {
 		body["eventstreams_endpoint"] = replaceTargetOptions.EventstreamsEndpoint
+	}
+	if replaceTargetOptions.CloudlogsEndpoint != nil {
+		body["cloudlogs_endpoint"] = replaceTargetOptions.CloudlogsEndpoint
 	}
 	_, err = builder.SetBodyContentJSON(body)
 	if err != nil {
@@ -1022,6 +1028,64 @@ func (atracker *AtrackerV2) PutSettingsWithContext(ctx context.Context, putSetti
 	return
 }
 
+// CloudLogsEndpoint : Property values for the IBM Cloud Logs endpoint in responses.
+type CloudLogsEndpoint struct {
+	// The CRN of the IBM Cloud Logs instance.
+	TargetCRN *string `json:"target_crn" validate:"required"`
+
+	// The host name of the IBM Cloud Logs endpoint.
+	Endpoint *string `json:"endpoint" validate:"required"`
+}
+
+// UnmarshalCloudLogsEndpoint unmarshals an instance of CloudLogsEndpoint from the specified map of raw messages.
+func UnmarshalCloudLogsEndpoint(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(CloudLogsEndpoint)
+	err = core.UnmarshalPrimitive(m, "target_crn", &obj.TargetCRN)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "endpoint", &obj.Endpoint)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
+// CloudLogsEndpointPrototype : Property values for an IBM Cloud Logs endpoint in requests.
+type CloudLogsEndpointPrototype struct {
+	// The CRN of the IBM Cloud Logs instance.
+	TargetCRN *string `json:"target_crn" validate:"required"`
+
+	// The host name of the IBM Cloud Logs endpoint.
+	Endpoint *string `json:"endpoint" validate:"required"`
+}
+
+// NewCloudLogsEndpointPrototype : Instantiate CloudLogsEndpointPrototype (Generic Model Constructor)
+func (*AtrackerV2) NewCloudLogsEndpointPrototype(targetCRN string, endpoint string) (_model *CloudLogsEndpointPrototype, err error) {
+	_model = &CloudLogsEndpointPrototype{
+		TargetCRN: core.StringPtr(targetCRN),
+		Endpoint: core.StringPtr(endpoint),
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	return
+}
+
+// UnmarshalCloudLogsEndpointPrototype unmarshals an instance of CloudLogsEndpointPrototype from the specified map of raw messages.
+func UnmarshalCloudLogsEndpointPrototype(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(CloudLogsEndpointPrototype)
+	err = core.UnmarshalPrimitive(m, "target_crn", &obj.TargetCRN)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "endpoint", &obj.Endpoint)
+	if err != nil {
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // CosEndpoint : Property values for a Cloud Object Storage Endpoint in responses.
 type CosEndpoint struct {
 	// The host name of the Cloud Object Storage endpoint.
@@ -1084,9 +1148,9 @@ type CosEndpointPrototype struct {
 // NewCosEndpointPrototype : Instantiate CosEndpointPrototype (Generic Model Constructor)
 func (*AtrackerV2) NewCosEndpointPrototype(endpoint string, targetCRN string, bucket string) (_model *CosEndpointPrototype, err error) {
 	_model = &CosEndpointPrototype{
-		Endpoint:  core.StringPtr(endpoint),
+		Endpoint: core.StringPtr(endpoint),
 		TargetCRN: core.StringPtr(targetCRN),
-		Bucket:    core.StringPtr(bucket),
+		Bucket: core.StringPtr(bucket),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -1135,7 +1199,7 @@ type CreateRouteOptions struct {
 // NewCreateRouteOptions : Instantiate CreateRouteOptions
 func (*AtrackerV2) NewCreateRouteOptions(name string, rules []RulePrototype) *CreateRouteOptions {
 	return &CreateRouteOptions{
-		Name:  core.StringPtr(name),
+		Name: core.StringPtr(name),
 		Rules: rules,
 	}
 }
@@ -1164,8 +1228,8 @@ type CreateTargetOptions struct {
 	// than `(space) - . _ :`. Do not include any personal identifying information (PII) in any resource names.
 	Name *string `json:"name" validate:"required"`
 
-	// The type of the target. It can be cloud_object_storage, logdna or event_streams. Based on this type you must include
-	// cos_endpoint, logdna_endpoint or eventstreams_endpoint.
+	// The type of the target. It can be cloud_object_storage, logdna, event_streams, or cloud_logs. Based on this type you
+	// must include cos_endpoint, logdna_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
 	TargetType *string `json:"target_type" validate:"required"`
 
 	// Property values for a Cloud Object Storage Endpoint in requests.
@@ -1177,6 +1241,9 @@ type CreateTargetOptions struct {
 	// Property values for an Event Streams Endpoint in requests.
 	EventstreamsEndpoint *EventstreamsEndpointPrototype `json:"eventstreams_endpoint,omitempty"`
 
+	// Property values for an IBM Cloud Logs endpoint in requests.
+	CloudlogsEndpoint *CloudLogsEndpointPrototype `json:"cloudlogs_endpoint,omitempty"`
+
 	// Include this optional field if you want to create a target in a different region other than the one you are
 	// connected.
 	Region *string `json:"region,omitempty"`
@@ -1186,18 +1253,19 @@ type CreateTargetOptions struct {
 }
 
 // Constants associated with the CreateTargetOptions.TargetType property.
-// The type of the target. It can be cloud_object_storage, logdna or event_streams. Based on this type you must include
-// cos_endpoint, logdna_endpoint or eventstreams_endpoint.
+// The type of the target. It can be cloud_object_storage, logdna, event_streams, or cloud_logs. Based on this type you
+// must include cos_endpoint, logdna_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
 const (
+	CreateTargetOptionsTargetTypeCloudLogsConst = "cloud_logs"
 	CreateTargetOptionsTargetTypeCloudObjectStorageConst = "cloud_object_storage"
-	CreateTargetOptionsTargetTypeEventStreamsConst       = "event_streams"
-	CreateTargetOptionsTargetTypeLogdnaConst             = "logdna"
+	CreateTargetOptionsTargetTypeEventStreamsConst = "event_streams"
+	CreateTargetOptionsTargetTypeLogdnaConst = "logdna"
 )
 
 // NewCreateTargetOptions : Instantiate CreateTargetOptions
 func (*AtrackerV2) NewCreateTargetOptions(name string, targetType string) *CreateTargetOptions {
 	return &CreateTargetOptions{
-		Name:       core.StringPtr(name),
+		Name: core.StringPtr(name),
 		TargetType: core.StringPtr(targetType),
 	}
 }
@@ -1229,6 +1297,12 @@ func (_options *CreateTargetOptions) SetLogdnaEndpoint(logdnaEndpoint *LogdnaEnd
 // SetEventstreamsEndpoint : Allow user to set EventstreamsEndpoint
 func (_options *CreateTargetOptions) SetEventstreamsEndpoint(eventstreamsEndpoint *EventstreamsEndpointPrototype) *CreateTargetOptions {
 	_options.EventstreamsEndpoint = eventstreamsEndpoint
+	return _options
+}
+
+// SetCloudlogsEndpoint : Allow user to set CloudlogsEndpoint
+func (_options *CreateTargetOptions) SetCloudlogsEndpoint(cloudlogsEndpoint *CloudLogsEndpointPrototype) *CreateTargetOptions {
+	_options.CloudlogsEndpoint = cloudlogsEndpoint
 	return _options
 }
 
@@ -1357,9 +1431,9 @@ type EventstreamsEndpointPrototype struct {
 func (*AtrackerV2) NewEventstreamsEndpointPrototype(targetCRN string, brokers []string, topic string, apiKey string) (_model *EventstreamsEndpointPrototype, err error) {
 	_model = &EventstreamsEndpointPrototype{
 		TargetCRN: core.StringPtr(targetCRN),
-		Brokers:   brokers,
-		Topic:     core.StringPtr(topic),
-		APIKey:    core.StringPtr(apiKey),
+		Brokers: brokers,
+		Topic: core.StringPtr(topic),
+		APIKey: core.StringPtr(apiKey),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
 	return
@@ -1535,7 +1609,7 @@ type LogdnaEndpointPrototype struct {
 // NewLogdnaEndpointPrototype : Instantiate LogdnaEndpointPrototype (Generic Model Constructor)
 func (*AtrackerV2) NewLogdnaEndpointPrototype(targetCRN string, ingestionKey string) (_model *LogdnaEndpointPrototype, err error) {
 	_model = &LogdnaEndpointPrototype{
-		TargetCRN:    core.StringPtr(targetCRN),
+		TargetCRN: core.StringPtr(targetCRN),
 		IngestionKey: core.StringPtr(ingestionKey),
 	}
 	err = core.ValidateStruct(_model, "required parameters")
@@ -1582,7 +1656,7 @@ type PutSettingsOptions struct {
 // NewPutSettingsOptions : Instantiate PutSettingsOptions
 func (*AtrackerV2) NewPutSettingsOptions(metadataRegionPrimary string, privateAPIEndpointOnly bool) *PutSettingsOptions {
 	return &PutSettingsOptions{
-		MetadataRegionPrimary:  core.StringPtr(metadataRegionPrimary),
+		MetadataRegionPrimary: core.StringPtr(metadataRegionPrimary),
 		PrivateAPIEndpointOnly: core.BoolPtr(privateAPIEndpointOnly),
 	}
 }
@@ -1642,8 +1716,8 @@ type ReplaceRouteOptions struct {
 // NewReplaceRouteOptions : Instantiate ReplaceRouteOptions
 func (*AtrackerV2) NewReplaceRouteOptions(id string, name string, rules []RulePrototype) *ReplaceRouteOptions {
 	return &ReplaceRouteOptions{
-		ID:    core.StringPtr(id),
-		Name:  core.StringPtr(name),
+		ID: core.StringPtr(id),
+		Name: core.StringPtr(name),
 		Rules: rules,
 	}
 }
@@ -1690,6 +1764,9 @@ type ReplaceTargetOptions struct {
 	// Property values for an Event Streams Endpoint in requests.
 	EventstreamsEndpoint *EventstreamsEndpointPrototype `json:"eventstreams_endpoint,omitempty"`
 
+	// Property values for an IBM Cloud Logs endpoint in requests.
+	CloudlogsEndpoint *CloudLogsEndpointPrototype `json:"cloudlogs_endpoint,omitempty"`
+
 	// Allows users to set headers on API requests
 	Headers map[string]string
 }
@@ -1728,6 +1805,12 @@ func (_options *ReplaceTargetOptions) SetLogdnaEndpoint(logdnaEndpoint *LogdnaEn
 // SetEventstreamsEndpoint : Allow user to set EventstreamsEndpoint
 func (_options *ReplaceTargetOptions) SetEventstreamsEndpoint(eventstreamsEndpoint *EventstreamsEndpointPrototype) *ReplaceTargetOptions {
 	_options.EventstreamsEndpoint = eventstreamsEndpoint
+	return _options
+}
+
+// SetCloudlogsEndpoint : Allow user to set CloudlogsEndpoint
+func (_options *ReplaceTargetOptions) SetCloudlogsEndpoint(cloudlogsEndpoint *CloudLogsEndpointPrototype) *ReplaceTargetOptions {
+	_options.CloudlogsEndpoint = cloudlogsEndpoint
 	return _options
 }
 
@@ -1977,6 +2060,9 @@ type Target struct {
 	// Property values for the Event Streams Endpoint in responses.
 	EventstreamsEndpoint *EventstreamsEndpoint `json:"eventstreams_endpoint,omitempty"`
 
+	// Property values for the IBM Cloud Logs endpoint in responses.
+	CloudlogsEndpoint *CloudLogsEndpoint `json:"cloudlogs_endpoint,omitempty"`
+
 	// The status of the write attempt to the target with the provided endpoint parameters.
 	WriteStatus *WriteStatus `json:"write_status" validate:"required"`
 
@@ -1996,9 +2082,10 @@ type Target struct {
 // Constants associated with the Target.TargetType property.
 // The type of the target.
 const (
+	TargetTargetTypeCloudLogsConst = "cloud_logs"
 	TargetTargetTypeCloudObjectStorageConst = "cloud_object_storage"
-	TargetTargetTypeEventStreamsConst       = "event_streams"
-	TargetTargetTypeLogdnaConst             = "logdna"
+	TargetTargetTypeEventStreamsConst = "event_streams"
+	TargetTargetTypeLogdnaConst = "logdna"
 )
 
 // UnmarshalTarget unmarshals an instance of Target from the specified map of raw messages.
@@ -2033,6 +2120,10 @@ func UnmarshalTarget(m map[string]json.RawMessage, result interface{}) (err erro
 		return
 	}
 	err = core.UnmarshalModel(m, "eventstreams_endpoint", &obj.EventstreamsEndpoint, UnmarshalEventstreamsEndpoint)
+	if err != nil {
+		return
+	}
+	err = core.UnmarshalModel(m, "cloudlogs_endpoint", &obj.CloudlogsEndpoint, UnmarshalCloudLogsEndpoint)
 	if err != nil {
 		return
 	}

--- a/atrackerv2/atracker_v2_examples_test.go
+++ b/atrackerv2/atracker_v2_examples_test.go
@@ -2,7 +2,7 @@
 // +build examples
 
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atrackerv2/atracker_v2_examples_test.go
+++ b/atrackerv2/atracker_v2_examples_test.go
@@ -1,7 +1,8 @@
 //go:build examples
+// +build examples
 
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+//
 // This file provides an example of how to use the atracker service.
 //
 // The following configuration properties are assumed to be defined:
@@ -40,6 +42,7 @@ import (
 // These configuration properties can be exported as environment variables, or stored
 // in a configuration file and then:
 // export IBM_CREDENTIALS_FILE=<name of configuration file>
+//
 var _ = Describe(`AtrackerV2 Examples Tests`, func() {
 
 	const externalConfigFile = "../atracker_v2.env"
@@ -142,8 +145,7 @@ var _ = Describe(`AtrackerV2 Examples Tests`, func() {
 			// begin-create_route
 
 			rulePrototypeModel := &atrackerv2.RulePrototype{
-				TargetIds: []string{targetIDLink},
-				Locations: []string{"us-south"},
+				TargetIds: []string{"c3af557f-fb0e-4476-85c3-0889e7fe7bc4"},
 			}
 
 			createRouteOptions := atrackerService.NewCreateRouteOptions(
@@ -301,8 +303,7 @@ var _ = Describe(`AtrackerV2 Examples Tests`, func() {
 			// begin-replace_route
 
 			rulePrototypeModel := &atrackerv2.RulePrototype{
-				TargetIds: []string{targetIDLink},
-				Locations: []string{"us-south"},
+				TargetIds: []string{"c3af557f-fb0e-4476-85c3-0889e7fe7bc4"},
 			}
 
 			replaceRouteOptions := atrackerService.NewReplaceRouteOptions(
@@ -368,28 +369,6 @@ var _ = Describe(`AtrackerV2 Examples Tests`, func() {
 			Expect(settings).ToNot(BeNil())
 
 		})
-
-		It(`DeleteRoute request example`, func() {
-			// begin-delete_route
-
-			deleteRouteOptions := atrackerService.NewDeleteRouteOptions(
-				routeIDLink,
-			)
-
-			response, err := atrackerService.DeleteRoute(deleteRouteOptions)
-			if err != nil {
-				panic(err)
-			}
-			if response.StatusCode != 204 {
-				fmt.Printf("\nUnexpected response status code received from DeleteRoute(): %d\n", response.StatusCode)
-			}
-
-			// end-delete_route
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(204))
-
-		})
 		It(`DeleteTarget request example`, func() {
 			fmt.Println("\nDeleteTarget() result:")
 			// begin-delete_target
@@ -410,6 +389,27 @@ var _ = Describe(`AtrackerV2 Examples Tests`, func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(warningReport).ToNot(BeNil())
+
+		})
+		It(`DeleteRoute request example`, func() {
+			// begin-delete_route
+
+			deleteRouteOptions := atrackerService.NewDeleteRouteOptions(
+				routeIDLink,
+			)
+
+			response, err := atrackerService.DeleteRoute(deleteRouteOptions)
+			if err != nil {
+				panic(err)
+			}
+			if response.StatusCode != 204 {
+				fmt.Printf("\nUnexpected response status code received from DeleteRoute(): %d\n", response.StatusCode)
+			}
+
+			// end-delete_route
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
 
 		})
 	})

--- a/atrackerv2/atracker_v2_examples_test.go
+++ b/atrackerv2/atracker_v2_examples_test.go
@@ -1,6 +1,7 @@
 //go:build examples
 // +build examples
 
+
 /**
  * (C) Copyright IBM Corp. 2024.
  *

--- a/atrackerv2/atracker_v2_integration_test.go
+++ b/atrackerv2/atracker_v2_integration_test.go
@@ -1,7 +1,8 @@
 //go:build integration
+// +build integration
 
 /**
- * (C) Copyright IBM Corp. 2023.
+ * (C) Copyright IBM Corp. 2022.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,7 +45,7 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 
 	const notFoundTargetID = "ffffffff-1111-1111-1111-111111111111"
 
-	const notFoundRouteID = "ffffffff-2222-2222-2222-222222222222"
+	const notFoundRouteID =  "ffffffff-2222-2222-2222-222222222222"
 
 	const badTargetType = "bad_target_type"
 
@@ -178,14 +179,14 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 
 			eventstreamsEndpointPrototypeModel := &atrackerv2.EventstreamsEndpointPrototype{
 				TargetCRN: core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
-				Topic:     core.StringPtr("my-test-topic"),
-				Brokers:   []string{"kafka-x:9094"},
-				APIKey:    core.StringPtr("xxxxxxxxxxx"),
+				Topic: core.StringPtr("my-test-topic"),
+				Brokers: []string{"kafka-x:9094"},
+				APIKey: core.StringPtr("xxxxxxxxxxx"),
 			}
 
 			createTargetOptions := &atrackerv2.CreateTargetOptions{
-				Name:                 core.StringPtr("my-ies-target"),
-				TargetType:           core.StringPtr("event_streams"),
+				Name:           core.StringPtr("my-ies-target"),
+				TargetType:     core.StringPtr("event_streams"),
 				EventstreamsEndpoint: eventstreamsEndpointPrototypeModel,
 			}
 
@@ -420,14 +421,14 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 
 			eventstreamsEndpointPrototypeModel := &atrackerv2.EventstreamsEndpointPrototype{
 				TargetCRN: core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
-				Topic:     core.StringPtr("my-test-topic"),
-				Brokers:   []string{"kafka-x:9094"},
-				APIKey:    core.StringPtr("xxxxxxxxxxxxx"),
+				Topic: core.StringPtr("my-test-topic"),
+				Brokers: []string{"kafka-x:9094"},
+				APIKey: core.StringPtr("xxxxxxxxxxxxx"),
 			}
 
 			replaceTargetOptions := &atrackerv2.ReplaceTargetOptions{
-				ID:                   &targetIDLink3,
-				Name:                 core.StringPtr("my-ies-target-modified"),
+				ID:             &targetIDLink3,
+				Name:           core.StringPtr("my-ies-target-modified"),
 				EventstreamsEndpoint: eventstreamsEndpointPrototypeModel,
 			}
 
@@ -436,6 +437,7 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(target).ToNot(BeNil())
 		})
+
 
 		It(`Returns 404 when target id is not found`, func() {
 

--- a/atrackerv2/atracker_v2_integration_test.go
+++ b/atrackerv2/atracker_v2_integration_test.go
@@ -2,7 +2,7 @@
 // +build integration
 
 /**
- * (C) Copyright IBM Corp. 2022.
+ * (C) Copyright IBM Corp. 2024.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atrackerv2/atracker_v2_integration_test.go
+++ b/atrackerv2/atracker_v2_integration_test.go
@@ -1,6 +1,7 @@
 //go:build integration
 // +build integration
 
+
 /**
  * (C) Copyright IBM Corp. 2024.
  *

--- a/atrackerv2/atracker_v2_test.go
+++ b/atrackerv2/atracker_v2_test.go
@@ -66,13 +66,14 @@ var _ = Describe(`AtrackerV2`, func() {
 		Context(`Using external config, construct service client instances`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ATRACKER_URL":       "https://atrackerv2/api",
+				"ATRACKER_URL": "https://atrackerv2/api",
 				"ATRACKER_AUTH_TYPE": "noauth",
 			}
 
 			It(`Create service client using external config successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{})
+				atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{
+				})
 				Expect(atrackerService).ToNot(BeNil())
 				Expect(serviceErr).To(BeNil())
 				ClearTestEnvironment(testEnvironment)
@@ -101,7 +102,8 @@ var _ = Describe(`AtrackerV2`, func() {
 			})
 			It(`Create service client using external config and set url programatically successfully`, func() {
 				SetTestEnvironment(testEnvironment)
-				atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{})
+				atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{
+				})
 				err := atrackerService.SetServiceURL("https://testService/api")
 				Expect(err).To(BeNil())
 				Expect(atrackerService).ToNot(BeNil())
@@ -119,12 +121,13 @@ var _ = Describe(`AtrackerV2`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid Auth`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ATRACKER_URL":       "https://atrackerv2/api",
+				"ATRACKER_URL": "https://atrackerv2/api",
 				"ATRACKER_AUTH_TYPE": "someOtherAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
-			atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{})
+			atrackerService, serviceErr := atrackerv2.NewAtrackerV2UsingExternalConfig(&atrackerv2.AtrackerV2Options{
+			})
 
 			It(`Instantiate service client with error`, func() {
 				Expect(atrackerService).To(BeNil())
@@ -135,7 +138,7 @@ var _ = Describe(`AtrackerV2`, func() {
 		Context(`Using external config, construct service client instances with error: Invalid URL`, func() {
 			// Map containing environment variables used in testing.
 			var testEnvironment = map[string]string{
-				"ATRACKER_AUTH_TYPE": "NOAuth",
+				"ATRACKER_AUTH_TYPE":   "NOAuth",
 			}
 
 			SetTestEnvironment(testEnvironment)
@@ -194,14 +197,6 @@ var _ = Describe(`AtrackerV2`, func() {
 			Expect(url).To(Equal("https://private.eu-es.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
-			url, err = atrackerv2.GetServiceURLForRegion("eu-fr2")
-			Expect(url).To(Equal("https://eu-fr2.atracker.cloud.ibm.com"))
-			Expect(err).To(BeNil())
-
-			url, err = atrackerv2.GetServiceURLForRegion("private.eu-fr2")
-			Expect(url).To(Equal("https://private.eu-fr2.atracker.cloud.ibm.com"))
-			Expect(err).To(BeNil())
-
 			url, err = atrackerv2.GetServiceURLForRegion("au-syd")
 			Expect(url).To(Equal("https://au-syd.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
@@ -211,43 +206,51 @@ var _ = Describe(`AtrackerV2`, func() {
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("ca-tor")
-			Expect(url).To(Equal("https://ca-tor.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://us-east.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.ca-tor")
-			Expect(url).To(Equal("https://private.ca-tor.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.us-east.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("br-sao")
-			Expect(url).To(Equal("https://br-sao.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://us-south.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.br-sao")
-			Expect(url).To(Equal("https://private.br-sao.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.us-south.atracker.cloud.ibm.com"))
+			Expect(err).To(BeNil())
+
+			url, err = atrackerv2.GetServiceURLForRegion("eu-fr2")
+			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
+			Expect(err).To(BeNil())
+
+			url, err = atrackerv2.GetServiceURLForRegion("private.eu-fr2")
+			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("jp-tok")
-			Expect(url).To(Equal("https://jp-tok.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.jp-tok")
-			Expect(url).To(Equal("https://private.jp-tok.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("jp-osa")
-			Expect(url).To(Equal("https://jp-osa.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.jp-osa")
-			Expect(url).To(Equal("https://private.jp-osa.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("in-che")
-			Expect(url).To(Equal("https://in-che.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("private.in-che")
-			Expect(url).To(Equal("https://private.in-che.atracker.cloud.ibm.com"))
+			Expect(url).To(Equal("https://private.eu-de.atracker.cloud.ibm.com"))
 			Expect(err).To(BeNil())
 
 			url, err = atrackerv2.GetServiceURLForRegion("INVALID_REGION")
@@ -299,6 +302,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsModel := new(atrackerv2.CreateTargetOptions)
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
@@ -306,6 +314,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
 				createTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
@@ -359,7 +368,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke CreateTarget successfully with retries`, func() {
@@ -391,6 +400,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsModel := new(atrackerv2.CreateTargetOptions)
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
@@ -398,6 +412,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
 				createTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -454,7 +469,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke CreateTarget successfully`, func() {
@@ -491,6 +506,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsModel := new(atrackerv2.CreateTargetOptions)
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
@@ -498,6 +518,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
 				createTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -536,6 +557,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsModel := new(atrackerv2.CreateTargetOptions)
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
@@ -543,6 +569,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
 				createTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
@@ -602,6 +629,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsModel := new(atrackerv2.CreateTargetOptions)
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
@@ -609,6 +641,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
 				createTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
@@ -689,7 +722,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
+					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
 				}))
 			})
 			It(`Invoke ListTargets successfully with retries`, func() {
@@ -744,7 +777,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
+					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
 				}))
 			})
 			It(`Invoke ListTargets successfully`, func() {
@@ -895,7 +928,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke GetTarget successfully with retries`, func() {
@@ -949,7 +982,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke GetTarget successfully`, func() {
@@ -1088,6 +1121,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the ReplaceTargetOptions model
 				replaceTargetOptionsModel := new(atrackerv2.ReplaceTargetOptions)
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
@@ -1095,6 +1133,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Expect response parsing to fail since we are receiving a text/plain response
 				result, response, operationErr := atrackerService.ReplaceTarget(replaceTargetOptionsModel)
@@ -1147,7 +1186,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ReplaceTarget successfully with retries`, func() {
@@ -1179,6 +1218,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the ReplaceTargetOptions model
 				replaceTargetOptionsModel := new(atrackerv2.ReplaceTargetOptions)
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
@@ -1186,6 +1230,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with a Context to test a timeout error
@@ -1241,7 +1286,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ReplaceTarget successfully`, func() {
@@ -1278,6 +1323,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the ReplaceTargetOptions model
 				replaceTargetOptionsModel := new(atrackerv2.ReplaceTargetOptions)
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
@@ -1285,6 +1335,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation with valid options model (positive test)
@@ -1322,6 +1373,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the ReplaceTargetOptions model
 				replaceTargetOptionsModel := new(atrackerv2.ReplaceTargetOptions)
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
@@ -1329,6 +1385,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 				// Invoke operation with empty URL (negative test)
 				err := atrackerService.SetServiceURL("")
@@ -1387,6 +1444,11 @@ var _ = Describe(`AtrackerV2`, func() {
 				eventstreamsEndpointPrototypeModel.Topic = core.StringPtr("my-topic")
 				eventstreamsEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+
 				// Construct an instance of the ReplaceTargetOptions model
 				replaceTargetOptionsModel := new(atrackerv2.ReplaceTargetOptions)
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
@@ -1394,6 +1456,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
 				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
+				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
 
 				// Invoke operation
@@ -1683,7 +1746,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ValidateTarget successfully with retries`, func() {
@@ -1737,7 +1800,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx"}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "endpoint": "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ValidateTarget successfully`, func() {
@@ -3336,6 +3399,13 @@ var _ = Describe(`AtrackerV2`, func() {
 				URL:           "http://atrackerv2modelgenerator.com",
 				Authenticator: &core.NoAuthAuthenticator{},
 			})
+			It(`Invoke NewCloudLogsEndpointPrototype successfully`, func() {
+				targetCRN := "crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
+				endpoint := "22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com"
+				_model, err := atrackerService.NewCloudLogsEndpointPrototype(targetCRN, endpoint)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
 			It(`Invoke NewCosEndpointPrototype successfully`, func() {
 				endpoint := "s3.private.us-east.cloud-object-storage.appdomain.cloud"
 				targetCRN := "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
@@ -3400,6 +3470,14 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(eventstreamsEndpointPrototypeModel.Topic).To(Equal(core.StringPtr("my-topic")))
 				Expect(eventstreamsEndpointPrototypeModel.APIKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				Expect(cloudLogsEndpointPrototypeModel).ToNot(BeNil())
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+				Expect(cloudLogsEndpointPrototypeModel.TargetCRN).To(Equal(core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")))
+				Expect(cloudLogsEndpointPrototypeModel.Endpoint).To(Equal(core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")))
+
 				// Construct an instance of the CreateTargetOptions model
 				createTargetOptionsName := "my-cos-target"
 				createTargetOptionsTargetType := "cloud_object_storage"
@@ -3409,6 +3487,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.SetCosEndpoint(cosEndpointPrototypeModel)
 				createTargetOptionsModel.SetLogdnaEndpoint(logdnaEndpointPrototypeModel)
 				createTargetOptionsModel.SetEventstreamsEndpoint(eventstreamsEndpointPrototypeModel)
+				createTargetOptionsModel.SetCloudlogsEndpoint(cloudLogsEndpointPrototypeModel)
 				createTargetOptionsModel.SetRegion("us-south")
 				createTargetOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(createTargetOptionsModel).ToNot(BeNil())
@@ -3417,6 +3496,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(createTargetOptionsModel.CosEndpoint).To(Equal(cosEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.LogdnaEndpoint).To(Equal(logdnaEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.EventstreamsEndpoint).To(Equal(eventstreamsEndpointPrototypeModel))
+				Expect(createTargetOptionsModel.CloudlogsEndpoint).To(Equal(cloudLogsEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.Region).To(Equal(core.StringPtr("us-south")))
 				Expect(createTargetOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
@@ -3577,6 +3657,14 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(eventstreamsEndpointPrototypeModel.Topic).To(Equal(core.StringPtr("my-topic")))
 				Expect(eventstreamsEndpointPrototypeModel.APIKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
 
+				// Construct an instance of the CloudLogsEndpointPrototype model
+				cloudLogsEndpointPrototypeModel := new(atrackerv2.CloudLogsEndpointPrototype)
+				Expect(cloudLogsEndpointPrototypeModel).ToNot(BeNil())
+				cloudLogsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
+				cloudLogsEndpointPrototypeModel.Endpoint = core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")
+				Expect(cloudLogsEndpointPrototypeModel.TargetCRN).To(Equal(core.StringPtr("crn:v1:bluemix:public:logs:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")))
+				Expect(cloudLogsEndpointPrototypeModel.Endpoint).To(Equal(core.StringPtr("22222222-2222-2222-2222-222222222222.api.eu-es.logs.cloud.ibm.com")))
+
 				// Construct an instance of the ReplaceTargetOptions model
 				id := "testString"
 				replaceTargetOptionsModel := atrackerService.NewReplaceTargetOptions(id)
@@ -3585,6 +3673,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.SetCosEndpoint(cosEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetLogdnaEndpoint(logdnaEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetEventstreamsEndpoint(eventstreamsEndpointPrototypeModel)
+				replaceTargetOptionsModel.SetCloudlogsEndpoint(cloudLogsEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
 				Expect(replaceTargetOptionsModel).ToNot(BeNil())
 				Expect(replaceTargetOptionsModel.ID).To(Equal(core.StringPtr("testString")))
@@ -3592,6 +3681,7 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(replaceTargetOptionsModel.CosEndpoint).To(Equal(cosEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.LogdnaEndpoint).To(Equal(logdnaEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.EventstreamsEndpoint).To(Equal(eventstreamsEndpointPrototypeModel))
+				Expect(replaceTargetOptionsModel.CloudlogsEndpoint).To(Equal(cloudLogsEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
 			It(`Invoke NewRulePrototype successfully`, func() {


### PR DESCRIPTION
## PR summary
Add support for a new ATracker target type (cloud-logs) and its endpoint fields


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
ATracker will support a new target type (cloud-logs) in addition to the existing target types

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Unit tests results:

```
veenarao$ go test
go: downloading github.com/onsi/gomega v1.31.1
Running Suite: AtrackerV2 Suite
===============================
Random Seed: 1712004023
Will run 94 of 94 specs

••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 94 of 94 Specs in 4.006 seconds
SUCCESS! -- 94 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok  	github.com/IBM/platform-services-go-sdk/atrackerv2	5.064s

```

Integration test results:

```
veenarao$ go test github.com/IBM/platform-services-go-sdk/atrackerv2 -tags="integration" -v
=== RUN   TestAtrackerV2
Running Suite: AtrackerV2 Suite
===============================
Random Seed: 1712004111
Will run 137 of 137 specs

••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
------------------------------
• [SLOW TEST:7.479 seconds]
AtrackerV2 Integration Tests
/Users/veenarao/go/src/github.com/IBM/platform-services-go-sdk/atrackerv2/atracker_v2_integration_test.go:42
  DeleteTarget - Delete a target
  /Users/veenarao/go/src/github.com/IBM/platform-services-go-sdk/atrackerv2/atracker_v2_integration_test.go:756
    DeleteTarget(deleteTargetOptions *DeleteTargetOptions)
    /Users/veenarao/go/src/github.com/IBM/platform-services-go-sdk/atrackerv2/atracker_v2_integration_test.go:804
------------------------------

Ran 137 of 137 Specs in 16.669 seconds
SUCCESS! -- 137 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestAtrackerV2 (16.71s)
PASS
ok  	github.com/IBM/platform-services-go-sdk/atrackerv2	17.733s
```
