### PR TITLE
fix(Atracker): re-gen service for mezmo removal and hand edits IT

### DIFF
--- a/atrackerv2/atracker_v2.go
+++ b/atrackerv2/atracker_v2.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /*
- * IBM OpenAPI SDK Code Generator Version: 3.94.1-71478489-20240820-161623
+ * IBM OpenAPI SDK Code Generator Version: 3.101.0-62624c1e-20250225-192301
  */
 
 // Package atrackerv2 : Operations and models for the AtrackerV2 service
@@ -35,7 +35,7 @@ import (
 )
 
 // AtrackerV2 : IBM Cloud Activity Tracker allows you to configure how auditing events are collected and stored in each
-// region in your account. Events can be sent to Cloud Object Storage bucket, Logdna or Event Streams.
+// region in your account. Events can be sent to Cloud Object Storage bucket, Cloud Logs or Event Streams.
 //
 // API Version: 2.0.0
 type AtrackerV2 struct {
@@ -253,9 +253,6 @@ func (atracker *AtrackerV2) CreateTargetWithContext(ctx context.Context, createT
 	}
 	if createTargetOptions.CosEndpoint != nil {
 		body["cos_endpoint"] = createTargetOptions.CosEndpoint
-	}
-	if createTargetOptions.LogdnaEndpoint != nil {
-		body["logdna_endpoint"] = createTargetOptions.LogdnaEndpoint
 	}
 	if createTargetOptions.EventstreamsEndpoint != nil {
 		body["eventstreams_endpoint"] = createTargetOptions.EventstreamsEndpoint
@@ -481,9 +478,6 @@ func (atracker *AtrackerV2) ReplaceTargetWithContext(ctx context.Context, replac
 	}
 	if replaceTargetOptions.CosEndpoint != nil {
 		body["cos_endpoint"] = replaceTargetOptions.CosEndpoint
-	}
-	if replaceTargetOptions.LogdnaEndpoint != nil {
-		body["logdna_endpoint"] = replaceTargetOptions.LogdnaEndpoint
 	}
 	if replaceTargetOptions.EventstreamsEndpoint != nil {
 		body["eventstreams_endpoint"] = replaceTargetOptions.EventstreamsEndpoint
@@ -1364,15 +1358,12 @@ type CreateTargetOptions struct {
 	// than `(space) - . _ :`. Do not include any personal identifying information (PII) in any resource names.
 	Name *string `json:"name" validate:"required"`
 
-	// The type of the target. It can be cloud_object_storage, logdna, event_streams, or cloud_logs. Based on this type you
-	// must include cos_endpoint, logdna_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
+	// The type of the target. It can be cloud_object_storage, event_streams, or cloud_logs. Based on this type you must
+	// include cos_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
 	TargetType *string `json:"target_type" validate:"required"`
 
 	// Property values for a Cloud Object Storage Endpoint in requests.
 	CosEndpoint *CosEndpointPrototype `json:"cos_endpoint,omitempty"`
-
-	// Property values for a LogDNA Endpoint in requests.
-	LogdnaEndpoint *LogdnaEndpointPrototype `json:"logdna_endpoint,omitempty"`
 
 	// Property values for an Event Streams Endpoint in requests.
 	EventstreamsEndpoint *EventstreamsEndpointPrototype `json:"eventstreams_endpoint,omitempty"`
@@ -1389,13 +1380,12 @@ type CreateTargetOptions struct {
 }
 
 // Constants associated with the CreateTargetOptions.TargetType property.
-// The type of the target. It can be cloud_object_storage, logdna, event_streams, or cloud_logs. Based on this type you
-// must include cos_endpoint, logdna_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
+// The type of the target. It can be cloud_object_storage, event_streams, or cloud_logs. Based on this type you must
+// include cos_endpoint, eventstreams_endpoint or cloudlogs_endpoint.
 const (
 	CreateTargetOptionsTargetTypeCloudLogsConst = "cloud_logs"
 	CreateTargetOptionsTargetTypeCloudObjectStorageConst = "cloud_object_storage"
 	CreateTargetOptionsTargetTypeEventStreamsConst = "event_streams"
-	CreateTargetOptionsTargetTypeLogdnaConst = "logdna"
 )
 
 // NewCreateTargetOptions : Instantiate CreateTargetOptions
@@ -1421,12 +1411,6 @@ func (_options *CreateTargetOptions) SetTargetType(targetType string) *CreateTar
 // SetCosEndpoint : Allow user to set CosEndpoint
 func (_options *CreateTargetOptions) SetCosEndpoint(cosEndpoint *CosEndpointPrototype) *CreateTargetOptions {
 	_options.CosEndpoint = cosEndpoint
-	return _options
-}
-
-// SetLogdnaEndpoint : Allow user to set LogdnaEndpoint
-func (_options *CreateTargetOptions) SetLogdnaEndpoint(logdnaEndpoint *LogdnaEndpointPrototype) *CreateTargetOptions {
-	_options.LogdnaEndpoint = logdnaEndpoint
 	return _options
 }
 
@@ -1572,7 +1556,8 @@ type EventstreamsEndpointPrototype struct {
 	// The messsage hub topic defined in the Event Streams instance.
 	Topic *string `json:"topic" validate:"required"`
 
-	// The user password (api key) for the message hub topic in the Event Streams instance.
+	// The user password (api key) for the message hub topic in the Event Streams instance. This is required if
+	// service_to_service is not enabled.
 	APIKey *string `json:"api_key,omitempty"`
 
 	// Determines if IBM Cloud Activity Tracker Event Routing has service to service authentication enabled. Set this flag
@@ -1744,63 +1729,6 @@ func (options *ListTargetsOptions) SetHeaders(param map[string]string) *ListTarg
 	return options
 }
 
-// LogdnaEndpoint : Property values for a LogDNA Endpoint in responses.
-type LogdnaEndpoint struct {
-	// The CRN of the LogDNA instance.
-	TargetCRN *string `json:"target_crn" validate:"required"`
-}
-
-// UnmarshalLogdnaEndpoint unmarshals an instance of LogdnaEndpoint from the specified map of raw messages.
-func UnmarshalLogdnaEndpoint(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(LogdnaEndpoint)
-	err = core.UnmarshalPrimitive(m, "target_crn", &obj.TargetCRN)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "target_crn-error", common.GetComponentInfo())
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// LogdnaEndpointPrototype : Property values for a LogDNA Endpoint in requests.
-type LogdnaEndpointPrototype struct {
-	// The CRN of the LogDNA instance.
-	TargetCRN *string `json:"target_crn" validate:"required"`
-
-	// The LogDNA ingestion key is used for routing logs to a specific LogDNA instance.
-	IngestionKey *string `json:"ingestion_key" validate:"required"`
-}
-
-// NewLogdnaEndpointPrototype : Instantiate LogdnaEndpointPrototype (Generic Model Constructor)
-func (*AtrackerV2) NewLogdnaEndpointPrototype(targetCRN string, ingestionKey string) (_model *LogdnaEndpointPrototype, err error) {
-	_model = &LogdnaEndpointPrototype{
-		TargetCRN: core.StringPtr(targetCRN),
-		IngestionKey: core.StringPtr(ingestionKey),
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	if err != nil {
-		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
-	}
-	return
-}
-
-// UnmarshalLogdnaEndpointPrototype unmarshals an instance of LogdnaEndpointPrototype from the specified map of raw messages.
-func UnmarshalLogdnaEndpointPrototype(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(LogdnaEndpointPrototype)
-	err = core.UnmarshalPrimitive(m, "target_crn", &obj.TargetCRN)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "target_crn-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalPrimitive(m, "ingestion_key", &obj.IngestionKey)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "ingestion_key-error", common.GetComponentInfo())
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
 // PutSettingsOptions : The PutSettings options.
 type PutSettingsOptions struct {
 	// To store all your meta data in a single region.
@@ -1928,9 +1856,6 @@ type ReplaceTargetOptions struct {
 	// Property values for a Cloud Object Storage Endpoint in requests.
 	CosEndpoint *CosEndpointPrototype `json:"cos_endpoint,omitempty"`
 
-	// Property values for a LogDNA Endpoint in requests.
-	LogdnaEndpoint *LogdnaEndpointPrototype `json:"logdna_endpoint,omitempty"`
-
 	// Property values for an Event Streams Endpoint in requests.
 	EventstreamsEndpoint *EventstreamsEndpointPrototype `json:"eventstreams_endpoint,omitempty"`
 
@@ -1963,12 +1888,6 @@ func (_options *ReplaceTargetOptions) SetName(name string) *ReplaceTargetOptions
 // SetCosEndpoint : Allow user to set CosEndpoint
 func (_options *ReplaceTargetOptions) SetCosEndpoint(cosEndpoint *CosEndpointPrototype) *ReplaceTargetOptions {
 	_options.CosEndpoint = cosEndpoint
-	return _options
-}
-
-// SetLogdnaEndpoint : Allow user to set LogdnaEndpoint
-func (_options *ReplaceTargetOptions) SetLogdnaEndpoint(logdnaEndpoint *LogdnaEndpointPrototype) *ReplaceTargetOptions {
-	_options.LogdnaEndpoint = logdnaEndpoint
 	return _options
 }
 
@@ -2248,9 +2167,6 @@ type Target struct {
 	// Property values for a Cloud Object Storage Endpoint in responses.
 	CosEndpoint *CosEndpoint `json:"cos_endpoint,omitempty"`
 
-	// Property values for a LogDNA Endpoint in responses.
-	LogdnaEndpoint *LogdnaEndpoint `json:"logdna_endpoint,omitempty"`
-
 	// Property values for the Event Streams Endpoint in responses.
 	EventstreamsEndpoint *EventstreamsEndpoint `json:"eventstreams_endpoint,omitempty"`
 
@@ -2279,7 +2195,6 @@ const (
 	TargetTargetTypeCloudLogsConst = "cloud_logs"
 	TargetTargetTypeCloudObjectStorageConst = "cloud_object_storage"
 	TargetTargetTypeEventStreamsConst = "event_streams"
-	TargetTargetTypeLogdnaConst = "logdna"
 )
 
 // UnmarshalTarget unmarshals an instance of Target from the specified map of raw messages.
@@ -2313,11 +2228,6 @@ func UnmarshalTarget(m map[string]json.RawMessage, result interface{}) (err erro
 	err = core.UnmarshalModel(m, "cos_endpoint", &obj.CosEndpoint, UnmarshalCosEndpoint)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "cos_endpoint-error", common.GetComponentInfo())
-		return
-	}
-	err = core.UnmarshalModel(m, "logdna_endpoint", &obj.LogdnaEndpoint, UnmarshalLogdnaEndpoint)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "logdna_endpoint-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalModel(m, "eventstreams_endpoint", &obj.EventstreamsEndpoint, UnmarshalEventstreamsEndpoint)

--- a/atrackerv2/atracker_v2_integration_test.go
+++ b/atrackerv2/atracker_v2_integration_test.go
@@ -2,7 +2,7 @@
 // +build integration
 
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,7 +60,6 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 		// Variables to hold link values
 		routeIDLink   string
 		targetIDLink  string
-		targetIDLink2 string
 		targetIDLink3 string
 	)
 
@@ -151,28 +150,6 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 
 			targetIDLink = *target.ID
 			fmt.Fprintf(GinkgoWriter, "Saved cos targetIDLink value: %v\n", targetIDLink)
-		})
-		It(`CreateTarget(createTargetOptions *CreateTargetOptions)`, func() {
-
-			logdnaEndpointPrototypeModel := &atrackerv2.LogdnaEndpointPrototype{
-				TargetCRN:    core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
-				IngestionKey: core.StringPtr("xxxxxxxxxxxxxx"),
-			}
-
-			createTargetOptions := &atrackerv2.CreateTargetOptions{
-				Name:           core.StringPtr("my-logdna-target"),
-				TargetType:     core.StringPtr("logdna"),
-				LogdnaEndpoint: logdnaEndpointPrototypeModel,
-			}
-
-			target, response, err := atrackerService.CreateTarget(createTargetOptions)
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(201))
-			Expect(target).ToNot(BeNil())
-
-			targetIDLink2 = *target.ID
-			fmt.Fprintf(GinkgoWriter, "Saved logdna targetIDLink value: %v\n", targetIDLink)
 		})
 
 		It(`CreateTarget(createTargetOptions *CreateTargetOptions)`, func() {
@@ -391,25 +368,6 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 				ID:          &targetIDLink,
 				Name:        core.StringPtr("my-cos-target"),
 				CosEndpoint: cosEndpointPrototypeModel,
-			}
-
-			target, response, err := atrackerService.ReplaceTarget(replaceTargetOptions)
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
-			Expect(target).ToNot(BeNil())
-		})
-
-		It(`ReplaceTarget(replaceTargetOptions *ReplaceTargetOptions) for logdna type of target`, func() {
-
-			logdnaEndpointPrototypeModel := &atrackerv2.LogdnaEndpointPrototype{
-				TargetCRN:    core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"),
-				IngestionKey: core.StringPtr("xxxxxxxxxxxxxx"),
-			}
-
-			replaceTargetOptions := &atrackerv2.ReplaceTargetOptions{
-				ID:             &targetIDLink2,
-				Name:           core.StringPtr("my-logdna-target-modified"),
-				LogdnaEndpoint: logdnaEndpointPrototypeModel,
 			}
 
 			target, response, err := atrackerService.ReplaceTarget(replaceTargetOptions)
@@ -696,21 +654,6 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 			Expect(response.StatusCode).To(Equal(201))
 			Expect(settings).ToNot(BeNil())
 		})
-
-		It(`Returns 403 when user is not authorized`, func() {
-
-			putSettingsOptions := &atrackerv2.PutSettingsOptions{
-				DefaultTargets:         []string{targetIDLink2},
-				PermittedTargetRegions: []string{"us-south"},
-				MetadataRegionPrimary:  core.StringPtr("us-south"),
-				PrivateAPIEndpointOnly: core.BoolPtr(false),
-			}
-
-			_, response, err := atrackerServiceNotAuthorized.PutSettings(putSettingsOptions)
-
-			Expect(err).NotTo(BeNil())
-			Expect(response.StatusCode).To(Equal(403))
-		})
 	})
 
 	Describe(`DeleteRoute - Delete a route`, func() {
@@ -791,16 +734,6 @@ var _ = Describe(`AtrackerV2 Integration Tests`, func() {
 
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(204))
-		})
-		It(`DeleteTarget(deleteTargetOptions *DeleteTargetOptions)`, func() {
-
-			deleteTargetOptions := &atrackerv2.DeleteTargetOptions{
-				ID: &targetIDLink2,
-			}
-
-			_, response, err := atrackerService.DeleteTarget(deleteTargetOptions)
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(200))
 		})
 		It(`DeleteTarget(deleteTargetOptions *DeleteTargetOptions)`, func() {
 

--- a/atrackerv2/atracker_v2_suite_test.go
+++ b/atrackerv2/atracker_v2_suite_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/atrackerv2/atracker_v2_test.go
+++ b/atrackerv2/atracker_v2_test.go
@@ -1,5 +1,5 @@
 /**
- * (C) Copyright IBM Corp. 2024.
+ * (C) Copyright IBM Corp. 2025.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -292,11 +292,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -314,7 +309,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				createTargetOptionsModel.TargetType = core.StringPtr("cloud_object_storage")
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
@@ -370,7 +364,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke CreateTarget successfully with retries`, func() {
@@ -390,11 +384,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -412,7 +401,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				createTargetOptionsModel.TargetType = core.StringPtr("cloud_object_storage")
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
@@ -471,7 +459,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke CreateTarget successfully`, func() {
@@ -496,11 +484,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -518,7 +501,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				createTargetOptionsModel.TargetType = core.StringPtr("cloud_object_storage")
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
@@ -547,11 +529,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -569,7 +546,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				createTargetOptionsModel.TargetType = core.StringPtr("cloud_object_storage")
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
@@ -619,11 +595,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -641,7 +612,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				createTargetOptionsModel.TargetType = core.StringPtr("cloud_object_storage")
 				createTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				createTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				createTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				createTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				createTargetOptionsModel.Region = core.StringPtr("us-south")
@@ -724,7 +694,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
+					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
 				}))
 			})
 			It(`Invoke ListTargets successfully with retries`, func() {
@@ -779,7 +749,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
+					fmt.Fprintf(res, "%s", `{"targets": [{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}]}`)
 				}))
 			})
 			It(`Invoke ListTargets successfully`, func() {
@@ -930,7 +900,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke GetTarget successfully with retries`, func() {
@@ -984,7 +954,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke GetTarget successfully`, func() {
@@ -1111,11 +1081,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -1133,7 +1098,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
 				replaceTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1188,7 +1152,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ReplaceTarget successfully with retries`, func() {
@@ -1208,11 +1172,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -1230,7 +1189,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
 				replaceTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1288,7 +1246,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ReplaceTarget successfully`, func() {
@@ -1313,11 +1271,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -1335,7 +1288,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
 				replaceTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1363,11 +1315,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -1385,7 +1332,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
 				replaceTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1434,11 +1380,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				cosEndpointPrototypeModel.APIKey = core.StringPtr("xxxxxxxxxxxxxx")
 				cosEndpointPrototypeModel.ServiceToServiceEnabled = core.BoolPtr(true)
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				eventstreamsEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
@@ -1456,7 +1397,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.ID = core.StringPtr("testString")
 				replaceTargetOptionsModel.Name = core.StringPtr("my-cos-target")
 				replaceTargetOptionsModel.CosEndpoint = cosEndpointPrototypeModel
-				replaceTargetOptionsModel.LogdnaEndpoint = logdnaEndpointPrototypeModel
 				replaceTargetOptionsModel.EventstreamsEndpoint = eventstreamsEndpointPrototypeModel
 				replaceTargetOptionsModel.CloudlogsEndpoint = cloudLogsEndpointPrototypeModel
 				replaceTargetOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
@@ -1748,7 +1688,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ValidateTarget successfully with retries`, func() {
@@ -1802,7 +1742,7 @@ var _ = Describe(`AtrackerV2`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "logdna_endpoint": {"target_crn": "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
+					fmt.Fprintf(res, "%s", `{"id": "f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "name": "a-cos-target-us-south", "crn": "crn:v1:bluemix:public:atracker:us-south:a/11111111111111111111111111111111:b6eec08b-5201-08ca-451b-cd71523e3626:target:f7dcfae6-e7c5-08ca-451b-fdfa696c9bb6", "target_type": "cloud_object_storage", "region": "us-south", "cos_endpoint": {"endpoint": "s3.private.us-east.cloud-object-storage.appdomain.cloud", "target_crn": "crn:v1:bluemix:public:cloud-object-storage:global:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "bucket": "my-atracker-bucket", "service_to_service_enabled": true}, "eventstreams_endpoint": {"target_crn": "crn:v1:bluemix:public:messagehub:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::", "brokers": ["kafka-x:9094"], "topic": "my-topic", "api_key": "xxxxxxxxxxxxxx", "service_to_service_enabled": false}, "cloudlogs_endpoint": {"target_crn": "crn:v1:bluemix:public:eu-es:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"}, "write_status": {"status": "success", "last_failure": "2021-05-18T20:15:12.353Z", "reason_for_last_failure": "Provided API key could not be found"}, "created_at": "2021-05-18T20:15:12.353Z", "updated_at": "2021-05-18T20:15:12.353Z", "message": "This is a valid target. However, there is another target already defined with the same target endpoint.", "api_version": 2}`)
 				}))
 			})
 			It(`Invoke ValidateTarget successfully`, func() {
@@ -3451,14 +3391,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(cosEndpointPrototypeModel.APIKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
 				Expect(cosEndpointPrototypeModel.ServiceToServiceEnabled).To(Equal(core.BoolPtr(true)))
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				Expect(logdnaEndpointPrototypeModel).ToNot(BeNil())
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-				Expect(logdnaEndpointPrototypeModel.TargetCRN).To(Equal(core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")))
-				Expect(logdnaEndpointPrototypeModel.IngestionKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				Expect(eventstreamsEndpointPrototypeModel).ToNot(BeNil())
@@ -3486,7 +3418,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				createTargetOptionsModel.SetName("my-cos-target")
 				createTargetOptionsModel.SetTargetType("cloud_object_storage")
 				createTargetOptionsModel.SetCosEndpoint(cosEndpointPrototypeModel)
-				createTargetOptionsModel.SetLogdnaEndpoint(logdnaEndpointPrototypeModel)
 				createTargetOptionsModel.SetEventstreamsEndpoint(eventstreamsEndpointPrototypeModel)
 				createTargetOptionsModel.SetCloudlogsEndpoint(cloudLogsEndpointPrototypeModel)
 				createTargetOptionsModel.SetRegion("us-south")
@@ -3495,7 +3426,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(createTargetOptionsModel.Name).To(Equal(core.StringPtr("my-cos-target")))
 				Expect(createTargetOptionsModel.TargetType).To(Equal(core.StringPtr("cloud_object_storage")))
 				Expect(createTargetOptionsModel.CosEndpoint).To(Equal(cosEndpointPrototypeModel))
-				Expect(createTargetOptionsModel.LogdnaEndpoint).To(Equal(logdnaEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.EventstreamsEndpoint).To(Equal(eventstreamsEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.CloudlogsEndpoint).To(Equal(cloudLogsEndpointPrototypeModel))
 				Expect(createTargetOptionsModel.Region).To(Equal(core.StringPtr("us-south")))
@@ -3572,13 +3502,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(listTargetsOptionsModel.Region).To(Equal(core.StringPtr("testString")))
 				Expect(listTargetsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
-			It(`Invoke NewLogdnaEndpointPrototype successfully`, func() {
-				targetCRN := "crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::"
-				ingestionKey := "xxxxxxxxxxxxxx"
-				_model, err := atrackerService.NewLogdnaEndpointPrototype(targetCRN, ingestionKey)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
 			It(`Invoke NewPutSettingsOptions successfully`, func() {
 				// Construct an instance of the PutSettingsOptions model
 				putSettingsOptionsMetadataRegionPrimary := "us-south"
@@ -3637,14 +3560,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(cosEndpointPrototypeModel.APIKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
 				Expect(cosEndpointPrototypeModel.ServiceToServiceEnabled).To(Equal(core.BoolPtr(true)))
 
-				// Construct an instance of the LogdnaEndpointPrototype model
-				logdnaEndpointPrototypeModel := new(atrackerv2.LogdnaEndpointPrototype)
-				Expect(logdnaEndpointPrototypeModel).ToNot(BeNil())
-				logdnaEndpointPrototypeModel.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-				logdnaEndpointPrototypeModel.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-				Expect(logdnaEndpointPrototypeModel.TargetCRN).To(Equal(core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")))
-				Expect(logdnaEndpointPrototypeModel.IngestionKey).To(Equal(core.StringPtr("xxxxxxxxxxxxxx")))
-
 				// Construct an instance of the EventstreamsEndpointPrototype model
 				eventstreamsEndpointPrototypeModel := new(atrackerv2.EventstreamsEndpointPrototype)
 				Expect(eventstreamsEndpointPrototypeModel).ToNot(BeNil())
@@ -3671,7 +3586,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				replaceTargetOptionsModel.SetID("testString")
 				replaceTargetOptionsModel.SetName("my-cos-target")
 				replaceTargetOptionsModel.SetCosEndpoint(cosEndpointPrototypeModel)
-				replaceTargetOptionsModel.SetLogdnaEndpoint(logdnaEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetEventstreamsEndpoint(eventstreamsEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetCloudlogsEndpoint(cloudLogsEndpointPrototypeModel)
 				replaceTargetOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
@@ -3679,7 +3593,6 @@ var _ = Describe(`AtrackerV2`, func() {
 				Expect(replaceTargetOptionsModel.ID).To(Equal(core.StringPtr("testString")))
 				Expect(replaceTargetOptionsModel.Name).To(Equal(core.StringPtr("my-cos-target")))
 				Expect(replaceTargetOptionsModel.CosEndpoint).To(Equal(cosEndpointPrototypeModel))
-				Expect(replaceTargetOptionsModel.LogdnaEndpoint).To(Equal(logdnaEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.EventstreamsEndpoint).To(Equal(eventstreamsEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.CloudlogsEndpoint).To(Equal(cloudLogsEndpointPrototypeModel))
 				Expect(replaceTargetOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
@@ -3761,25 +3674,6 @@ var _ = Describe(`AtrackerV2`, func() {
 
 			var result *atrackerv2.EventstreamsEndpointPrototype
 			err = atrackerv2.UnmarshalEventstreamsEndpointPrototype(raw, &result)
-			Expect(err).To(BeNil())
-			Expect(result).ToNot(BeNil())
-			Expect(result).To(Equal(model))
-		})
-		It(`Invoke UnmarshalLogdnaEndpointPrototype successfully`, func() {
-			// Construct an instance of the model.
-			model := new(atrackerv2.LogdnaEndpointPrototype)
-			model.TargetCRN = core.StringPtr("crn:v1:bluemix:public:logdna:us-south:a/11111111111111111111111111111111:22222222-2222-2222-2222-222222222222::")
-			model.IngestionKey = core.StringPtr("xxxxxxxxxxxxxx")
-
-			b, err := json.Marshal(model)
-			Expect(err).To(BeNil())
-
-			var raw map[string]json.RawMessage
-			err = json.Unmarshal(b, &raw)
-			Expect(err).To(BeNil())
-
-			var result *atrackerv2.LogdnaEndpointPrototype
-			err = atrackerv2.UnmarshalLogdnaEndpointPrototype(raw, &result)
 			Expect(err).To(BeNil())
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))


### PR DESCRIPTION
## PR summary
- Due to Mezmo (LogDNA) end of service after 3/30/2025, remove logdna related reference from atracker sdk.

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been ~~added~~ updated (for bug fixes / features)
  - [x] Remove logdna tests due to logdna end-of-service
- [x] Docs have been added / updated (for bug fixes / features)

## Current vs new behavior  
<!-- Please describe the current behavior that you are modifying and the new behavior. -->

## Does this PR introduce a breaking change?    
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This PR removes `logdna` support because logdna (mezmo) will be end of service after 3/30. No changes to API itself, but customers will not be able to create/update any targets in `logdna` type. This has been communicated to customers.

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->