### PR TITLE
fix(Usage Reports): re-add offset to SnapshotListNext

### DIFF
--- a/usagereportsv4/usage_reports_v4.go
+++ b/usagereportsv4/usage_reports_v4.go
@@ -1094,6 +1094,101 @@ func (usageReports *UsageReportsV4) DeleteReportsSnapshotConfigWithContext(ctx c
 	return
 }
 
+// ValidateReportsSnapshotConfig : Verify billing to COS authorization
+// Verify billing service to COS bucket authorization for the given account_id. If COS bucket information is not
+// provided, COS bucket information is retrieved from the configuration file.
+func (usageReports *UsageReportsV4) ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptions *ValidateReportsSnapshotConfigOptions) (result *SnapshotConfigValidateResponse, response *core.DetailedResponse, err error) {
+	result, response, err = usageReports.ValidateReportsSnapshotConfigWithContext(context.Background(), validateReportsSnapshotConfigOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// ValidateReportsSnapshotConfigWithContext is an alternate form of the ValidateReportsSnapshotConfig method which supports a Context parameter
+func (usageReports *UsageReportsV4) ValidateReportsSnapshotConfigWithContext(ctx context.Context, validateReportsSnapshotConfigOptions *ValidateReportsSnapshotConfigOptions) (result *SnapshotConfigValidateResponse, response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(validateReportsSnapshotConfigOptions, "validateReportsSnapshotConfigOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(validateReportsSnapshotConfigOptions, "validateReportsSnapshotConfigOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.POST)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = usageReports.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(usageReports.Service.Options.URL, `/v1/billing-reports-snapshot-config/validate`, nil)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range validateReportsSnapshotConfigOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("usage_reports", "V4", "ValidateReportsSnapshotConfig")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if validateReportsSnapshotConfigOptions.AccountID != nil {
+		body["account_id"] = validateReportsSnapshotConfigOptions.AccountID
+	}
+	if validateReportsSnapshotConfigOptions.Interval != nil {
+		body["interval"] = validateReportsSnapshotConfigOptions.Interval
+	}
+	if validateReportsSnapshotConfigOptions.CosBucket != nil {
+		body["cos_bucket"] = validateReportsSnapshotConfigOptions.CosBucket
+	}
+	if validateReportsSnapshotConfigOptions.CosLocation != nil {
+		body["cos_location"] = validateReportsSnapshotConfigOptions.CosLocation
+	}
+	if validateReportsSnapshotConfigOptions.CosReportsFolder != nil {
+		body["cos_reports_folder"] = validateReportsSnapshotConfigOptions.CosReportsFolder
+	}
+	if validateReportsSnapshotConfigOptions.ReportTypes != nil {
+		body["report_types"] = validateReportsSnapshotConfigOptions.ReportTypes
+	}
+	if validateReportsSnapshotConfigOptions.Versioning != nil {
+		body["versioning"] = validateReportsSnapshotConfigOptions.Versioning
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "set-json-body-error", common.GetComponentInfo())
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = usageReports.Service.Request(request, &rawResponse)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "validate_reports_snapshot_config", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalSnapshotConfigValidateResponse)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "unmarshal-resp-error", common.GetComponentInfo())
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
 // GetReportsSnapshot : Fetch the current or past snapshots
 // Returns the billing reports snapshots captured for the given Account Id in the specific time period.
 func (usageReports *UsageReportsV4) GetReportsSnapshot(getReportsSnapshotOptions *GetReportsSnapshotOptions) (result *SnapshotList, response *core.DetailedResponse, err error) {
@@ -3347,6 +3442,7 @@ func UnmarshalSnapshotListFirst(m map[string]json.RawMessage, result interface{}
 type SnapshotListNext struct {
 	Href *string `json:"href,omitempty"`
 
+	// The value of the `_start` query parameter to fetch the next page.
 	Offset *string `json:"offset,omitempty"`
 }
 
@@ -3354,12 +3450,13 @@ type SnapshotListNext struct {
 func UnmarshalSnapshotListNext(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(SnapshotListNext)
 	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
-	if err != nil {	
+	if err != nil {
+		err = core.SDKErrorf(err, "", "href-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
 	if err != nil {
-		err = core.SDKErrorf(err, "", "href-error", common.GetComponentInfo())
+		err = core.SDKErrorf(err, "", "offset-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -3789,6 +3886,40 @@ func UnmarshalSnapshotConfig(m map[string]json.RawMessage, result interface{}) (
 	return
 }
 
+// SnapshotConfigValidateResponse : Validated billing service to COS bucket authorization.
+type SnapshotConfigValidateResponse struct {
+	// Account ID for which billing report snapshot is configured.
+	AccountID *string `json:"account_id,omitempty"`
+
+	// The name of the COS bucket to store the snapshot of the billing reports.
+	CosBucket *string `json:"cos_bucket,omitempty"`
+
+	// Region of the COS instance.
+	CosLocation *string `json:"cos_location,omitempty"`
+}
+
+// UnmarshalSnapshotConfigValidateResponse unmarshals an instance of SnapshotConfigValidateResponse from the specified map of raw messages.
+func UnmarshalSnapshotConfigValidateResponse(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(SnapshotConfigValidateResponse)
+	err = core.UnmarshalPrimitive(m, "account_id", &obj.AccountID)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "account_id-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "cos_bucket", &obj.CosBucket)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "cos_bucket-error", common.GetComponentInfo())
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "cos_location", &obj.CosLocation)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "cos_location-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
+}
+
 // Subscription : Subscription struct
 type Subscription struct {
 	// The ID of the subscription.
@@ -4140,15 +4271,15 @@ const (
 // Constants associated with the ValidateReportsSnapshotConfigOptions.ReportTypes property.
 const (
 	ValidateReportsSnapshotConfigOptionsReportTypesAccountResourceInstanceUsageConst = "account_resource_instance_usage"
-	ValidateReportsSnapshotConfigOptionsReportTypesAccountSummaryConst               = "account_summary"
-	ValidateReportsSnapshotConfigOptionsReportTypesEnterpriseSummaryConst            = "enterprise_summary"
+	ValidateReportsSnapshotConfigOptionsReportTypesAccountSummaryConst = "account_summary"
+	ValidateReportsSnapshotConfigOptionsReportTypesEnterpriseSummaryConst = "enterprise_summary"
 )
 
 // Constants associated with the ValidateReportsSnapshotConfigOptions.Versioning property.
 // A new version of report is created or the existing report version is overwritten with every update. Defaults to
 // "new".
 const (
-	ValidateReportsSnapshotConfigOptionsVersioningNewConst       = "new"
+	ValidateReportsSnapshotConfigOptionsVersioningNewConst = "new"
 	ValidateReportsSnapshotConfigOptionsVersioningOverwriteConst = "overwrite"
 )
 
@@ -4207,6 +4338,7 @@ func (options *ValidateReportsSnapshotConfigOptions) SetHeaders(param map[string
 	return options
 }
 
+//
 // GetResourceUsageAccountPager can be used to simplify the use of the "GetResourceUsageAccount" method.
 //
 type GetResourceUsageAccountPager struct {

--- a/usagereportsv4/usage_reports_v4.go
+++ b/usagereportsv4/usage_reports_v4.go
@@ -3346,12 +3346,18 @@ func UnmarshalSnapshotListFirst(m map[string]json.RawMessage, result interface{}
 // SnapshotListNext : Reference to the next page of the search query if any.
 type SnapshotListNext struct {
 	Href *string `json:"href,omitempty"`
+
+	Offset *string `json:"offset,omitempty"`
 }
 
 // UnmarshalSnapshotListNext unmarshals an instance of SnapshotListNext from the specified map of raw messages.
 func UnmarshalSnapshotListNext(m map[string]json.RawMessage, result interface{}) (err error) {
 	obj := new(SnapshotListNext)
 	err = core.UnmarshalPrimitive(m, "href", &obj.Href)
+	if err != nil {	
+		return
+	}
+	err = core.UnmarshalPrimitive(m, "offset", &obj.Offset)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "href-error", common.GetComponentInfo())
 		return

--- a/usagereportsv4/usage_reports_v4_test.go
+++ b/usagereportsv4/usage_reports_v4_test.go
@@ -3183,6 +3183,280 @@ var _ = Describe(`UsageReportsV4`, func() {
 			})
 		})
 	})
+	Describe(`ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptions *ValidateReportsSnapshotConfigOptions) - Operation response error`, func() {
+		validateReportsSnapshotConfigPath := "/v1/billing-reports-snapshot-config/validate"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(validateReportsSnapshotConfigPath))
+					Expect(req.Method).To(Equal("POST"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke ValidateReportsSnapshotConfig with error: Operation response processing error`, func() {
+				usageReportsService, serviceErr := usagereportsv4.NewUsageReportsV4(&usagereportsv4.UsageReportsV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(usageReportsService).ToNot(BeNil())
+
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsModel := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				validateReportsSnapshotConfigOptionsModel.AccountID = core.StringPtr("abc")
+				validateReportsSnapshotConfigOptionsModel.Interval = core.StringPtr("daily")
+				validateReportsSnapshotConfigOptionsModel.CosBucket = core.StringPtr("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.CosLocation = core.StringPtr("us-south")
+				validateReportsSnapshotConfigOptionsModel.CosReportsFolder = core.StringPtr("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.ReportTypes = []string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}
+				validateReportsSnapshotConfigOptionsModel.Versioning = core.StringPtr("new")
+				validateReportsSnapshotConfigOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				usageReportsService.EnableRetries(0, 0)
+				result, response, operationErr = usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptions *ValidateReportsSnapshotConfigOptions)`, func() {
+		validateReportsSnapshotConfigPath := "/v1/billing-reports-snapshot-config/validate"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(validateReportsSnapshotConfigPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"account_id": "abc", "cos_bucket": "bucket_name", "cos_location": "us-south"}`)
+				}))
+			})
+			It(`Invoke ValidateReportsSnapshotConfig successfully with retries`, func() {
+				usageReportsService, serviceErr := usagereportsv4.NewUsageReportsV4(&usagereportsv4.UsageReportsV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(usageReportsService).ToNot(BeNil())
+				usageReportsService.EnableRetries(0, 0)
+
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsModel := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				validateReportsSnapshotConfigOptionsModel.AccountID = core.StringPtr("abc")
+				validateReportsSnapshotConfigOptionsModel.Interval = core.StringPtr("daily")
+				validateReportsSnapshotConfigOptionsModel.CosBucket = core.StringPtr("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.CosLocation = core.StringPtr("us-south")
+				validateReportsSnapshotConfigOptionsModel.CosReportsFolder = core.StringPtr("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.ReportTypes = []string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}
+				validateReportsSnapshotConfigOptionsModel.Versioning = core.StringPtr("new")
+				validateReportsSnapshotConfigOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := usageReportsService.ValidateReportsSnapshotConfigWithContext(ctx, validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				usageReportsService.DisableRetries()
+				result, response, operationErr := usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = usageReportsService.ValidateReportsSnapshotConfigWithContext(ctx, validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(validateReportsSnapshotConfigPath))
+					Expect(req.Method).To(Equal("POST"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"account_id": "abc", "cos_bucket": "bucket_name", "cos_location": "us-south"}`)
+				}))
+			})
+			It(`Invoke ValidateReportsSnapshotConfig successfully`, func() {
+				usageReportsService, serviceErr := usagereportsv4.NewUsageReportsV4(&usagereportsv4.UsageReportsV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(usageReportsService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := usageReportsService.ValidateReportsSnapshotConfig(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsModel := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				validateReportsSnapshotConfigOptionsModel.AccountID = core.StringPtr("abc")
+				validateReportsSnapshotConfigOptionsModel.Interval = core.StringPtr("daily")
+				validateReportsSnapshotConfigOptionsModel.CosBucket = core.StringPtr("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.CosLocation = core.StringPtr("us-south")
+				validateReportsSnapshotConfigOptionsModel.CosReportsFolder = core.StringPtr("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.ReportTypes = []string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}
+				validateReportsSnapshotConfigOptionsModel.Versioning = core.StringPtr("new")
+				validateReportsSnapshotConfigOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke ValidateReportsSnapshotConfig with error: Operation validation and request error`, func() {
+				usageReportsService, serviceErr := usagereportsv4.NewUsageReportsV4(&usagereportsv4.UsageReportsV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(usageReportsService).ToNot(BeNil())
+
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsModel := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				validateReportsSnapshotConfigOptionsModel.AccountID = core.StringPtr("abc")
+				validateReportsSnapshotConfigOptionsModel.Interval = core.StringPtr("daily")
+				validateReportsSnapshotConfigOptionsModel.CosBucket = core.StringPtr("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.CosLocation = core.StringPtr("us-south")
+				validateReportsSnapshotConfigOptionsModel.CosReportsFolder = core.StringPtr("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.ReportTypes = []string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}
+				validateReportsSnapshotConfigOptionsModel.Versioning = core.StringPtr("new")
+				validateReportsSnapshotConfigOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := usageReportsService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+				// Construct a second instance of the ValidateReportsSnapshotConfigOptions model with no property values
+				validateReportsSnapshotConfigOptionsModelNew := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				// Invoke operation with invalid model (negative test)
+				result, response, operationErr = usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke ValidateReportsSnapshotConfig successfully`, func() {
+				usageReportsService, serviceErr := usagereportsv4.NewUsageReportsV4(&usagereportsv4.UsageReportsV4Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(usageReportsService).ToNot(BeNil())
+
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsModel := new(usagereportsv4.ValidateReportsSnapshotConfigOptions)
+				validateReportsSnapshotConfigOptionsModel.AccountID = core.StringPtr("abc")
+				validateReportsSnapshotConfigOptionsModel.Interval = core.StringPtr("daily")
+				validateReportsSnapshotConfigOptionsModel.CosBucket = core.StringPtr("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.CosLocation = core.StringPtr("us-south")
+				validateReportsSnapshotConfigOptionsModel.CosReportsFolder = core.StringPtr("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.ReportTypes = []string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}
+				validateReportsSnapshotConfigOptionsModel.Versioning = core.StringPtr("new")
+				validateReportsSnapshotConfigOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := usageReportsService.ValidateReportsSnapshotConfig(validateReportsSnapshotConfigOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`GetReportsSnapshot(getReportsSnapshotOptions *GetReportsSnapshotOptions) - Operation response error`, func() {
 		getReportsSnapshotPath := "/v1/billing-reports-snapshots"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
@@ -3262,7 +3536,7 @@ var _ = Describe(`UsageReportsV4`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"count": 3, "first": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "next": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "snapshots": [{"account_id": "abc", "month": "2023-06", "account_type": "account", "expected_processed_at": 1687470383610, "state": "enabled", "billing_period": {"start": "2023-06-01T00:00:00.000Z", "end": "2023-06-30T23:59:59.999Z"}, "snapshot_id": "1685577600000", "charset": "UTF-8", "compression": "GZIP", "content_type": "text/csv", "bucket": "bucket_name", "version": "1.0", "created_on": "2023-06-22T21:47:28.297Z", "report_types": [{"type": "account_summary", "version": "1.0"}], "files": [{"report_types": "account_summary", "location": "june/2023-06/1685577600000/2023-06-account-summary-272b9a4f73e11030d0ba037daee47a35.csv.gz", "account_id": "abc"}], "processed_at": 1687470448297}]}`)
+					fmt.Fprintf(res, "%s", `{"count": 3, "first": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "next": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06", "offset": "Offset"}, "snapshots": [{"account_id": "abc", "month": "2023-06", "account_type": "account", "expected_processed_at": 1687470383610, "state": "enabled", "billing_period": {"start": "2023-06-01T00:00:00.000Z", "end": "2023-06-30T23:59:59.999Z"}, "snapshot_id": "1685577600000", "charset": "UTF-8", "compression": "GZIP", "content_type": "text/csv", "bucket": "bucket_name", "version": "1.0", "created_on": "2023-06-22T21:47:28.297Z", "report_types": [{"type": "account_summary", "version": "1.0"}], "files": [{"report_types": "account_summary", "location": "june/2023-06/1685577600000/2023-06-account-summary-272b9a4f73e11030d0ba037daee47a35.csv.gz", "account_id": "abc"}], "processed_at": 1687470448297}]}`)
 				}))
 			})
 			It(`Invoke GetReportsSnapshot successfully with retries`, func() {
@@ -3327,7 +3601,7 @@ var _ = Describe(`UsageReportsV4`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"count": 3, "first": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "next": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "snapshots": [{"account_id": "abc", "month": "2023-06", "account_type": "account", "expected_processed_at": 1687470383610, "state": "enabled", "billing_period": {"start": "2023-06-01T00:00:00.000Z", "end": "2023-06-30T23:59:59.999Z"}, "snapshot_id": "1685577600000", "charset": "UTF-8", "compression": "GZIP", "content_type": "text/csv", "bucket": "bucket_name", "version": "1.0", "created_on": "2023-06-22T21:47:28.297Z", "report_types": [{"type": "account_summary", "version": "1.0"}], "files": [{"report_types": "account_summary", "location": "june/2023-06/1685577600000/2023-06-account-summary-272b9a4f73e11030d0ba037daee47a35.csv.gz", "account_id": "abc"}], "processed_at": 1687470448297}]}`)
+					fmt.Fprintf(res, "%s", `{"count": 3, "first": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06"}, "next": {"href": "/v1/billing-reports-snapshots?_limit=10&account_id=272b9a4f73e11030d0ba037daee47a35&date_from=-Infinity&date_to=Infinity&month=2023-06", "offset": "Offset"}, "snapshots": [{"account_id": "abc", "month": "2023-06", "account_type": "account", "expected_processed_at": 1687470383610, "state": "enabled", "billing_period": {"start": "2023-06-01T00:00:00.000Z", "end": "2023-06-30T23:59:59.999Z"}, "snapshot_id": "1685577600000", "charset": "UTF-8", "compression": "GZIP", "content_type": "text/csv", "bucket": "bucket_name", "version": "1.0", "created_on": "2023-06-22T21:47:28.297Z", "report_types": [{"type": "account_summary", "version": "1.0"}], "files": [{"report_types": "account_summary", "location": "june/2023-06/1685577600000/2023-06-account-summary-272b9a4f73e11030d0ba037daee47a35.csv.gz", "account_id": "abc"}], "processed_at": 1687470448297}]}`)
 				}))
 			})
 			It(`Invoke GetReportsSnapshot successfully`, func() {
@@ -3499,10 +3773,10 @@ var _ = Describe(`UsageReportsV4`, func() {
 
 				getReportsSnapshotOptionsModel := &usagereportsv4.GetReportsSnapshotOptions{
 					AccountID: core.StringPtr("abc"),
-					Month:     core.StringPtr("2023-02"),
-					DateFrom:  core.Int64Ptr(int64(1675209600000)),
-					DateTo:    core.Int64Ptr(int64(1675987200000)),
-					Limit:     core.Int64Ptr(int64(30)),
+					Month: core.StringPtr("2023-02"),
+					DateFrom: core.Int64Ptr(int64(1675209600000)),
+					DateTo: core.Int64Ptr(int64(1675987200000)),
+					Limit: core.Int64Ptr(int64(30)),
 				}
 
 				pager, err := usageReportsService.NewGetReportsSnapshotPager(getReportsSnapshotOptionsModel)
@@ -3528,10 +3802,10 @@ var _ = Describe(`UsageReportsV4`, func() {
 
 				getReportsSnapshotOptionsModel := &usagereportsv4.GetReportsSnapshotOptions{
 					AccountID: core.StringPtr("abc"),
-					Month:     core.StringPtr("2023-02"),
-					DateFrom:  core.Int64Ptr(int64(1675209600000)),
-					DateTo:    core.Int64Ptr(int64(1675987200000)),
-					Limit:     core.Int64Ptr(int64(30)),
+					Month: core.StringPtr("2023-02"),
+					DateFrom: core.Int64Ptr(int64(1675209600000)),
+					DateTo: core.Int64Ptr(int64(1675987200000)),
+					Limit: core.Int64Ptr(int64(30)),
 				}
 
 				pager, err := usageReportsService.NewGetReportsSnapshotPager(getReportsSnapshotOptionsModel)
@@ -3812,6 +4086,28 @@ var _ = Describe(`UsageReportsV4`, func() {
 				Expect(updateReportsSnapshotConfigOptionsModel.Versioning).To(Equal(core.StringPtr("new")))
 				Expect(updateReportsSnapshotConfigOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewValidateReportsSnapshotConfigOptions successfully`, func() {
+				// Construct an instance of the ValidateReportsSnapshotConfigOptions model
+				validateReportsSnapshotConfigOptionsAccountID := "abc"
+				validateReportsSnapshotConfigOptionsModel := usageReportsService.NewValidateReportsSnapshotConfigOptions(validateReportsSnapshotConfigOptionsAccountID)
+				validateReportsSnapshotConfigOptionsModel.SetAccountID("abc")
+				validateReportsSnapshotConfigOptionsModel.SetInterval("daily")
+				validateReportsSnapshotConfigOptionsModel.SetCosBucket("bucket_name")
+				validateReportsSnapshotConfigOptionsModel.SetCosLocation("us-south")
+				validateReportsSnapshotConfigOptionsModel.SetCosReportsFolder("IBMCloud-Billing-Reports")
+				validateReportsSnapshotConfigOptionsModel.SetReportTypes([]string{"account_summary", "enterprise_summary", "account_resource_instance_usage"})
+				validateReportsSnapshotConfigOptionsModel.SetVersioning("new")
+				validateReportsSnapshotConfigOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(validateReportsSnapshotConfigOptionsModel).ToNot(BeNil())
+				Expect(validateReportsSnapshotConfigOptionsModel.AccountID).To(Equal(core.StringPtr("abc")))
+				Expect(validateReportsSnapshotConfigOptionsModel.Interval).To(Equal(core.StringPtr("daily")))
+				Expect(validateReportsSnapshotConfigOptionsModel.CosBucket).To(Equal(core.StringPtr("bucket_name")))
+				Expect(validateReportsSnapshotConfigOptionsModel.CosLocation).To(Equal(core.StringPtr("us-south")))
+				Expect(validateReportsSnapshotConfigOptionsModel.CosReportsFolder).To(Equal(core.StringPtr("IBMCloud-Billing-Reports")))
+				Expect(validateReportsSnapshotConfigOptionsModel.ReportTypes).To(Equal([]string{"account_summary", "enterprise_summary", "account_resource_instance_usage"}))
+				Expect(validateReportsSnapshotConfigOptionsModel.Versioning).To(Equal(core.StringPtr("new")))
+				Expect(validateReportsSnapshotConfigOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 		})
 	})
 	Describe(`Utility function tests`, func() {
@@ -3843,8 +4139,7 @@ var _ = Describe(`UsageReportsV4`, func() {
 //
 
 func CreateMockByteArray(mockData string) *[]byte {
-	ba := make([]byte, 0)
-	ba = append(ba, mockData...)
+	ba := []byte(mockData)
 	return &ba
 }
 


### PR DESCRIPTION
## PR summary
re-add the offset property to SnapshotListNext which was incorrectly removed after re-generating the service


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->
SnapshotListNext should now contain the offset property

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

test results:
```
Running Suite: UsageReportsV4 Suite
===================================
Random Seed: 1714067348
Will run 103 of 103 specs

•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 103 of 103 Specs in 3.204 seconds
SUCCESS! -- 103 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/IBM/platform-services-go-sdk/usagereportsv4  3.852s
```
integration tests:
```
Running Suite: UsageReportsV4 Suite
===================================
Random Seed: 1714067407
Will run 119 of 119 specs

•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 119 of 119 Specs in 18.440 seconds
SUCCESS! -- 119 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/IBM/platform-services-go-sdk/usagereportsv4  19.778s
```
examples:
```
•••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••
Ran 117 of 117 Specs in 14.238 seconds
SUCCESS! -- 117 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
ok      github.com/IBM/platform-services-go-sdk/usagereportsv4  15.493s
```