### PR TITLE
build: add dependency cooldown logic to renovate config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 package-lock=false
+minimummin-release-age=3

--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,14 @@
   "packageRules": [
     {
       "matchManagers": ["gomod"],
-      "groupName": "Go dependencies",
-      "constraints": {
-        "go": "1.25"
-      },
       "minimumReleaseAge": "3 days",
-      "postUpdateOptions": ["gomodTidy"]
+      "postUpdateOptions": ["gomodTidy"],
+      "description": "Wait 3 days before updating Go dependencies"
     },
     {
       "matchManagers" : ["npm"],
-      "extends": ["security:minimumReleaseAgeNpm"]
+      "extends": ["security:minimumReleaseAgeNpm"],
+      "description": "Wait 3 days before updating semantic release dependencies"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "prConcurrentLimit": 4,
-  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "reviewers": ["pyrooka", "diatrcz", "Andris28"],
   "packageRules": [
     {
       "matchManagers": ["gomod"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "prConcurrentLimit": 4,
+  "reviewers": ["Norbert-Biczo", "Lidia-Tarcza", "Andras-Felleg"],
+  "packageRules": [
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "Go dependencies",
+      "constraints": {
+        "go": "1.25"
+      },
+      "minimumReleaseAge": "3 days",
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "matchManagers" : ["npm"],
+      "extends": ["security:minimumReleaseAgeNpm"]
+    }
+  ]
 }


### PR DESCRIPTION
In this commit we add dependency cooldown logic
that enables us to update more frequently and worry
less about compromised packages.