### PR TITLE
build: enable gosec linter in golangci-lint

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,13 @@
+linters:
+  enable:
+    - gosec
+
+run:
+  timeout: 5m
+
+issues:
+  exclude-rules:
+    # Skip test files when running the gosec linter.
+    - path: (.+)_test\.go
+      linters:
+        - gosec

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$|_test.go|package-lock.json|.cra/.cveignore",
     "lines": null
   },
-  "generated_at": "2024-05-16T15:03:35Z",
+  "generated_at": "2024-08-01T17:16:09Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -70,7 +70,7 @@
         "hashed_secret": "dc893c9c63b0a9f1ac2b956b807ee3d8bc8e1128",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5535,
+        "line_number": 5659,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -78,7 +78,7 @@
         "hashed_secret": "c334fe1f9004e339ead59696c029181963999ff3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5559,
+        "line_number": 5683,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -86,7 +86,7 @@
         "hashed_secret": "f971798ba28d8d6a66ee5bdea060b751a078c2fa",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5665,
+        "line_number": 5789,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -94,7 +94,7 @@
         "hashed_secret": "e7369ac81427d43f7615f691cd1cf5c3ef9b2f00",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5689,
+        "line_number": 5813,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -102,7 +102,7 @@
         "hashed_secret": "bc31992082895a108753616f5be455b3e897bb29",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5881,
+        "line_number": 6005,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -110,7 +110,7 @@
         "hashed_secret": "21ac4c0699bb3f370e2c21331fd8606739b1079b",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 5905,
+        "line_number": 6029,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -118,7 +118,7 @@
         "hashed_secret": "6452e7c5a42f97b00af1a210afc7d4de315e57ec",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 22580,
+        "line_number": 22814,
         "type": "Secret Keyword",
         "verified_result": null
       }
@@ -242,7 +242,7 @@
         "hashed_secret": "bbccdf2efb33b52e6c9d0a14dd70b2d415fbea6e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2366,
+        "line_number": 2645,
         "type": "Secret Keyword",
         "verified_result": null
       },
@@ -250,7 +250,7 @@
         "hashed_secret": "d6b1537b6181f0a1c9dffdf7980702e6a773efbb",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 2441,
+        "line_number": 2720,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,7 @@ stages:
 
 # Default "install" and "script" steps.
 install:
-  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.55.2
-  - curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin
+  - curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(go env GOPATH)/bin v1.59.1
 script:
   - make travis-ci
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 # Makefile to build the project
 GO=go
 LINT=golangci-lint
-GOSEC=gosec
-
 COVERAGE = -coverprofile=coverage.txt -covermode=atomic
 
 all: tidy test lint
-travis-ci: tidy test-cov lint scan-gosec
+travis-ci: tidy test-cov lint
 
 test:
 	${GO} test ./...
@@ -21,10 +19,7 @@ test-int-cov:
 	${GO} test ./... -tags=integration ${COVERAGE}
 
 lint:
-	${LINT} run --build-tags=integration,examples --timeout 120s
-
-scan-gosec:
-	${GOSEC} ./...
+	${LINT} run --build-tags=integration,examples
 
 tidy:
 	${GO} mod tidy


### PR DESCRIPTION
## PR summary
This commit removes the use of the gosec standalone tool and enables the gosec linter supported by golangci-lint.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->